### PR TITLE
update status lexicon to use correct timestamp format

### DIFF
--- a/lexicons/fm.teal.alpha/actor/status.json
+++ b/lexicons/fm.teal.alpha/actor/status.json
@@ -13,12 +13,12 @@
           "time": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of when the item was recorded"
+            "description": "The RFC 3339 formatted time of when the item was recorded"
           },
           "expiry": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
+            "description": "The RFC 3339 formatted time of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
           },
           "item": {
             "type": "ref",


### PR DESCRIPTION
not a breaking change in code or codegen of the lexicon, but an important distinction 