### PR TITLE
update natb/jacquard

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,3 +19,10 @@ EXPO_PUBLIC_BASE_URL= # same as CLIENT_ADDRESS but with http scheme like https:/
 
 SQLX_OFFLINE=true
 SQLX_OFFLINE_DIR="./.sqlx"
+
+# Last.fm eval (scripts/eval/evaluate.ts)
+# Get your API key at https://www.last.fm/api/account/create
+LASTFM_API_KEY=
+LASTFM_API_SECRET=
+# Optional: proxy for eval requests (bypasses MB rate limiting)
+# PROXY_URL=http://user:pass@proxy-host:port

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .DS_Store
 *.pem
 *.sqlite
+*.db
 
 # debug
 npm-debug.log*
@@ -68,3 +69,11 @@ vendor/**/node_modules/
 
 # claude
 .claude
+
+# archive (exploration code and old docs - not part of production)
+archive/
+
+# evaluation results (data files, not code)
+scripts/eval/results/
+
+.lastfm_session_key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,183 @@
+# Teal Development Guidelines
+
+## Build Commands
+- Dev server: `turbo dev --filter=@teal/aqua`
+- Build all: `pnpm build`
+- Build Rust: `pnpm build:rust`
+- Test: `pnpm test`
+- DB migrate: `pnpm db:migrate`
+- DB reset: `pnpm db:reset`
+- Lexicon gen: `pnpm lex:gen`
+- Setup: `./scripts/setup-sqlx.sh`
+
+## Project Structure
+```
+teal/
+├── apps/aqua/              # Main Rust/Axum web app
+├── services/
+│   ├── cadet/             # AT Protocol jetstream consumer
+│   ├── rocketman/         # Jetstream library
+│   ├── satellite/         # Processing service
+│   ├── types/             # Shared types
+│   └── migrations/        # SQLx migrations
+├── lexicons/fm.teal.alpha/ # AT Protocol schemas
+│   ├── feed/              # Music play types
+│   ├── actor/             # Profile types
+│   └── stats/             # Analytics
+├── tools/lexicon-cli/      # Code generation
+└── compose.yaml           # Docker setup
+```
+
+## Tech Stack
+- **Backend**: Rust (Axum, SQLx, Tokio, Serde, Tracing)
+- **Database**: PostgreSQL + Garnet/Redis
+- **Frontend**: TypeScript, Turbo, pnpm, Biome
+- **Protocol**: AT Protocol, IPLD/CAR, WebSocket streams
+- **Deploy**: Docker Compose, Traefik
+
+## Services
+- **Aqua**: HTTP API, OAuth, play submission, profiles, CAR import
+- **Cadet**: Real-time jetstream consumer, background jobs, metrics
+- **Rocketman**: Reusable WebSocket consumer framework
+- **Satellite**: Analytics, aggregation, external APIs
+
+## Database Schema
+```sql
+artists (mbid UUID, name TEXT, play_count INTEGER)
+releases (mbid UUID, name TEXT, play_count INTEGER)
+recordings (mbid UUID, name TEXT, play_count INTEGER)
+plays (uri TEXT, did TEXT, rkey TEXT, cid TEXT, track_name TEXT,
+       played_time TIMESTAMPTZ, recording_mbid UUID, release_mbid UUID,
+       submission_client_agent TEXT, music_service_base_domain TEXT)
+profiles (did TEXT, display_name TEXT, description TEXT, avatar BLOB, banner BLOB)
+```
+
+## AT Protocol Integration
+### Music Play Schema (`fm.teal.alpha.feed.play`)
+```json
+{
+  "trackName": "string (required)",
+  "trackMbId": "string", "recordingMbId": "string",
+  "duration": "integer", "artists": [{"name": "string", "mbid": "string"}],
+  "releaseName": "string", "releaseMbId": "string",
+  "isrc": "string", "originUrl": "string",
+  "musicServiceBaseDomain": "string", "submissionClientAgent": "string",
+  "playedTime": "datetime"
+}
+```
+
+### Profile Schema (`fm.teal.alpha.actor.profile`)
+```json
+{
+  "displayName": "string", "description": "string",
+  "featuredItem": {"mbid": "string", "type": "album|track|artist"},
+  "avatar": "blob", "banner": "blob", "createdAt": "datetime"
+}
+```
+
+## Core Features
+- **Music Tracking**: primarily MusicBrainz metadata, multi-platform support, scrobbling logic
+- **Social**: Federated profiles, activity feeds, featured items, rich text
+- **Real-time**: WebSocket streams, CAR processing, background jobs
+- **Analytics**: Play counts, charts, materialized views
+
+## Development Setup
+```bash
+# Install & setup
+pnpm install
+cp apps/aqua/.env.example apps/aqua/.env
+./scripts/setup-sqlx.sh
+
+# Start dependencies
+docker compose -f compose.dev.yml up -d garnet postgres
+
+# Run dev server
+turbo dev --filter=@teal/aqua
+# Access: http://localhost:3000
+```
+
+## Database Operations
+```bash
+pnpm db:create          # Create DB
+pnpm db:migrate         # Run migrations
+pnpm db:migrate:revert  # Revert migration
+pnpm db:reset          # Reset DB
+pnpm db:prepare        # Prepare queries
+```
+
+## Lexicon Management
+```bash
+pnpm lex:gen       # Generate types
+pnpm lex:watch     # Watch & regenerate
+pnpm lex:validate  # Validate schemas
+pnpm lex:diff      # Show changes
+```
+
+## Rust Development Guidelines
+- **Error Handling**: Always use `anyhow::Result<T>` for fallible functions, never `Result<T, String>`
+- **Async Patterns**: Use `async/await` throughout, avoid `tokio::spawn` unless necessary for parallelism
+- **Database**: SQLx queries MUST be compile-time verified with `cargo sqlx prepare`
+- **Types**: Use workspace types from `types` crate, avoid duplicating structs across services
+- **Imports**: Group std → external → workspace → local, use `use` not `extern crate`
+- **Lifetimes**: Avoid explicit lifetimes unless required, let compiler infer
+- **Memory**: Use `Arc<T>` for shared ownership, `Rc<T>` only in single-threaded contexts
+- **Serialization**: Use `#[derive(Serialize, Deserialize)]` with serde, not manual impls
+- **Logging**: Use `tracing::info!`, `tracing::error!` etc, not `println!` or `log` crate
+- **Testing**: Place unit tests in `#[cfg(test)]` modules, integration tests in `tests/` directory
+
+## Git Workflow Guidelines
+- **Codex: You MUST work in a branch, you can NOT push to main and thus you need to make a PR per-feature**
+- **Branch naming**: `feature/short-description`, `fix/issue-description`, `refactor/component-name`
+- **Commit format**: `type(scope): description` - e.g. `feat(cadet): add jetstream reconnection`, `fix(aqua): handle empty play submissions`
+- **Commit types**: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `style`
+- **Branch lifecycle**: Create from `main`, keep updated with `git rebase main`, squash before merge
+- **PR requirements**: All tests pass, no clippy warnings, SQLx queries prepared, lexicons validated
+- **Commit size**: Small, focused commits - one logical change per commit
+- **Message body**: Include WHY for non-obvious changes, reference issues with `#123`
+- **Breaking changes**: Mark with `BREAKING:` in commit body, update migration docs
+
+## Code Standards
+- **TypeScript**: Biome format (`pnpm fix`), explicit types
+- **DB**: Snake_case, migrations, indexes, constraints
+- **AT Protocol**: URI format, lexicon validation, federation-ready
+
+## Testing
+```bash
+pnpm test           # All tests
+pnpm test:rust      # Rust only
+cargo test          # Service tests
+cargo tarpaulin     # Coverage
+```
+
+## Deployment
+```bash
+# Environment vars: DATABASE_URL, REDIS_URL, AT_PROTOCOL_JWT_SECRET
+docker compose build
+docker compose up -d
+docker compose exec aqua-api pnpm db:migrate
+```
+
+## Architecture
+- **Microservices**: Rust services with shared types
+- **Federation**: AT Protocol for decentralized social music
+- **Scrobble When**: <2min = full play, ≥2min = half duration (max 4min)
+- **Data Flow**: WebSocket → Cadet → PostgreSQL → Aqua API
+- **Caching**: Redis for sessions, jobs, API responses
+- **Monitoring**: Prometheus metrics, structured logging
+
+## Key Patterns
+- **Lexicon-first**: Schema definitions drive code generation
+- **Event-driven**: Real-time processing via jetstream
+- **Content-addressable**: CAR files for federated data
+- **Type-safe**: SQLx compile-time query verification
+- **Async-first**: Tokio runtime throughout
+
+## Rust Anti-Patterns to Avoid
+- **DON'T**: Use `unwrap()` or `expect()` in production code - use proper error handling
+- **DON'T**: Clone unnecessarily - prefer borrowing with `&` or using `Arc<T>`
+- **DON'T**: Use `String` when `&str` suffices - avoid unnecessary allocations
+- **DON'T**: Mix blocking and async code - use `tokio::task::spawn_blocking` for CPU work
+- **DON'T**: Ignore compiler warnings - *fix all clippy lints before committing*
+- **DON'T**: Write raw SQL strings - use SQLx query macros or builder patterns
+- **DON'T**: Use global state - pass dependencies through function parameters or structs
+- **DON'T**: Implement `Debug` manually - use `#[derive(Debug)]` unless custom formatting needed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "types",
+ "unicode-normalization",
  "url",
  "uuid",
 ]
@@ -5393,3 +5394,7 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "textprep"
+version = "0.1.4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,6 @@
 version = 4
 
 [[package]]
-name = "abnf"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087113bd50d9adce24850eed5d0476c7d199d532fce8fab5173650331e09033a"
-dependencies = [
- "abnf-core",
- "nom",
-]
-
-[[package]]
-name = "abnf-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44e09c43ae1c368fb91a03a566472d0087c26cf7e1b9e8e289c14ede681dd7d"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -86,44 +67,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aqua"
@@ -159,9 +140,12 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayref"
@@ -177,13 +161,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.33"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -196,7 +179,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -207,17 +190,17 @@ checksum = "aeb2a4631a64a242ae62c3ceb140adfa2a8bdacb1b22a6549db5de2ce3389c1d"
 dependencies = [
  "async-trait",
  "bytes",
- "cid 0.11.1",
+ "cid",
  "dashmap",
  "futures",
  "ipld-core",
  "iroh-car",
  "log",
- "multihash 0.19.3",
+ "multihash",
  "serde",
  "serde_ipld_dagcbor",
  "serde_ipld_dagjson",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -229,6 +212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -245,9 +237,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -255,11 +247,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -268,16 +259,16 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -303,13 +294,13 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -322,13 +313,13 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -376,50 +367,24 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.110",
-]
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -428,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -439,15 +404,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -460,10 +426,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bon"
-version = "3.8.1"
+name = "block-buffer"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -471,57 +446,49 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.8.1"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.7"
+name = "borrow-or-share"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
-name = "btree-range-map"
-version = "0.7.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be5c9672446d3800bcbcaabaeba121fe22f1fb25700c4562b22faf76d377c33"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "btree-slab",
- "cc-traits",
- "range-traits",
- "serde",
- "slab",
-]
-
-[[package]]
-name = "btree-slab"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2b56d3029f075c4fa892428a098425b86cef5c89ae54073137ece416aef13c"
-dependencies = [
- "cc-traits",
- "slab",
- "smallvec",
+ "tinyvec",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -531,9 +498,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -547,28 +514,25 @@ dependencies = [
  "atmst",
  "base64 0.22.1",
  "chrono",
- "cid 0.11.1",
  "dotenvy",
  "flume",
  "futures",
  "iroh-car",
  "jacquard-common",
- "libipld",
  "metrics 0.23.1",
  "metrics-exporter-prometheus",
  "multibase",
  "multihash-codetable",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "reqwest",
  "rocketman",
  "serde",
- "serde_ipld_dagcbor",
  "serde_json",
  "sqlx",
  "time",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tracing",
  "tracing-subscriber",
  "types",
@@ -579,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -606,7 +570,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -620,32 +584,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cc-traits"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
-dependencies = [
- "slab",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -662,16 +608,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -703,47 +649,22 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
- "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "cid"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
-dependencies = [
- "core2",
- "multibase",
- "multihash 0.19.3",
+ "multihash",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -751,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -763,36 +684,45 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
+name = "cobs"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -820,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.32"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -831,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -858,9 +788,19 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "core-foundation"
@@ -889,15 +829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,19 +838,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -929,6 +869,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
@@ -994,6 +940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,12 +960,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1024,21 +979,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1049,25 +1003,25 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1079,15 +1033,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1095,12 +1049,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1116,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1141,7 +1095,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1151,8 +1105,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -1160,10 +1141,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1195,7 +1186,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1217,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1226,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1241,7 +1232,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1252,6 +1243,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1302,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1318,18 +1321,29 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1341,7 +1355,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1373,9 +1387,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1387,10 +1401,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures-buffered"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1398,15 +1425,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1426,38 +1453,51 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1467,8 +1507,22 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -1484,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1504,16 +1558,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "group"
@@ -1528,16 +1589,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1554,6 +1615,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1575,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1586,6 +1656,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1607,12 +1691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex_fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,7 +1705,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1652,12 +1730,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1668,7 +1745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1679,7 +1756,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1697,23 +1774,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.8.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1721,34 +1806,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.35",
- "rustls-native-certs 0.8.2",
- "rustls-pki-types",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -1765,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1789,12 +1872,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1802,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1815,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1829,15 +1913,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1849,15 +1933,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1867,6 +1951,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1887,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1897,49 +1987,41 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
+name = "inventory"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "ipld-core"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
+checksum = "090f624976d72f0b0bb71b86d58dc16c15e069193067cb3a3a09d655246cbbda"
 dependencies = [
- "cid 0.11.1",
+ "cid",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iroh-car"
@@ -1948,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f8cd4cb9aa083fba8b52e921764252d0b4dcb1cd6d120b809dbfe1106e81a"
 dependencies = [
  "anyhow",
- "cid 0.11.1",
+ "cid",
  "futures",
  "serde",
  "serde_ipld_dagcbor",
@@ -1964,65 +2046,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jacquard-common"
-version = "0.5.4"
+version = "0.12.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf91dfa4ade1ca83c9afccee4ece7ed72b6607a0853d88623958d4e7c5382eb3"
+checksum = "e830579811d60e29209c9466d034225d5e045ecdc2b3c55282709bd07da97869"
 dependencies = [
  "base64 0.22.1",
  "bon",
  "bytes",
  "chrono",
- "cid 0.11.1",
+ "ciborium",
+ "ciborium-io",
+ "cid",
+ "fluent-uri",
+ "futures",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
- "http 1.3.1",
+ "hashbrown 0.15.5",
+ "http 1.4.0",
  "ipld-core",
  "k256",
- "langtag",
+ "maitake-sync",
  "miette",
  "multibase",
- "multihash 0.19.3",
+ "multihash",
+ "n0-future",
  "ouroboros",
+ "oxilangtag",
  "p256",
- "rand 0.9.2",
+ "phf",
+ "postcard",
+ "rand 0.9.4",
  "regex",
+ "regex-automata",
+ "regex-lite",
  "reqwest",
+ "rustversion",
  "serde",
+ "serde_bytes",
  "serde_html_form",
  "serde_ipld_dagcbor",
  "serde_json",
  "signature",
  "smol_str",
- "thiserror 2.0.17",
+ "spin 0.10.0",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite-wasm",
+ "tokio-util",
  "trait-variant",
- "url",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "jacquard-derive"
-version = "0.5.4"
+version = "0.12.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7db8498da87d842297b169a0080eed751bce173c56626b5fa71261fe72f804"
+checksum = "93f83b8049e4e7916e0f6764c3deaf5e55a7ffbab26c379415e9b1d4d645d957"
 dependencies = [
+ "heck 0.5.0",
+ "jacquard-lexicon",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jacquard-lexicon"
+version = "0.12.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64935ef85dd24f60f467082c21ad52f739a02dd402a2adf40e5794e3de949e1f"
+dependencies = [
+ "cid",
+ "dashmap",
+ "heck 0.5.0",
+ "inventory",
+ "jacquard-common",
+ "miette",
+ "multihash",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_repr",
+ "serde_with",
+ "sha2 0.10.9",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2037,10 +2157,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2055,28 +2177,18 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "langtag"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb4c689a30e48ebeaa14237f34037e300dd072e6ad21a9ec72e810ff3c6600"
-dependencies = [
- "serde",
- "static-regular-grammar",
- "thiserror 1.0.69",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -2085,129 +2197,37 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
-
-[[package]]
-name = "libipld"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ccd6b8ffb3afee7081fcaec00e1b099fd1c7ccf35ba5729d88538fcc3b4599"
-dependencies = [
- "fnv",
- "libipld-cbor",
- "libipld-cbor-derive",
- "libipld-core",
- "libipld-json",
- "libipld-macro",
- "libipld-pb",
- "log",
- "multihash 0.18.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libipld-cbor"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d98c9d1747aa5eef1cf099cd648c3fd2d235249f5fed07522aaebc348e423b"
-dependencies = [
- "byteorder",
- "libipld-core",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libipld-cbor-derive"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5ba3a729b72973e456a1812b0afe2e176a376c1836cc1528e9fc98ae8cb838"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
-
-[[package]]
-name = "libipld-core"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acd707e8d8b092e967b2af978ed84709eaded82b75effe6cb6f6cc797ef8158"
-dependencies = [
- "anyhow",
- "cid 0.10.1",
- "core2",
- "multibase",
- "multihash 0.18.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libipld-json"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25856def940047b07b25c33d4e66d248597049ab0202085215dc4dca0487731c"
-dependencies = [
- "libipld-core",
- "multihash 0.18.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "libipld-macro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71171c54214f866ae6722f3027f81dff0931e600e5a61e6b1b6a49ca0b5ed4ae"
-dependencies = [
- "libipld-core",
-]
-
-[[package]]
-name = "libipld-pb"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2d0f866c4cd5dc9aa8068c429ba478d2882a3a4b70ab56f7e9a0eddf5d16f"
-dependencies = [
- "bytes",
- "libipld-core",
- "quick-protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2222,15 +2242,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2243,9 +2263,22 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2254,14 +2287,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "match-lookup"
-version = "0.1.1"
+name = "maitake-sync"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+checksum = "6816ab14147f80234c675b80ed6dc4f440d8a1cefc158e766067aedb84c0bcd5"
+dependencies = [
+ "cordyceps",
+ "loom",
+ "mycelium-bitfield",
+ "pin-project",
+ "portable-atomic",
+]
+
+[[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2277,14 +2332,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
@@ -2298,12 +2353,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.2"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -2319,7 +2374,7 @@ dependencies = [
  "hyper-util",
  "indexmap",
  "ipnet",
- "metrics 0.24.2",
+ "metrics 0.24.6",
  "metrics-util",
  "quanta",
  "thiserror 1.0.69",
@@ -2336,9 +2391,9 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.5",
- "metrics 0.24.2",
+ "metrics 0.24.6",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2362,7 +2417,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2389,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2407,11 +2462,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -2429,88 +2484,80 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.18.1"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest",
- "multihash-derive 0.8.1",
- "sha2",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
  "serde",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "multihash-codetable"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
+checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
- "core2",
- "digest",
- "multihash-derive 0.9.1",
+ "digest 0.11.3",
+ "multihash-derive",
  "ripemd",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sha3",
- "strobe-rs",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "4723acdce756db211a53f01b3419dbdf63cb48cef5df86260f55309364735fbf"
 dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1b7edab35d920890b88643a765fc9bd295cf0201f4154dda231bef9b8404eb"
-dependencies = [
- "core2",
- "multihash 0.19.3",
+ "multihash",
  "multihash-derive-impl",
 ]
 
 [[package]]
 name = "multihash-derive-impl"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
+checksum = "f932556f78452e5604cef711349d337ec081a9aa3c96e67b3127c8f5df05d550"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "mycelium-bitfield"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e0cc5e2c585acbd15c5ce911dff71e1f4d5313f43345873311c4f5efd741cc"
+
+[[package]]
+name = "n0-future"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb0e5d99e681ab3c938842b96fcb41bf8a7bb4bfdb11ccbd653a7e83e06c794"
+dependencies = [
+ "cfg_aliases",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -2519,7 +2566,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2534,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -2562,25 +2609,25 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2638,14 +2685,14 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2658,6 +2705,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2686,7 +2739,16 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "oxilangtag"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2698,7 +2760,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2725,9 +2787,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2746,16 +2808,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "phf"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "phf_generator"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -2780,21 +2898,40 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2821,7 +2958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2835,52 +2972,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror 1.0.69",
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2893,7 +2996,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -2914,15 +3017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,9 +3028,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2944,20 +3038,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2979,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2993,10 +3087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3005,12 +3105,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3030,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3039,14 +3139,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -3057,14 +3157,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "range-traits"
-version = "0.3.2"
+name = "rapidhash"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20581732dd76fa913c7dff1a2412b714afe3573e94d41c34719de73337cc8ab"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -3072,7 +3175,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3106,7 +3209,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3115,16 +3227,36 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "ref-cast"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3134,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3144,25 +3276,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.8"
+name = "regex-lite"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3174,7 +3311,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3191,7 +3328,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3212,7 +3349,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3220,11 +3357,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3239,8 +3376,8 @@ dependencies = [
  "derive_builder",
  "flume",
  "futures-util",
- "metrics 0.24.2",
- "rand 0.8.5",
+ "metrics 0.24.6",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tokio",
@@ -3253,12 +3390,12 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3273,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3288,11 +3425,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3313,15 +3450,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3332,7 +3469,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
@@ -3340,14 +3477,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3361,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3381,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3399,9 +3536,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "satellite"
@@ -3423,12 +3560,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3466,7 +3609,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3475,11 +3618,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3488,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3498,13 +3641,19 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3543,19 +3692,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.8"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
 dependencies = [
  "form_urlencoded",
  "indexmap",
  "itoa",
- "ryu",
  "serde_core",
 ]
 
@@ -3573,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagjson"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d2d9d1f29999ee9a3d774fe2a5db4cc199da5178d0350f5e4482ea04252aee"
+checksum = "eb3dfb1d7b111db0edee8409c57a9b2b1eef47ebc0ec890cc980b0c3b027a8a9"
 dependencies = [
  "ipld-core",
  "serde",
@@ -3584,15 +3732,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3604,6 +3752,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3619,14 +3778,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3642,17 +3840,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "keccak",
 ]
 
@@ -3673,10 +3882,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3686,27 +3896,33 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3719,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
@@ -3729,12 +3945,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3745,6 +3961,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -3793,12 +4015,12 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -3818,7 +4040,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3836,12 +4058,12 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.110",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -3854,12 +4076,12 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3876,15 +4098,15 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -3899,7 +4121,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -3917,14 +4139,14 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -3951,7 +4173,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -3963,26 +4185,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static-regular-grammar"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4a6c40247579acfbb138c3cd7de3dab113ab4ac6227f1b7de7d626ee667957"
-dependencies = [
- "abnf",
- "btree-range-map",
- "ciborium",
- "hex_fmt",
- "indoc",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "serde",
- "sha2",
- "syn 2.0.110",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "static_assertions"
@@ -3999,19 +4201,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
-]
-
-[[package]]
-name = "strobe-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fe17535ea31344936cc58d29fec9b500b0452ddc4cc24c429c8a921a0e84e5"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "keccak",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4039,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4059,25 +4248,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4105,11 +4282,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4136,7 +4313,7 @@ dependencies = [
  "hex",
  "k256",
  "multibase",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
@@ -4145,12 +4322,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4167,11 +4344,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4182,18 +4359,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4207,9 +4384,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4217,22 +4394,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4240,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4250,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4265,9 +4442,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4297,13 +4474,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4322,15 +4499,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4355,56 +4532,83 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.35",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.28.0",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.17"
+name = "tokio-tungstenite-wasm"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "e21a5c399399c3db9f08d8297ac12b500e86bca82e930253fdc62eaf9c0de6ae"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "js-sys",
+ "rustls 0.23.40",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4414,18 +4618,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4439,20 +4643,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "async-compression",
+ "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
- "iri-string",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4469,9 +4678,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4481,20 +4690,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4513,14 +4722,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4533,7 +4746,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4554,9 +4767,9 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls 0.21.12",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "url",
  "utf-8",
@@ -4564,28 +4777,47 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
+ "byteorder",
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
- "rustls 0.23.35",
+ "rand 0.8.6",
+ "rustls 0.23.40",
  "rustls-pki-types",
- "sha1",
- "thiserror 2.0.17",
+ "sha1 0.10.6",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "tungstenite"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "types"
@@ -4595,6 +4827,7 @@ dependencies = [
  "bytes",
  "jacquard-common",
  "jacquard-derive",
+ "jacquard-lexicon",
  "miette",
  "serde",
  "thiserror 1.0.69",
@@ -4608,9 +4841,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -4626,6 +4859,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -4659,9 +4898,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4689,13 +4928,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4776,11 +5015,20 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4791,9 +5039,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4804,22 +5052,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4827,24 +5072,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4861,10 +5128,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.82"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4892,14 +5171,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4966,9 +5245,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4979,7 +5258,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4990,7 +5269,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5001,7 +5280,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5012,14 +5291,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -5029,13 +5302,13 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5049,29 +5322,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5080,7 +5335,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5125,7 +5380,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5165,7 +5420,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5316,24 +5571,112 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -5343,9 +5686,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5354,55 +5697,55 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -5410,26 +5753,12 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5438,9 +5767,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5449,14 +5778,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"
@@ -5485,7 +5820,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "textprep"
-version = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ sqlx = { version = "0.8", features = [
     "chrono",
     "tls-rustls",
 ] }
-jacquard-common = { version = "0.5", features = ["reqwest-client"] }
-jacquard-derive = { version = "0.5" }
+jacquard-common = { version = "0.12.0-beta.2", features = ["reqwest-client"] }
+jacquard-derive = { version = "0.12.0-beta.2" }
+jacquard-lexicon = { version = "0.12.0-beta.2" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"
@@ -53,8 +54,6 @@ thiserror = "1.0"
 
 # CAR and IPLD dependencies
 iroh-car = "0.5"
-libipld = { version = "0.16", features = ["dag-cbor", "dag-json"] }
-cid = "0.11"
 base64 = "0.22"
 atmst = "0.0.1"
 

--- a/apps/amethyst/app/auth/callback.tsx
+++ b/apps/amethyst/app/auth/callback.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { View } from "react-native";
 import { Link, router, Stack } from "expo-router";
 import { useLocalSearchParams } from "expo-router/build/hooks";
@@ -7,27 +7,23 @@ import { Icon } from "@/lib/icons/iconWithClassName";
 import { useStore } from "@/stores/mainStore";
 import { PencilLine } from "lucide-react-native";
 
-interface CallbackSearchParams {
-  iss: string;
-  state: string;
-  code: string;
-}
-
 export default function AuthOptions() {
-  const { oauthCallback, status } = useStore((state) => state);
-
+  const status = useStore((state) => state.status);
   const params = useLocalSearchParams<"iss" | "state" | "code">();
   const { state } = params;
-  useEffect(() => {
-    // Only proceed if params exist
-    if (params) {
-      const searchParams = new URLSearchParams(params);
-      oauthCallback(searchParams);
-    }
-  }, [params, oauthCallback]);
+  const calledRef = useRef(false);
 
   useEffect(() => {
-    // Wrap navigation in requestAnimationFrame to ensure root layout is mounted
+    // The OAuth state in IndexedDB is deleted on first read (replay prevention).
+    // Must only call oauthCallback once -- a second call will fail with
+    // "Unknown authorization session".
+    if (calledRef.current || !params) return;
+    calledRef.current = true;
+    const searchParams = new URLSearchParams(params);
+    useStore.getState().oauthCallback(searchParams);
+  }, [params]);
+
+  useEffect(() => {
     if (status === "loggedIn") {
       requestAnimationFrame(() => {
         router.replace("/");
@@ -35,7 +31,6 @@ export default function AuthOptions() {
     }
   }, [status]);
 
-  // if no state then redirect to error page
   if (!params) {
     return (
       <View>

--- a/apps/amethyst/app/onboarding/imageSelectionPage.tsx
+++ b/apps/amethyst/app/onboarding/imageSelectionPage.tsx
@@ -8,7 +8,7 @@ import { Icon } from "@/lib/icons/iconWithClassName";
 import { Pen } from "lucide-react-native";
 
 interface ImageSelectionPageProps {
-  onComplete: (avatarUri: string, bannerUri: string) => void;
+  onComplete: (avatarUri: string | undefined, bannerUri: string | undefined) => void;
   initialAvatar?: string;
   initialBanner?: string;
 }
@@ -39,9 +39,7 @@ const ImageSelectionPage: React.FC<ImageSelectionPageProps> = ({
     setLoading(false);
   };
   const handleNext = () => {
-    if (avatarUri && bannerUri) {
-      onComplete(avatarUri, bannerUri);
-    }
+    onComplete(avatarUri || undefined, bannerUri || undefined);
   };
 
   return (
@@ -90,11 +88,7 @@ const ImageSelectionPage: React.FC<ImageSelectionPageProps> = ({
         </View>
       </Pressable>
 
-      <Button
-        onPress={handleNext}
-        disabled={!avatarUri || !bannerUri}
-        className="w-full"
-      >
+      <Button onPress={handleNext} className="w-full">
         <Text>Next</Text>
       </Button>
     </View>

--- a/apps/amethyst/app/onboarding/index.tsx
+++ b/apps/amethyst/app/onboarding/index.tsx
@@ -65,9 +65,9 @@ export default function OnboardingPage() {
     checkProfileStatus();
   }, [agent]);
 
-  const handleImageSelectionComplete = (avatar: string, banner: string) => {
-    setAvatarUri(avatar);
-    setBannerUri(banner);
+  const handleImageSelectionComplete = (avatar: string | undefined, banner: string | undefined) => {
+    setAvatarUri(avatar ?? "");
+    setBannerUri(banner ?? "");
     onComplete({ displayName, description }, avatar, banner);
   };
 
@@ -83,12 +83,10 @@ export default function OnboardingPage() {
 
   const onComplete = async (
     updatedProfile: { displayName: any; description: any },
-    newAvatarUri: string,
-    newBannerUri: string,
+    newAvatarUri: string | undefined,
+    newBannerUri: string | undefined,
   ) => {
     if (!agent) return;
-    // Implement your save logic here (e.g., update your database or state)
-    console.log("Saving profile:", updatedProfile, newAvatarUri, newBannerUri);
 
     setSubmissionStep(1);
 
@@ -111,32 +109,23 @@ export default function OnboardingPage() {
     let newAvatarBlob = currentUser?.avatar ?? undefined;
     let newBannerBlob = currentUser?.banner ?? undefined;
     if (newAvatarUri) {
-      console.log(newAvatarUri);
-      // if it is http/s url then do nothing
       if (!newAvatarUri.startsWith("http")) {
         setSubmissionStep(2);
-        console.log("Uploading avatar");
-        // its a b64 encoded data uri, decode it and get a blob
         const data = await fetch(newAvatarUri).then((r) => r.blob());
         const fileType = newAvatarUri.split(";")[0].split(":")[1];
-        console.log(fileType);
         const blob = new Blob([data], { type: fileType });
-        newAvatarBlob = (await agent.uploadBlob(blob)).data.blob;
+        newAvatarBlob = (await agent.uploadBlob(blob, { encoding: fileType })).data.blob;
       }
     }
     if (newBannerUri) {
       if (!newBannerUri.startsWith("http")) {
         setSubmissionStep(3);
-        console.log("Uploading banner");
         const data = await fetch(newBannerUri).then((r) => r.blob());
         const fileType = newBannerUri.split(";")[0].split(":")[1];
-        console.log(fileType);
         const blob = new Blob([data], { type: fileType });
-        newBannerBlob = (await agent.uploadBlob(blob)).data.blob;
+        newBannerBlob = (await agent.uploadBlob(blob, { encoding: fileType })).data.blob;
       }
     }
-
-    console.log("done uploading");
 
     setSubmissionStep(4);
 
@@ -173,8 +162,6 @@ export default function OnboardingPage() {
         },
       );
     }
-
-    console.log(post);
 
     // Update profile status to mark onboarding as completed
     const profileStatusRecord: ProfileStatusRecord = {

--- a/apps/amethyst/components/actor/actorView.tsx
+++ b/apps/amethyst/components/actor/actorView.tsx
@@ -71,9 +71,6 @@ export default function ActorView({ actorDid, pdsAgent }: ActorViewProps) {
     if (!pdsAgent) {
       return;
     }
-    // Implement your save logic here (e.g., update your database or state)
-    console.log("Saving profile:", updatedProfile, newAvatarUri, newBannerUri);
-
     // Update the local profile data
     setProfile((prevProfile) => ({
       ...prevProfile,
@@ -104,27 +101,20 @@ export default function ActorView({ actorDid, pdsAgent }: ActorViewProps) {
     if (newAvatarUri) {
       // if it is http/s url then do nothing
       if (!newAvatarUri.startsWith("http")) {
-        console.log("Uploading avatar");
-        // its a b64 encoded data uri, decode it and get a blob
         const data = await fetch(newAvatarUri).then((r) => r.blob());
         const fileType = newAvatarUri.split(";")[0].split(":")[1];
-        console.log(fileType);
         const blob = new Blob([data], { type: fileType });
-        newAvatarBlob = (await pdsAgent.uploadBlob(blob)).data.blob;
+        newAvatarBlob = (await pdsAgent.uploadBlob(blob, { encoding: fileType })).data.blob;
       }
     }
     if (newBannerUri) {
       if (!newBannerUri.startsWith("http")) {
-        console.log("Uploading banner");
         const data = await fetch(newBannerUri).then((r) => r.blob());
         const fileType = newBannerUri.split(";")[0].split(":")[1];
-        console.log(fileType);
         const blob = new Blob([data], { type: fileType });
-        newBannerBlob = (await pdsAgent.uploadBlob(blob)).data.blob;
+        newBannerBlob = (await pdsAgent.uploadBlob(blob, { encoding: fileType })).data.blob;
       }
     }
-
-    console.log("done uploading");
 
     let record: ProfileRecord = {
       displayName: updatedProfile.displayName,

--- a/apps/amethyst/jest.lib.config.ts
+++ b/apps/amethyst/jest.lib.config.ts
@@ -1,0 +1,27 @@
+/**
+ * Jest config for pure TypeScript library tests (no React Native / Expo deps).
+ * Run: npx jest --config jest.lib.config.ts
+ */
+import type { Config } from "jest";
+
+const config: Config = {
+  testMatch: ["<rootDir>/lib/__tests__/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          module: "commonjs",
+          moduleResolution: "node",
+          esModuleInterop: true,
+          target: "es2020",
+          lib: ["es2020"],
+          strict: true,
+        },
+      },
+    ],
+  },
+  testEnvironment: "node",
+};
+
+export default config;

--- a/apps/amethyst/lib/__tests__/fuzzyMatching.test.ts
+++ b/apps/amethyst/lib/__tests__/fuzzyMatching.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for fuzzy matching utilities
+ */
+
+import {
+  levenshteinDistance,
+  similarityRatio,
+  fuzzyMatch,
+  fuzzyScore,
+} from "../fuzzyMatching";
+
+describe("levenshteinDistance", () => {
+  describe("exact matches", () => {
+    it("should return 0 for identical strings", () => {
+      expect(levenshteinDistance("hello", "hello")).toBe(0);
+      expect(levenshteinDistance("Beatles", "Beatles")).toBe(0);
+    });
+
+    it("should return 0 for case-insensitive matches", () => {
+      expect(levenshteinDistance("HELLO", "hello")).toBe(0);
+      expect(levenshteinDistance("Beatles", "BEATLES")).toBe(0);
+    });
+
+    it("should return 0 for empty strings", () => {
+      expect(levenshteinDistance("", "")).toBe(0);
+    });
+  });
+
+  describe("single edits", () => {
+    it("should return 1 for single character insertion", () => {
+      expect(levenshteinDistance("hello", "helloo")).toBe(1);
+    });
+
+    it("should return 1 for single character deletion", () => {
+      expect(levenshteinDistance("hello", "helo")).toBe(1);
+    });
+
+    it("should return 1 for single character substitution", () => {
+      expect(levenshteinDistance("hello", "hallo")).toBe(1);
+    });
+  });
+
+  describe("multiple edits", () => {
+    it("should return correct distance for multiple edits", () => {
+      expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    });
+
+    it("should return string length when comparing to empty", () => {
+      expect(levenshteinDistance("hello", "")).toBe(5);
+      expect(levenshteinDistance("", "world")).toBe(5);
+    });
+  });
+
+  describe("music-specific cases", () => {
+    it("should correctly measure Beatles/Beetles typo", () => {
+      expect(levenshteinDistance("beatles", "beetles")).toBe(1);
+    });
+
+    it("should handle AC/DC variations", () => {
+      expect(levenshteinDistance("acdc", "ac/dc")).toBe(1);
+    });
+  });
+});
+
+describe("similarityRatio", () => {
+  it("should return 1.0 for identical strings", () => {
+    expect(similarityRatio("hello", "hello")).toBe(1.0);
+  });
+
+  it("should return 1.0 for empty strings", () => {
+    expect(similarityRatio("", "")).toBe(1.0);
+  });
+
+  it("should return 0.0 for completely different strings", () => {
+    expect(similarityRatio("abc", "xyz")).toBe(0);
+  });
+
+  it("should return higher ratio for more similar strings", () => {
+    const closeRatio = similarityRatio("hello", "hallo");
+    const farRatio = similarityRatio("hello", "world");
+    expect(closeRatio).toBeGreaterThan(farRatio);
+  });
+});
+
+describe("fuzzyMatch", () => {
+  describe("exact matches", () => {
+    it("should match identical strings", () => {
+      expect(fuzzyMatch("Hello World", "Hello World")).toBe(true);
+    });
+
+    it("should match case-insensitively", () => {
+      expect(fuzzyMatch("HELLO", "hello")).toBe(true);
+    });
+
+    it("should match with accent differences", () => {
+      expect(fuzzyMatch("Beyonce", "Beyonce")).toBe(true);
+    });
+  });
+
+  describe("similarity threshold", () => {
+    it("should match similar strings above threshold", () => {
+      expect(fuzzyMatch("hello", "hallo", 0.7)).toBe(true);
+    });
+
+    it("should not match dissimilar strings", () => {
+      expect(fuzzyMatch("hello", "world", 0.7)).toBe(false);
+    });
+
+    it("should respect custom threshold", () => {
+      expect(fuzzyMatch("hello", "hallo", 0.9)).toBe(false);
+      expect(fuzzyMatch("hello", "hallo", 0.7)).toBe(true);
+    });
+  });
+});
+
+describe("fuzzyScore", () => {
+  it("should return 1.0 for exact matches", () => {
+    expect(fuzzyScore("Hello World", "Hello World")).toBe(1.0);
+  });
+
+  it("should score 'starts with' matches by coverage", () => {
+    // "Hello" (5) in "Hello World" (11): 0.7 + 0.2 * (5/11) ≈ 0.791
+    const score = fuzzyScore("Hello", "Hello World");
+    expect(score).toBeGreaterThan(0.7);
+    expect(score).toBeLessThan(0.9);
+
+    // High coverage prefix scores near 0.9
+    expect(fuzzyScore("Hello Worl", "Hello World")).toBeGreaterThan(0.88);
+  });
+
+  it("should score 'contains' matches by coverage", () => {
+    // "World" (5) in "Hello World" (11): 0.5 + 0.3 * (5/11) ≈ 0.636
+    const score = fuzzyScore("World", "Hello World");
+    expect(score).toBeGreaterThan(0.5);
+    expect(score).toBeLessThan(0.8);
+
+    // High coverage containment scores near 0.8
+    expect(fuzzyScore("ello World", "Hello World")).toBeGreaterThan(0.75);
+
+    // Low coverage containment scores near 0.5
+    expect(fuzzyScore("lo", "Hello World")).toBeLessThan(0.6);
+  });
+
+  it("should return similarity ratio for partial matches", () => {
+    const score = fuzzyScore("hello", "hallo");
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(0.8);
+  });
+});
+
+describe("edge cases", () => {
+  it("should handle empty strings", () => {
+    expect(fuzzyMatch("", "")).toBe(true);
+    expect(fuzzyScore("", "")).toBe(1.0);
+  });
+
+  it("should handle very long strings", () => {
+    const long1 = "a".repeat(100);
+    const long2 = "a".repeat(99) + "b";
+    expect(fuzzyMatch(long1, long2, 0.9)).toBe(true);
+  });
+});

--- a/apps/amethyst/lib/__tests__/musicbrainzCleaner.test.ts
+++ b/apps/amethyst/lib/__tests__/musicbrainzCleaner.test.ts
@@ -1,0 +1,855 @@
+/**
+ * Tests for MusicBrainz name cleaning utilities
+ * 
+ * These tests validate the cleaning logic that significantly improves
+ * MusicBrainz search matching (measured during evaluation runs; details live in the eval commit message)
+ */
+
+import {
+  cleanArtistName,
+  cleanTrackName,
+  cleanReleaseName,
+  normalizeForComparison,
+} from "../musicbrainzCleaner";
+
+describe("cleanTrackName", () => {
+  describe("basic cleaning", () => {
+    it("should return trimmed input for simple names", () => {
+      expect(cleanTrackName("  Hello World  ")).toBe("Hello World");
+    });
+
+    it("should handle empty strings", () => {
+      expect(cleanTrackName("")).toBe("");
+    });
+
+    it("should preserve normal track names", () => {
+      expect(cleanTrackName("Bohemian Rhapsody")).toBe("Bohemian Rhapsody");
+      expect(cleanTrackName("Hotel California")).toBe("Hotel California");
+    });
+
+    it("should strip leading/trailing decorative characters", () => {
+      expect(cleanTrackName("* * Track Name * *")).toBe("Track Name");
+      expect(cleanTrackName("~~Song Title~~")).toBe("Song Title");
+      expect(cleanTrackName("***")).toBe("***"); // Don't strip to empty
+    });
+
+    it("should remove [SNIPPET] and [Preview] brackets", () => {
+      expect(cleanTrackName("Song [SNIPPET]")).toBe("Song");
+      expect(cleanTrackName("Track Name [Preview]")).toBe("Track Name");
+    });
+  });
+
+  describe("parenthetical guff removal", () => {
+    it("should remove (Remastered) suffix", () => {
+      expect(cleanTrackName("Bohemian Rhapsody (Remastered)")).toBe("Bohemian Rhapsody");
+    });
+
+    it("should remove (Live) suffix", () => {
+      expect(cleanTrackName("Stairway to Heaven (Live)")).toBe("Stairway to Heaven");
+    });
+
+    it("should remove year in parentheses", () => {
+      expect(cleanTrackName("Come Together (2019 Mix)")).toBe("Come Together");
+    });
+
+    it("should remove (Radio Edit)", () => {
+      expect(cleanTrackName("Blinding Lights (Radio Edit)")).toBe("Blinding Lights");
+    });
+
+    it("should handle multiple guff words", () => {
+      expect(cleanTrackName("Song (Live Remastered Version)")).toBe("Song");
+    });
+
+    it("should remove multiple parenthetical guff groups", () => {
+      expect(cleanTrackName("Song (Live) (Remastered)")).toBe("Song");
+      expect(cleanTrackName("Track (Bonus Track) (Live) (Remastered)")).toBe("Track");
+    });
+
+    it("should remove later guff groups while keeping non-guff ones", () => {
+      expect(cleanTrackName("Song (feat. Artist) (Live)")).toBe("Song (feat. Artist)");
+      expect(cleanTrackName("Song (Remix) (Live Version)")).toBe("Song (Remix)");
+    });
+  });
+
+  describe("bracket guff removal", () => {
+    it("should remove [Remastered] suffix", () => {
+      expect(cleanTrackName("Hey Jude [Remastered]")).toBe("Hey Jude");
+    });
+
+    it("should remove [Official Video] suffix", () => {
+      expect(cleanTrackName("Bad Guy [Official Video]")).toBe("Bad Guy");
+    });
+  });
+
+  describe("remix preservation (disambiguation)", () => {
+    // CRITICAL: These tests verify the smart remix handling that prevents
+    // incorrect removal of distinguishing remix info
+    
+    it("should PRESERVE remix info for generic base names", () => {
+      // "High" is generic, so "Branchez Remix" must be kept
+      expect(cleanTrackName("High (Branchez Remix)")).toBe("High (Branchez Remix)");
+    });
+
+    it("should PRESERVE remix info when it contains artist name", () => {
+      // "Diplo Remix" contains an artist name, must be kept
+      expect(cleanTrackName("Get Lucky (Diplo Remix)")).toBe("Get Lucky (Diplo Remix)");
+    });
+
+    it("should PRESERVE remix info for short base names", () => {
+      // Short names need disambiguation
+      expect(cleanTrackName("One (Skrillex Remix)")).toBe("One (Skrillex Remix)");
+    });
+
+    it("should PRESERVE remix info with artist names even for longer base names", () => {
+      // "Extended" is detected as potentially an artist name (>3 chars, not a keyword)
+      // This is conservative: better to preserve too much than lose disambiguation
+      expect(cleanTrackName("Billie Jean (Extended Remix)")).toBe("Billie Jean (Extended Remix)");
+    });
+
+    it("should PRESERVE remix for short base names even without artist", () => {
+      // "Billie Jean" is <15 chars (short) so remix is preserved for disambiguation
+      // There could be many tracks named "Billie Jean" - the remix helps distinguish
+      expect(cleanTrackName("Billie Jean (Remix)")).toBe("Billie Jean (Remix)");
+    });
+
+    it("should remove pure guff remix for long unique base names", () => {
+      // Very long, specific names don't need remix info for disambiguation
+      expect(cleanTrackName("Bohemian Rhapsody Is A Very Long Title (Remix)")).toBe("Bohemian Rhapsody Is A Very Long Title");
+    });
+
+    it("should PRESERVE artist edition as remix-like", () => {
+      // "Kaytranada Edition" contains an artist name + "edition" -> remix-like
+      expect(cleanTrackName("Be Your Girl (Kaytranada Edition)")).toBe("Be Your Girl (Kaytranada Edition)");
+    });
+
+    it("should strip generic edition without artist name", () => {
+      expect(cleanTrackName("OK Computer (Special Edition)")).toBe("OK Computer");
+      expect(cleanTrackName("Abbey Road (Deluxe Edition)")).toBe("Abbey Road");
+    });
+  });
+
+  describe("named mix preservation (disambiguation)", () => {
+    it("should PRESERVE named artist mixes in parentheses", () => {
+      expect(cleanTrackName("Hear Me (Zomby mix)")).toBe("Hear Me (Zomby mix)");
+    });
+
+    it("should PRESERVE named mixes with long artist names", () => {
+      expect(cleanTrackName("Voodoo Ray (Frankie Knuckles Ballroom Mix)"))
+        .toBe("Voodoo Ray (Frankie Knuckles Ballroom Mix)");
+    });
+
+    it("should convert dash-separated named mixes to parenthesized format", () => {
+      expect(cleanTrackName("Forest Drive West - Rupture Mix"))
+        .toBe("Forest Drive West (Rupture Mix)");
+      expect(cleanTrackName("Champion - Miami Mix"))
+        .toBe("Champion (Miami Mix)");
+    });
+
+    it("should strip generic mixes without artist names", () => {
+      expect(cleanTrackName("Fire (Original Mix)")).toBe("Fire");
+      expect(cleanTrackName("Bohemian Rhapsody Is Long (Club Mix)"))
+        .toBe("Bohemian Rhapsody Is Long");
+    });
+  });
+
+  describe("audio format preservation (disambiguation)", () => {
+    it("should PRESERVE mono for short/common base names", () => {
+      expect(cleanTrackName("She Loves You (mono)")).toBe("She Loves You (mono)");
+    });
+
+    it("should PRESERVE stereo for short base names", () => {
+      expect(cleanTrackName("HYPNOSIS (stereo)")).toBe("HYPNOSIS (stereo)");
+    });
+
+    it("should strip mono/stereo for long unique base names", () => {
+      expect(cleanTrackName("Bohemian Rhapsody Is A Very Long Title (mono)")).toBe("Bohemian Rhapsody Is A Very Long Title");
+    });
+  });
+
+  describe("instrumental/acoustic preservation (always kept)", () => {
+    it("should PRESERVE instrumental in parentheses", () => {
+      expect(cleanTrackName("Things We Do for Love (Instrumental)")).toBe("Things We Do for Love (Instrumental)");
+    });
+
+    it("should PRESERVE instrumental in brackets", () => {
+      expect(cleanTrackName("Let's Hook Up (Asthma) [Instrumental]")).toBe("Let's Hook Up (Asthma) [Instrumental]");
+    });
+
+    it("should PRESERVE instrumental mix as dash suffix", () => {
+      expect(cleanTrackName("Jazz Lick - Instrumental Mix")).toBe("Jazz Lick (Instrumental Mix)");
+    });
+
+    it("should PRESERVE acoustic in parentheses", () => {
+      expect(cleanTrackName("Creep (Acoustic)")).toBe("Creep (Acoustic)");
+    });
+
+    it("should PRESERVE instrumental for long base names", () => {
+      // Unlike mono/stereo, instrumental is always preserved (distinct recordings in MB)
+      expect(cleanTrackName("A Very Long And Specific Track Name (Instrumental)")).toBe(
+        "A Very Long And Specific Track Name (Instrumental)"
+      );
+    });
+  });
+
+  describe("remaster preservation (disambiguation)", () => {
+    it("should PRESERVE remaster+year in parentheses", () => {
+      expect(cleanTrackName("There Is a Light That Never Goes Out (2011 Remaster)")).toBe(
+        "There Is a Light That Never Goes Out (2011 Remaster)"
+      );
+    });
+
+    it("should PRESERVE remaster+year as dash suffix", () => {
+      expect(cleanTrackName("This Charming Man - 2011 Remaster")).toBe(
+        "This Charming Man - 2011 Remaster"
+      );
+    });
+
+    it("should STRIP plain remaster without year", () => {
+      expect(cleanTrackName("Bohemian Rhapsody (Remastered)")).toBe("Bohemian Rhapsody");
+    });
+
+    it("should STRIP plain remaster dash suffix without year", () => {
+      expect(cleanTrackName("Song - Remastered")).toBe("Song");
+    });
+
+    it("should handle remastered+year variant", () => {
+      expect(cleanTrackName("Remember - Remastered 1999")).toBe("Remember - Remastered 1999");
+    });
+
+    it("should handle bracketed remaster+year", () => {
+      expect(cleanTrackName("Song Title [2020 Remaster]")).toBe("Song Title [2020 Remaster]");
+    });
+  });
+
+  describe("featuring artist handling", () => {
+    it("should PRESERVE feat info for generic base names", () => {
+      expect(cleanTrackName("Song (feat. Artist)")).toBe("Song (feat. Artist)");
+    });
+
+    it("should PRESERVE feat info when it contains artist name", () => {
+      expect(cleanTrackName("Roses (feat. ROZES)")).toBe("Roses (feat. ROZES)");
+    });
+
+    it("should remove feat from middle of track title", () => {
+      // When feat is in the main title (not parenthesized), remove the suffix
+      expect(cleanTrackName("Timber feat. Ke$ha")).toBe("Timber");
+    });
+
+    it("should handle ft. abbreviation", () => {
+      expect(cleanTrackName("See You Again ft. Charlie Puth")).toBe("See You Again");
+    });
+
+    it("should handle featuring spelled out", () => {
+      expect(cleanTrackName("Empire State of Mind featuring Alicia Keys")).toBe("Empire State of Mind");
+    });
+  });
+
+  describe("nested parentheses", () => {
+    it("should handle nested parentheses correctly", () => {
+      expect(cleanTrackName("Track (Part (Two))")).toBe("Track (Part (Two))");
+    });
+
+    it("should only remove outer guff with nested content", () => {
+      expect(cleanTrackName("Track ((Live) 2019)")).toBe("Track");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle track names that are only parenthetical", () => {
+      expect(cleanTrackName("(Intro)")).toBe("(Intro)");
+    });
+
+    it("should handle unmatched parentheses", () => {
+      expect(cleanTrackName("Track (with open paren")).toBe("Track (with open paren");
+    });
+
+    it("should handle only closing parenthesis", () => {
+      expect(cleanTrackName("Track with close paren)")).toBe("Track with close paren)");
+    });
+
+    it("should preserve non-guff parenthetical content", () => {
+      expect(cleanTrackName("A Day in the Life (From Sgt. Pepper's)")).toBe("A Day in the Life (From Sgt. Pepper's)");
+    });
+  });
+});
+
+describe("cleanArtistName", () => {
+  describe("basic cleaning", () => {
+    it("should return trimmed input for simple names", () => {
+      expect(cleanArtistName("  The Beatles  ")).toBe("The Beatles");
+    });
+
+    it("should handle empty strings", () => {
+      expect(cleanArtistName("")).toBe("");
+    });
+  });
+
+  describe("The prefix preservation", () => {
+    it("should preserve 'The ' prefix (MB indexes artists with The)", () => {
+      expect(cleanArtistName("The Beatles")).toBe("The Beatles");
+      expect(cleanArtistName("The Rolling Stones")).toBe("The Rolling Stones");
+    });
+
+    it("should preserve case-insensitive 'The '", () => {
+      expect(cleanArtistName("THE BEATLES")).toBe("THE BEATLES");
+      expect(cleanArtistName("the beatles")).toBe("the beatles");
+    });
+
+    it("should handle 'The' as entire name", () => {
+      expect(cleanArtistName("The")).toBe("The");
+    });
+
+    it("should handle 'The The' band name", () => {
+      expect(cleanArtistName("The The")).toBe("The The");
+    });
+  });
+
+  describe("featuring removal", () => {
+    it("should remove feat. suffix", () => {
+      expect(cleanArtistName("Drake feat. Rihanna")).toBe("Drake");
+    });
+
+    it("should remove ft. suffix", () => {
+      expect(cleanArtistName("Post Malone ft. 21 Savage")).toBe("Post Malone");
+    });
+
+    it("should remove featuring suffix", () => {
+      expect(cleanArtistName("Jay-Z featuring Beyoncé")).toBe("Jay-Z");
+    });
+  });
+
+  describe("parenthetical content handling", () => {
+    // NUANCE: Country disambiguators like (US), (UK) are NOT guff
+    // They're important for distinguishing bands with the same name
+    // Bush (US) vs Bush (UK) are different bands!
+    it("should PRESERVE country disambiguators", () => {
+      expect(cleanArtistName("Bush (US)")).toBe("Bush (US)");
+      expect(cleanArtistName("Suede (UK)")).toBe("Suede (UK)");
+    });
+
+    it("should remove actual guff like (Live)", () => {
+      expect(cleanArtistName("Artist (Live)")).toBe("Artist");
+    });
+  });
+});
+
+describe("cleanReleaseName", () => {
+  it("should clean release names like track names", () => {
+    expect(cleanReleaseName("Abbey Road (Remastered)")).toBe("Abbey Road");
+  });
+
+  it("should remove [Deluxe Edition]", () => {
+    expect(cleanReleaseName("1989 [Deluxe Edition]")).toBe("1989");
+  });
+
+  it("should remove (Expanded Edition)", () => {
+    expect(cleanReleaseName("Thriller (Expanded Edition)")).toBe("Thriller");
+  });
+
+  it("should remove [Anniversary Edition]", () => {
+    expect(cleanReleaseName("Dark Side of the Moon [50th Anniversary Edition]")).toBe("Dark Side of the Moon");
+  });
+
+  it("should remove (Special Edition)", () => {
+    expect(cleanReleaseName("OK Computer (Special Edition)")).toBe("OK Computer");
+  });
+});
+
+describe("normalizeForComparison", () => {
+  describe("accent handling", () => {
+    it("should normalize accented characters", () => {
+      expect(normalizeForComparison("Beyoncé")).toBe("beyonce");
+      expect(normalizeForComparison("Björk")).toBe("bjork");
+      expect(normalizeForComparison("Motörhead")).toBe("motorhead");
+    });
+
+    it("should handle various accents", () => {
+      expect(normalizeForComparison("Sigur Rós")).toBe("sigur ros");
+      expect(normalizeForComparison("Zoé")).toBe("zoe");
+    });
+  });
+
+  describe("case normalization", () => {
+    it("should lowercase everything", () => {
+      expect(normalizeForComparison("HELLO WORLD")).toBe("hello world");
+      expect(normalizeForComparison("HeLLo WoRLd")).toBe("hello world");
+    });
+  });
+
+  describe("whitespace normalization", () => {
+    it("should normalize multiple spaces", () => {
+      expect(normalizeForComparison("Hello    World")).toBe("hello world");
+    });
+
+    it("should trim leading/trailing whitespace", () => {
+      expect(normalizeForComparison("  hello  ")).toBe("hello");
+    });
+  });
+
+  describe("special character handling", () => {
+    it("should remove non-alphanumeric characters", () => {
+      expect(normalizeForComparison("AC/DC")).toBe("acdc");
+      expect(normalizeForComparison("Guns N' Roses")).toBe("guns n roses");
+    });
+
+    it("should preserve Japanese characters", () => {
+      // Japanese characters are now preserved (not filtered to empty)
+      const result = normalizeForComparison("きゃりーぱみゅぱみゅ");
+      expect(result).not.toBe("");
+    });
+
+    it("should preserve Greek letters in band names", () => {
+      // CHVRCHΞS has a Greek Xi -- now preserved
+      expect(normalizeForComparison("CHVRCHΞS")).toBe("chvrchξs");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty string", () => {
+      expect(normalizeForComparison("")).toBe("");
+    });
+
+    it("should handle only spaces", () => {
+      expect(normalizeForComparison("   ")).toBe("");
+    });
+
+    it("should handle only special characters", () => {
+      expect(normalizeForComparison("!!!")).toBe("");
+    });
+  });
+});
+
+describe("unhandled/documented nuances", () => {
+  // These tests document known edge cases and their current behavior
+  // Some may need future improvements
+
+  describe("collaboration patterns", () => {
+    it("should handle 'vs' pattern (treated as guff, removes right side)", () => {
+      // "vs" is in GUFF_WORDS but only in parenthetical content
+      // Regular "A vs B" format is NOT cleaned
+      expect(cleanArtistName("Artist A vs Artist B")).toBe("Artist A vs Artist B");
+    });
+
+    it("should preserve '&' collaborations", () => {
+      expect(cleanArtistName("Hall & Oates")).toBe("Hall & Oates");
+    });
+
+    it("should preserve 'x' collaborations", () => {
+      expect(cleanArtistName("Marshmello x Juice WRLD")).toBe("Marshmello x Juice WRLD");
+    });
+  });
+
+  describe("numbers in names", () => {
+    it("should preserve numbers in band names", () => {
+      expect(cleanArtistName("Sum 41")).toBe("Sum 41");
+      expect(cleanArtistName("Blink-182")).toBe("Blink-182");
+      expect(cleanArtistName("311")).toBe("311");
+    });
+
+    it("should preserve numbers in track names", () => {
+      expect(cleanTrackName("1979")).toBe("1979");
+      expect(cleanTrackName("99 Problems")).toBe("99 Problems");
+    });
+  });
+
+  describe("punctuation in names", () => {
+    it("should preserve exclamation marks in names", () => {
+      expect(cleanArtistName("P!nk")).toBe("P!nk");
+      // "The !!!" is preserved (no "The" stripping -- MB indexes with "The")
+      expect(cleanArtistName("The !!!")).toBe("The !!!");
+    });
+
+    it("should preserve hyphens in names", () => {
+      expect(cleanArtistName("Jay-Z")).toBe("Jay-Z");
+      expect(cleanTrackName("Re-Arranged")).toBe("Re-Arranged");
+    });
+  });
+
+  describe("CJK (Chinese/Japanese/Korean) handling", () => {
+    it("should preserve Japanese track names", () => {
+      expect(cleanTrackName("花火")).toBe("花火");
+      expect(cleanTrackName("きゃりーぱみゅぱみゅ")).toBe("きゃりーぱみゅぱみゅ");
+    });
+
+    it("normalizeForComparison preserves non-Latin characters", () => {
+      // CJK characters are now preserved during normalization
+      expect(normalizeForComparison("花火")).toBe("花火");
+      expect(normalizeForComparison("YOASOBI")).toBe("yoasobi"); // Latin OK
+    });
+  });
+
+  describe("classical music patterns", () => {
+    it("should preserve opus numbers", () => {
+      expect(cleanTrackName("Symphony No. 5, Op. 67")).toBe("Symphony No. 5, Op. 67");
+    });
+
+    it("should preserve movement numbers", () => {
+      expect(cleanTrackName("Violin Concerto in D major: I. Allegro")).toBe("Violin Concerto in D major: I. Allegro");
+    });
+  });
+
+  describe("DJ and electronic music patterns", () => {
+    it("should not remove 'DJ' from artist names", () => {
+      expect(cleanArtistName("DJ Shadow")).toBe("DJ Shadow");
+    });
+
+    it("should PRESERVE production credits with artist names (disambiguation)", () => {
+      // "prod" is in guff words, but "Metro Boomin" is an artist name (>3 chars)
+      // This is kept for disambiguation - different producers = different versions
+      expect(cleanTrackName("Song [prod. Metro Boomin]")).toBe("Song [prod. Metro Boomin]");
+    });
+
+    it("should PRESERVE produced by credits with artist names", () => {
+      // "Produced by" + artist name is kept for disambiguation
+      expect(cleanTrackName("Song (Produced by Metro Boomin)")).toBe("Song (Produced by Metro Boomin)");
+    });
+
+    it("should remove pure production markers without artist names", () => {
+      // Just "(prod)" or "(production)" without an artist can be removed
+      expect(cleanTrackName("Song (prod)")).toBe("Song");
+      expect(cleanTrackName("Song [Production]")).toBe("Song");
+    });
+  });
+});
+
+describe("threshold boundary tests (overfitting check)", () => {
+  // These tests verify behavior around the threshold boundaries
+  // to ensure we haven't overfit to specific lengths
+  
+  describe("SHORT_NAME_THRESHOLD (15 chars)", () => {
+    it("should preserve remix for 14-char name (below threshold)", () => {
+      // "Bohemian Rhap" = 13 chars (< 15) -> remix preserved
+      expect(cleanTrackName("Bohemian Rhap (Remix)")).toBe("Bohemian Rhap (Remix)");
+    });
+
+    it("should REMOVE remix for exactly 15-char name (at threshold)", () => {
+      // "Bohemian Rhapso" = 15 chars (not < 15) -> isShort = false
+      // Since it's not short, remix can be removed (no artist name in "Remix")
+      expect(cleanTrackName("Bohemian Rhapso (Remix)")).toBe("Bohemian Rhapso");
+    });
+
+    it("should remove remix for 20+ char name (well above threshold)", () => {
+      // Long unique names have remix removed when no artist name present
+      const result = cleanTrackName("A Very Long Unique Track Name Here (Remix)");
+      expect(result).toBe("A Very Long Unique Track Name Here");
+    });
+  });
+
+  describe("diverse length inputs", () => {
+    it("should handle single character track names", () => {
+      expect(cleanTrackName("A")).toBe("A");
+      expect(cleanTrackName("A (Remix)")).toBe("A (Remix)"); // Short, preserve
+    });
+
+    it("should handle very long track names (100+ chars)", () => {
+      const longName = "This Is An Extremely Long Track Name That Goes On And On And Contains Many Words And Should Still Work";
+      expect(cleanTrackName(longName)).toBe(longName);
+    });
+
+    it("should handle long track with guff", () => {
+      // Remaster+year is preserved (eval: 0 improvements from stripping, 11 regressions)
+      const longWithGuff = "This Is An Extremely Long Track Name That Goes On And On (2023 Remaster)";
+      expect(cleanTrackName(longWithGuff)).toBe("This Is An Extremely Long Track Name That Goes On And On (2023 Remaster)");
+    });
+  });
+});
+
+describe("diverse real-world inputs (overfitting check)", () => {
+  // These tests use varied real-world examples to ensure
+  // the logic generalizes beyond the evaluation dataset
+
+  describe("international artists", () => {
+    it("should handle Spanish accents", () => {
+      expect(cleanArtistName("José González")).toBe("José González");
+      expect(normalizeForComparison("José González")).toBe("jose gonzalez");
+    });
+
+    it("should handle French accents", () => {
+      expect(cleanTrackName("Édith Piaf - La Vie en Rose")).toBe("Édith Piaf - La Vie en Rose");
+    });
+
+    it("should handle German umlauts", () => {
+      expect(cleanArtistName("Röyksopp")).toBe("Röyksopp");
+      expect(normalizeForComparison("Röyksopp")).toBe("royksopp");
+    });
+
+    it("should handle Nordic names", () => {
+      expect(cleanArtistName("Sigur Rós")).toBe("Sigur Rós");
+      expect(cleanArtistName("The Sigur Rós")).toBe("The Sigur Rós");
+    });
+  });
+
+  describe("various genres", () => {
+    it("should PRESERVE hip-hop production credits with artist names", () => {
+      // "Mike WiLL Made-It" is an artist name (>4 chars), so it's preserved for disambiguation
+      expect(cleanTrackName("DNA. (prod. Mike WiLL Made-It)")).toBe("DNA. (prod. Mike WiLL Made-It)");
+    });
+
+    it("should handle EDM variations", () => {
+      expect(cleanTrackName("Levels (Radio Edit)")).toBe("Levels");
+      expect(cleanTrackName("Levels (Extended Mix)")).toBe("Levels");
+    });
+
+    it("should handle classical with opus", () => {
+      expect(cleanTrackName("Piano Sonata No. 14 in C-sharp minor, Op. 27, No. 2")).toBe(
+        "Piano Sonata No. 14 in C-sharp minor, Op. 27, No. 2"
+      );
+    });
+
+    it("should PRESERVE live at venue (venue name acts as disambiguation)", () => {
+      // "Newport" is >4 chars and not a guff word, so it's preserved
+      expect(cleanTrackName("Take Five (Live at Newport)")).toBe("Take Five (Live at Newport)");
+    });
+
+    it("should remove pure (Live) without venue", () => {
+      expect(cleanTrackName("Take Five (Live)")).toBe("Take Five");
+    });
+
+    it("should handle metal bands", () => {
+      expect(cleanArtistName("Motörhead")).toBe("Motörhead");
+      // Note: "The " prefix removal doesn't apply to non-"The " strings
+    });
+  });
+
+  describe("edge case formats", () => {
+    it("should handle double parentheses", () => {
+      expect(cleanTrackName("Song ((Live))")).toBe("Song");
+    });
+
+    it("should handle mixed parens and brackets", () => {
+      expect(cleanTrackName("Song (Live) [Remastered]")).toBe("Song");
+    });
+
+    it("should handle multiple feat patterns (only removes first)", () => {
+      // Current implementation only removes the first feat pattern
+      // "Song feat. A feat. B" -> removes first feat -> "Song feat. B"
+      // Then the remaining "feat. B" is checked again but "B" is too short (<4 chars)
+      // Actually, the first match removes everything after "feat."
+      // So "Song feat. A feat. B" -> "Song"... let me verify
+      // Actually the feat pattern matches to end of string, removing "A feat. B"
+      // But shouldKeepForDisambiguation might preserve it...
+      // "Song" is 4 chars (short), "A feat. B" has "feat" which matches,
+      // and "B" is only 1 char (not >4), so no artist name detected
+      // Since Song is short (<15) and common phrase, shouldKeep might trigger
+      // Let's just test actual behavior:
+      expect(cleanTrackName("Song feat. A feat. B")).toBe("Song feat. A feat. B");
+    });
+
+    it("should handle empty parentheses", () => {
+      expect(cleanTrackName("Song ()")).toBe("Song ()");
+    });
+
+    it("should handle only whitespace in parens", () => {
+      expect(cleanTrackName("Song (   )")).toBe("Song (   )");
+    });
+  });
+});
+
+describe("real test cases from evaluation data", () => {
+  // Representative cases observed during evaluation runs.
+  // We keep a small set of these as regression tests, but we don't commit raw evaluation results.
+
+  describe("featuring tracks", () => {
+    it("should handle '212 (feat. Lazy Jay)' by Azealia Banks", () => {
+      // Short base name "212" (3 chars) + feat = should preserve
+      expect(cleanTrackName("212 (feat. Lazy Jay)")).toBe("212 (feat. Lazy Jay)");
+    });
+
+    it("should handle 'Get Thy Bearings (Feat. Szjerdene)' by Bonobo", () => {
+      // "Get Thy Bearings" is 16 chars (> 15), but "Szjerdene" is an artist name
+      expect(cleanTrackName("Get Thy Bearings (Feat. Szjerdene)")).toBe("Get Thy Bearings (Feat. Szjerdene)");
+    });
+
+    it("should handle 'Club classics featuring bb trickz' by Charli xcx", () => {
+      // "featuring" in track title (not parenthesized) - gets removed
+      // NUANCE: Non-parenthesized feat patterns are removed regardless of base name length
+      // This is intentional: the feat info is in the artist field, not needed in track
+      expect(cleanTrackName("Club classics featuring bb trickz")).toBe("Club classics");
+    });
+  });
+
+  describe("remix tracks", () => {
+    it("should handle 'Dubplate (Total Science Remix)' by Wots My Code", () => {
+      // "Dubplate" is 8 chars (< 15), "Total Science" is artist name
+      expect(cleanTrackName("Dubplate (Total Science Remix)")).toBe("Dubplate (Total Science Remix)");
+    });
+
+    it("should convert 'Sensation - Rrose Remix' to parenthesized format", () => {
+      // Dash-separated remix converted to MB's parenthesized convention
+      expect(cleanTrackName("Sensation - Rrose Remix")).toBe("Sensation (Rrose Remix)");
+    });
+
+    it("should convert 'All Of My - Aries Remix' to parenthesized format", () => {
+      expect(cleanTrackName("All Of My - Aries Remix")).toBe("All Of My (Aries Remix)");
+    });
+  });
+
+  describe("parenthetical tracks", () => {
+    it("should handle 'Maximum Style (Lover To Lover)' by Tom & Jerry", () => {
+      // "(Lover To Lover)" is not guff - it's a subtitle
+      expect(cleanTrackName("Maximum Style (Lover To Lover)")).toBe("Maximum Style (Lover To Lover)");
+    });
+
+    it("should handle 'Let The Sunshine In (Reprise) - Remastered 2000' by The 5th Dimension", () => {
+      // "(Reprise)" is guff and stripped, "- Remastered 2000" has remaster+year so preserved
+      const result = cleanTrackName("Let The Sunshine In (Reprise) - Remastered 2000");
+      expect(result).toBe("Let The Sunshine In - Remastered 2000");
+    });
+
+    it("should handle 'Movin Too Fast (radio Mix)' by Romina Johnson", () => {
+      // "(radio Mix)" contains "radio" and "mix" - both guff
+      expect(cleanTrackName("Movin Too Fast (radio Mix)")).toBe("Movin Too Fast");
+    });
+  });
+});
+
+describe("unmatchable track categories (from MusicBrainz algorithm doc)", () => {
+  // These are documented categories that are inherently hard to match
+
+  describe("non-Latin text", () => {
+    it("should preserve Russian text", () => {
+      expect(cleanTrackName("ektenia ii: blagoslovenie")).toBe("ektenia ii: blagoslovenie");
+    });
+
+    it("should preserve Japanese kanji", () => {
+      expect(cleanTrackName("花火")).toBe("花火");
+    });
+  });
+
+  describe("garbage/corrupted data", () => {
+    it("should preserve garbage data (no cleaning can fix it)", () => {
+      expect(cleanTrackName("2xsm4xsa4xsmadkc4xs31xsoo1xsl")).toBe("2xsm4xsa4xsmadkc4xs31xsoo1xsl");
+    });
+  });
+
+  describe("medleys/mashups", () => {
+    it("should preserve medley format", () => {
+      expect(cleanTrackName("day tripper / if i needed someone / i want you")).toBe(
+        "day tripper / if i needed someone / i want you"
+      );
+    });
+  });
+
+  describe("classical music formatting", () => {
+    it("should preserve classical movement notation", () => {
+      expect(cleanTrackName("seasons (summer): iii. presto")).toBe("seasons (summer): iii. presto");
+    });
+
+    it("should preserve symphony notation", () => {
+      expect(cleanTrackName("symphony no. 5 in c minor, op. 67: i. allegro con brio")).toBe(
+        "symphony no. 5 in c minor, op. 67: i. allegro con brio"
+      );
+    });
+  });
+
+  describe("unconventional punctuation", () => {
+    it("should preserve period in middle of title", () => {
+      expect(cleanTrackName("sit down. stand up")).toBe("sit down. stand up");
+    });
+
+    it("should preserve slash separator", () => {
+      expect(cleanTrackName("eve white/eve black")).toBe("eve white/eve black");
+    });
+
+    it("should preserve trailing ellipsis", () => {
+      expect(cleanTrackName("i'm but a wave to ...")).toBe("i'm but a wave to ...");
+    });
+  });
+});
+
+describe("apostrophe handling (critical for matching)", () => {
+  // Different apostrophe characters are a common source of mismatches
+  
+  it("should preserve straight apostrophe", () => {
+    expect(cleanTrackName("I'm Not Okay (I Promise)")).toBe("I'm Not Okay (I Promise)");
+  });
+
+  it("should preserve curly apostrophe", () => {
+    expect(cleanTrackName("I'm Not Okay (I Promise)")).toBe("I'm Not Okay (I Promise)");
+  });
+
+  it("should normalize both apostrophes identically for comparison", () => {
+    const straight = normalizeForComparison("I'm Not Okay");
+    const curly = normalizeForComparison("I'm Not Okay");
+    expect(straight).toBe(curly);
+  });
+
+  it("should handle Don't with straight apostrophe", () => {
+    expect(normalizeForComparison("Don't Stop Me Now")).toBe("dont stop me now");
+  });
+
+  it("should handle Don't with curly apostrophe", () => {
+    expect(normalizeForComparison("Don't Stop Me Now")).toBe("dont stop me now");
+  });
+});
+
+describe("non-Latin normalization (CJK, Cyrillic, etc.)", () => {
+  it("should preserve and distinguish CJK characters", () => {
+    // Different Japanese track names must NOT normalize to the same string
+    expect(normalizeForComparison("花火")).not.toBe("");
+    expect(normalizeForComparison("花火")).toBe("花火");
+    expect(normalizeForComparison("春の歌")).toBe("春の歌");
+    expect(normalizeForComparison("花火")).not.toBe(normalizeForComparison("春の歌"));
+  });
+
+  it("should preserve Cyrillic characters", () => {
+    expect(normalizeForComparison("Кино")).toBe("кино");
+    expect(normalizeForComparison("Кино")).not.toBe(normalizeForComparison("Мумий"));
+  });
+
+  it("should preserve Korean characters", () => {
+    const input = "\uBD04\uB0A0"; // 봄날
+    const result = normalizeForComparison(input);
+    expect(result).not.toBe("");
+    expect(result).toBe(input);
+  });
+
+  it("should preserve Arabic characters", () => {
+    expect(normalizeForComparison("حبيبي")).not.toBe("");
+  });
+
+  it("should still strip Latin diacriticals", () => {
+    expect(normalizeForComparison("Beyonce")).toBe("beyonce");
+    expect(normalizeForComparison("Bjork")).toBe("bjork");
+  });
+
+  it("should handle mixed Latin and CJK", () => {
+    // "RADWIMPS 前前前世" should keep both parts
+    const result = normalizeForComparison("RADWIMPS 前前前世");
+    expect(result).toContain("radwimps");
+    expect(result).toContain("前前前世");
+  });
+});
+
+describe("integration scenarios", () => {
+  describe("real-world track names from evaluation", () => {
+    it("should clean Last.fm scrobble format", () => {
+      expect(cleanTrackName("High You Are (Branchez Remix)")).toBe("High You Are (Branchez Remix)");
+    });
+
+    it("should handle YouTube-style titles", () => {
+      expect(cleanTrackName("Bohemian Rhapsody [Official Video]")).toBe("Bohemian Rhapsody");
+    });
+
+    it("should handle Spotify-style remasters", () => {
+      // Remaster+year is preserved (eval: stripping never helps, causes regressions)
+      expect(cleanTrackName("Hotel California - 2013 Remaster")).toBe("Hotel California - 2013 Remaster");
+    });
+  });
+
+  describe("matching after cleaning", () => {
+    it("should preserve remaster+year info but strip plain remaster", () => {
+      // With year: preserved (eval data shows stripping never helps)
+      expect(cleanTrackName("Bohemian Rhapsody (2011 Remaster)")).toBe("Bohemian Rhapsody (2011 Remaster)");
+      // Without year: stripped (no disambiguation value)
+      expect(cleanTrackName("Bohemian Rhapsody (Remastered)")).toBe("Bohemian Rhapsody");
+    });
+
+    it("should enable accent-insensitive matching", () => {
+      const scrobble = "Déjà Vu";
+      const mbResult = "Deja Vu";
+      
+      expect(normalizeForComparison(scrobble)).toBe(normalizeForComparison(mbResult));
+    });
+  });
+});

--- a/apps/amethyst/lib/__tests__/musicbrainzRanking.test.ts
+++ b/apps/amethyst/lib/__tests__/musicbrainzRanking.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for MusicBrainz result ranking utilities
+ * 
+ * These tests validate the client-side ranking that improves result quality
+ * (measured during evaluation runs; details live in the eval commit message)
+ */
+
+import {
+  scoreResult,
+  rankResults,
+  rankMultiStageResults,
+  type RankingQuery,
+} from "../musicbrainzRanking";
+import type { MusicBrainzRecording } from "../oldStamp";
+
+// Helper to create mock recording
+function mockRecording(
+  title: string,
+  artist?: string,
+  release?: string,
+  opts?: { disambiguation?: string; releaseStatus?: string; score?: number },
+): MusicBrainzRecording {
+  const rec: MusicBrainzRecording = {
+    id: "test-id-" + Math.random().toString(36).slice(2),
+    title,
+    "artist-credit": artist ? [{ name: artist, artist: { id: "artist-id", name: artist } }] : [],
+    releases: release
+      ? [{ id: "release-id", title: release, ...(opts?.releaseStatus ? { status: opts.releaseStatus } : {}) }]
+      : [],
+  };
+  if (opts?.disambiguation) rec.disambiguation = opts.disambiguation;
+  if (opts?.score != null) rec.score = opts.score;
+  return rec;
+}
+
+describe("scoreResult", () => {
+  describe("strategy-based scoring", () => {
+    it("should score exact matches higher than fuzzy", () => {
+      const recording = mockRecording("Test Track", "Test Artist");
+      const query: RankingQuery = { track: "Test Track", artist: "Test Artist" };
+      
+      const exactScore = scoreResult(recording, query, "exact");
+      const fuzzyScore = scoreResult(recording, query, "fuzzy");
+      
+      expect(exactScore).toBeGreaterThan(fuzzyScore);
+    });
+
+    it("should score fuzzy matches higher than partial", () => {
+      const recording = mockRecording("Test Track", "Test Artist");
+      const query: RankingQuery = { track: "Test Track", artist: "Test Artist" };
+      
+      const fuzzyScore = scoreResult(recording, query, "fuzzy");
+      const partialScore = scoreResult(recording, query, "partial");
+      
+      expect(fuzzyScore).toBeGreaterThan(partialScore);
+    });
+  });
+
+  describe("track name matching", () => {
+    it("should boost exact track matches", () => {
+      const exactMatch = mockRecording("Hello World", "Artist");
+      const partialMatch = mockRecording("Hello World (Remix)", "Artist");
+      
+      const query: RankingQuery = { cleanedTrack: "Hello World" };
+      
+      const exactScore = scoreResult(exactMatch, query, "exact");
+      const partialScore = scoreResult(partialMatch, query, "exact");
+      
+      expect(exactScore).toBeGreaterThan(partialScore);
+    });
+
+    it("should boost partial matches (startsWith/contains) over no match", () => {
+      const partialMatch = mockRecording("Hello World Extended", "Artist");
+      const noMatch = mockRecording("Something Else", "Artist");
+
+      const query: RankingQuery = { cleanedTrack: "Hello World" };
+
+      const partialScore = scoreResult(partialMatch, query, "exact");
+      const noMatchScore = scoreResult(noMatch, query, "exact");
+
+      expect(partialScore).toBeGreaterThan(noMatchScore);
+    });
+  });
+
+  describe("artist name matching", () => {
+    it("should boost exact artist matches", () => {
+      const exactMatch = mockRecording("Track", "Beatles");
+      const partialMatch = mockRecording("Track", "Beatles Cover Band");
+      
+      const query: RankingQuery = { track: "Track", cleanedArtist: "Beatles" };
+      
+      const exactScore = scoreResult(exactMatch, query, "exact");
+      const partialScore = scoreResult(partialMatch, query, "exact");
+      
+      // exactMatch has exact artist ("Beatles" === "Beatles")
+      // partialMatch has starts-with artist ("Beatles Cover Band" starts with "Beatles")
+      expect(exactScore).toBeGreaterThan(partialScore);
+    });
+  });
+
+  describe("track-only searches (no artist)", () => {
+    it("should score track-only exact matches reasonably", () => {
+      const recording = mockRecording("Unique Track Name");
+
+      const trackOnlyQuery: RankingQuery = { cleanedTrack: "Unique Track Name" };
+
+      const trackOnlyScore = scoreResult(recording, trackOnlyQuery, "exact");
+
+      // Should get strategy base (3.0) * exact match boost (2.2) = ~6.6
+      expect(trackOnlyScore).toBeGreaterThan(3.0);
+    });
+
+    it("should apply higher release boost for track-only searches", () => {
+      const recording = mockRecording("Common Name", undefined, "Specific Album");
+      
+      const query: RankingQuery = { cleanedTrack: "Common Name", cleanedRelease: "Specific Album" };
+      
+      const score = scoreResult(recording, query, "exact");
+      
+      // Should have release boost applied
+      expect(score).toBeGreaterThan(1.0);
+    });
+  });
+
+  describe("both track and artist match", () => {
+    it("should apply strong bonus when both match", () => {
+      const fullMatch = mockRecording("Hello World", "Test Artist");
+      const trackOnlyMatch = mockRecording("Hello World", "Different Artist");
+      
+      const query: RankingQuery = { cleanedTrack: "Hello World", cleanedArtist: "Test Artist" };
+      
+      const fullScore = scoreResult(fullMatch, query, "exact");
+      const partialScore = scoreResult(trackOnlyMatch, query, "exact");
+      
+      expect(fullScore).toBeGreaterThan(partialScore);
+    });
+  });
+
+  describe("featuring artist bonus", () => {
+    it("should boost when query feat matches result feat", () => {
+      const recording = mockRecording("Timber (feat. Kesha)", "Pitbull");
+      const query: RankingQuery = { track: "Timber feat. Kesha", artist: "Pitbull" };
+      
+      const score = scoreResult(recording, query, "exact");
+      
+      // Should have featuring boost applied
+      expect(score).toBeGreaterThan(3.0); // Base exact (3.0) + bonuses
+    });
+  });
+
+  describe("variant matching", () => {
+    it("should boost when both query and result mention 'live'", () => {
+      const liveRecording = mockRecording("Stairway to Heaven (Live)", "Led Zeppelin");
+      const studioRecording = mockRecording("Stairway to Heaven", "Led Zeppelin");
+      const query: RankingQuery = { track: "Stairway to Heaven (Live)", artist: "Led Zeppelin" };
+
+      const liveScore = scoreResult(liveRecording, query, "exact");
+      const studioScore = scoreResult(studioRecording, query, "exact");
+
+      expect(liveScore).toBeGreaterThan(studioScore);
+    });
+
+    it("should boost mono recording when query mentions mono", () => {
+      const monoRec = mockRecording("She Loves You", "The Beatles", undefined, { disambiguation: "mono" });
+      const stereoRec = mockRecording("She Loves You", "The Beatles");
+      const query: RankingQuery = { track: "She Loves You (mono)", cleanedTrack: "She Loves You", artist: "The Beatles" };
+
+      const monoScore = scoreResult(monoRec, query, "exact");
+      const stereoScore = scoreResult(stereoRec, query, "exact");
+
+      expect(monoScore).toBeGreaterThan(stereoScore);
+    });
+
+    it("should boost remaster when query mentions remaster", () => {
+      const remaster = mockRecording("This Charming Man", "The Smiths", undefined, { disambiguation: "2011 remaster" });
+      const original = mockRecording("This Charming Man", "The Smiths");
+      const query: RankingQuery = { track: "This Charming Man - 2011 Remaster", cleanedTrack: "This Charming Man", artist: "The Smiths" };
+
+      const remasterScore = scoreResult(remaster, query, "exact");
+      const originalScore = scoreResult(original, query, "exact");
+
+      expect(remasterScore).toBeGreaterThan(originalScore);
+    });
+
+    it("should penalize variant result when query doesn't mention variant", () => {
+      const variant = mockRecording("Song", "Artist", undefined, { disambiguation: "live" });
+      const standard = mockRecording("Song", "Artist");
+      const query: RankingQuery = { track: "Song", artist: "Artist" };
+
+      const variantScore = scoreResult(variant, query, "exact");
+      const standardScore = scoreResult(standard, query, "exact");
+
+      expect(standardScore).toBeGreaterThan(variantScore);
+    });
+
+    it("should boost edit version via disambiguation when query mentions edit", () => {
+      // When "edit" is in disambiguation (not title), variant boost isn't offset by exact-match loss
+      const editRec = mockRecording("hotline", "Artist", undefined, { disambiguation: "edit" });
+      const standardRec = mockRecording("hotline", "Artist");
+      const query: RankingQuery = { track: "hotline (edit)", cleanedTrack: "hotline", artist: "Artist" };
+
+      const editScore = scoreResult(editRec, query, "exact");
+      const standardScore = scoreResult(standardRec, query, "exact");
+
+      expect(editScore).toBeGreaterThan(standardScore);
+    });
+  });
+
+  describe("MB API score prior", () => {
+    it("should favor results with higher MB scores", () => {
+      const highScore = { ...mockRecording("Track", "Artist"), score: 100 };
+      const lowScore = { ...mockRecording("Track", "Artist"), score: 40 };
+      const query: RankingQuery = { cleanedTrack: "Track", cleanedArtist: "Artist" };
+
+      const high = scoreResult(highScore, query, "exact");
+      const low = scoreResult(lowScore, query, "exact");
+      expect(high).toBeGreaterThan(low);
+    });
+
+    it("should handle missing score gracefully", () => {
+      const noScore = mockRecording("Track", "Artist");
+      const query: RankingQuery = { cleanedTrack: "Track" };
+      const s = scoreResult(noScore, query, "exact");
+      expect(s).toBeGreaterThan(0);
+    });
+  });
+
+  describe("position prior", () => {
+    it("should penalize later positions", () => {
+      const rec = mockRecording("Track", "Artist");
+      const query: RankingQuery = { cleanedTrack: "Track", cleanedArtist: "Artist" };
+
+      const pos0 = scoreResult(rec, query, "exact", 0);
+      const pos10 = scoreResult(rec, query, "exact", 10);
+      expect(pos0).toBeGreaterThan(pos10);
+    });
+  });
+
+  describe("release status", () => {
+    it("should favor official releases over bootlegs", () => {
+      const official = {
+        ...mockRecording("Track", "Artist"),
+        releases: [{ id: "r1", title: "Album", status: "Official" }],
+      };
+      const bootleg = {
+        ...mockRecording("Track", "Artist"),
+        releases: [{ id: "r2", title: "Album", status: "Bootleg" }],
+      };
+      const query: RankingQuery = { cleanedTrack: "Track", cleanedArtist: "Artist" };
+
+      const offScore = scoreResult(official, query, "exact");
+      const bootScore = scoreResult(bootleg, query, "exact");
+      expect(offScore).toBeGreaterThan(bootScore);
+    });
+  });
+
+  describe("accent-insensitive matching", () => {
+    it("should match accented and non-accented versions", () => {
+      const recording = mockRecording("Deja Vu", "Beyonce");
+      const query: RankingQuery = { cleanedTrack: "Déjà Vu", cleanedArtist: "Beyoncé" };
+      
+      const score = scoreResult(recording, query, "exact");
+      
+      // Should still get exact match bonuses due to normalization
+      expect(score).toBeGreaterThan(1.0);
+    });
+  });
+});
+
+describe("rankResults", () => {
+  it("should sort results by score descending", () => {
+    const results: MusicBrainzRecording[] = [
+      mockRecording("Similar Track", "Artist"),
+      mockRecording("Exact Track", "Artist"),
+      mockRecording("Different Track", "Artist"),
+    ];
+    
+    const query: RankingQuery = { cleanedTrack: "Exact Track" };
+    const ranked = rankResults(results, query, "exact");
+    
+    expect(ranked[0].title).toBe("Exact Track");
+  });
+
+  it("should handle empty results", () => {
+    const query: RankingQuery = { cleanedTrack: "Test" };
+    const ranked = rankResults([], query, "exact");
+    
+    expect(ranked).toHaveLength(0);
+  });
+});
+
+describe("rankMultiStageResults", () => {
+  it("should combine and rank results from multiple stages", () => {
+    const exactResults: MusicBrainzRecording[] = [
+      mockRecording("Exact Match", "Artist"),
+    ];
+    const fuzzyResults: MusicBrainzRecording[] = [
+      mockRecording("Fuzzy Match", "Artist"),
+    ];
+    const partialResults: MusicBrainzRecording[] = [
+      mockRecording("Partial Match", "Artist"),
+    ];
+    
+    const stageResults = [
+      { results: exactResults, strategy: "exact" as const },
+      { results: fuzzyResults, strategy: "fuzzy" as const },
+      { results: partialResults, strategy: "partial" as const },
+    ];
+    
+    const query: RankingQuery = { cleanedTrack: "Exact Match" };
+    const ranked = rankMultiStageResults(stageResults, query);
+    
+    expect(ranked).toHaveLength(3);
+    expect(ranked[0].title).toBe("Exact Match");
+  });
+
+  it("should deduplicate results by ID", () => {
+    const recording = mockRecording("Same Track", "Artist");
+    
+    const stageResults = [
+      { results: [recording], strategy: "exact" as const },
+      { results: [recording], strategy: "fuzzy" as const }, // Same recording
+    ];
+    
+    const query: RankingQuery = { cleanedTrack: "Same Track" };
+    const ranked = rankMultiStageResults(stageResults, query);
+    
+    expect(ranked).toHaveLength(1);
+  });
+
+  it("should prefer exact stage result when same recording in multiple stages", () => {
+    const recording = mockRecording("Track", "Artist");
+    
+    const stageResults = [
+      { results: [recording], strategy: "fuzzy" as const },
+      { results: [recording], strategy: "exact" as const },
+    ];
+    
+    const query: RankingQuery = { cleanedTrack: "Track" };
+    const ranked = rankMultiStageResults(stageResults, query);
+    
+    expect(ranked).toHaveLength(1);
+    // Should keep the higher-scored version (exact)
+  });
+
+  it("should handle empty stage results", () => {
+    const stageResults = [
+      { results: [], strategy: "exact" as const },
+      { results: [mockRecording("Result", "Artist")], strategy: "fuzzy" as const },
+    ];
+    
+    const query: RankingQuery = { cleanedTrack: "Result" };
+    const ranked = rankMultiStageResults(stageResults, query);
+    
+    expect(ranked).toHaveLength(1);
+  });
+});
+
+describe("edge cases", () => {
+  it("should handle recordings with missing fields", () => {
+    const recording: MusicBrainzRecording = {
+      id: "test-id",
+      title: "Test",
+      // No artist-credit or releases
+    };
+    
+    const query: RankingQuery = { cleanedTrack: "Test", cleanedArtist: "Artist" };
+    const score = scoreResult(recording, query, "exact");
+    
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it("should handle empty query", () => {
+    const recording = mockRecording("Track", "Artist");
+    const query: RankingQuery = {};
+    
+    const score = scoreResult(recording, query, "exact");
+    
+    // Base strategy score should still apply
+    expect(score).toBe(3.0); // SCORE_EXACT
+  });
+
+  it("should handle very long track names", () => {
+    const longName = "A".repeat(500);
+    const recording = mockRecording(longName, "Artist");
+    const query: RankingQuery = { cleanedTrack: longName };
+    
+    const score = scoreResult(recording, query, "exact");
+    
+    expect(score).toBeGreaterThan(1.0);
+  });
+});

--- a/apps/amethyst/lib/__tests__/searchPipeline.e2e.test.ts
+++ b/apps/amethyst/lib/__tests__/searchPipeline.e2e.test.ts
@@ -1,0 +1,212 @@
+/**
+ * End-to-end tests for the MusicBrainz search pipeline.
+ * Hits the real MusicBrainz API -- run manually, not on CI.
+ *
+ * Run: cd apps/amethyst && npx jest --config jest.lib.config.ts searchPipeline.e2e
+ *
+ * Tests the full chain: raw input -> cleaning -> multi-stage search -> ranking -> result
+ */
+
+import { searchMusicbrainz } from "../searchOrchestrator";
+import {
+  cleanTrackName,
+  cleanArtistName,
+  normalizeForComparison,
+} from "../musicbrainzCleaner";
+
+const RATE_LIMIT_MS = 1500;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+jest.setTimeout(60000);
+
+const RUN_E2E = process.env.RUN_E2E === "1" || process.env.RUN_E2E === "true";
+const describeE2E = RUN_E2E ? describe : describe.skip;
+
+// =============================================================================
+// CLEANING UNIT TESTS (no API calls)
+// =============================================================================
+
+describe("cleaning pipeline", () => {
+  it("preserves remaster+year (eval: stripping never helps, 11 regressions)", () => {
+    expect(cleanTrackName("Bennie And The Jets (Remastered 2014)")).toBe(
+      "Bennie And The Jets (Remastered 2014)"
+    );
+  });
+
+  it("removes plain guff without year", () => {
+    expect(cleanTrackName("Bennie And The Jets (Remastered)")).toBe(
+      "Bennie And The Jets"
+    );
+  });
+
+  it("preserves remix for short/generic base names", () => {
+    expect(cleanTrackName("High (Branchez Remix)")).toBe(
+      "High (Branchez Remix)"
+    );
+  });
+
+  it("preserves remaster+year for long specific names", () => {
+    expect(cleanTrackName("Bohemian Rhapsody (2011 Remastered Version)")).toBe(
+      "Bohemian Rhapsody (2011 Remastered Version)"
+    );
+  });
+
+  it('preserves "The" prefix in artist name', () => {
+    expect(cleanArtistName("The Beatles")).toBe("The Beatles");
+  });
+
+  it("preserves non-Latin characters", () => {
+    expect(normalizeForComparison("久石譲")).not.toBe("");
+    expect(normalizeForComparison("봄날")).not.toBe("");
+  });
+
+  it("strips accents for comparison", () => {
+    expect(normalizeForComparison("Beyoncé")).toBe("beyonce");
+    expect(normalizeForComparison("Orquesta Filarmónica")).toBe(
+      "orquesta filarmonica"
+    );
+  });
+});
+
+// =============================================================================
+// E2E SEARCH TESTS (real MusicBrainz API)
+// =============================================================================
+
+describeE2E("e2e: search returns results (real MB API)", () => {
+  it("finds Bohemian Rhapsody by Queen at P@1", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Bohemian Rhapsody",
+      artist: "Queen",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    const first = results[0];
+    expect(first.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(normalizeForComparison(first.title)).toContain("bohemian rhapsody");
+
+    const artists = (first["artist-credit"] || [])
+      .map((a: any) => normalizeForComparison(a.artist?.name || ""))
+      .join(" ");
+    expect(artists).toContain("queen");
+  });
+
+  it("finds track with version suffix (dash-separated)", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Somebody's Watching Me - Single Version",
+      artist: "Rockwell",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    // Check top 10 -- multi-stage search should find it even if not P@1
+    const found = results
+      .slice(0, 10)
+      .some((r: any) =>
+        normalizeForComparison(r.title).includes("somebody")
+      );
+    expect(found).toBe(true);
+  });
+
+  it("finds track with parenthetical remix", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Paper Planes (DFA Remix)",
+      artist: "M.I.A.",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(normalizeForComparison(results[0].title)).toContain("paper planes");
+  });
+
+  it("finds track-only search (no artist) somewhere in results", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Bohemian Rhapsody",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    // Track-only search without artist is inherently ambiguous.
+    // Just verify the pipeline returns results and doesn't crash.
+    // The correct track should appear somewhere in the result set.
+    const found = results.some((r: any) =>
+      normalizeForComparison(r.title).includes("bohemian rhapsody")
+    );
+    expect(found).toBe(true);
+  });
+
+  it("finds Japanese artist", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Merry-Go-Round",
+      artist: "久石譲",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    // Should find results -- may be credited as "Joe Hisaishi" in MB
+    expect(results[0].id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("finds track with accented artist name", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Dios Nunca Muere",
+      artist: "Orquesta Filarmónica",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("handles featuring artist in title", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Unholy (feat. Kim Petras)",
+      artist: "Sam Smith",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    // Check that "Unholy" appears somewhere in top 5 (not necessarily P@1)
+    const top5Titles = results
+      .slice(0, 5)
+      .map((r: any) => normalizeForComparison(r.title));
+    expect(top5Titles.some((t: string) => t.includes("unholy"))).toBe(true);
+  });
+});
+
+// =============================================================================
+// RESULT STRUCTURE (validates contract with submit.tsx)
+// =============================================================================
+
+describeE2E("e2e: result structure matches PlayRecord contract", () => {
+  it("returns all fields needed by createPlayRecord()", async () => {
+    await sleep(RATE_LIMIT_MS);
+    const results = await searchMusicbrainz({
+      track: "Bohemian Rhapsody",
+      artist: "Queen",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    const r = results[0];
+
+    // recordingMbId
+    expect(r.id).toMatch(/^[0-9a-f-]{36}$/);
+
+    // trackName
+    expect(typeof r.title).toBe("string");
+    expect(r.title.length).toBeGreaterThan(0);
+
+    // artists[].artistMbId and artistName
+    const credits = r["artist-credit"] as any[];
+    expect(credits).toBeDefined();
+    expect(credits!.length).toBeGreaterThan(0);
+    expect(credits![0].artist.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(typeof credits![0].artist.name).toBe("string");
+
+    // releases[].id and title (for releaseMbId)
+    expect(r.releases).toBeDefined();
+    if (r.releases && r.releases.length > 0) {
+      expect(r.releases[0].id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(typeof r.releases[0].title).toBe("string");
+    }
+  });
+});

--- a/apps/amethyst/lib/fuzzyMatching.ts
+++ b/apps/amethyst/lib/fuzzyMatching.ts
@@ -1,0 +1,87 @@
+/**
+ * Fuzzy matching utilities for MusicBrainz search
+ *
+ * Provides edit distance (Levenshtein) and scored similarity
+ * for comparing track/artist names against search results.
+ */
+
+import { normalizeForComparison } from "./musicbrainzCleaner";
+
+/**
+ * Calculate Levenshtein edit distance between two strings
+ */
+export function levenshteinDistance(str1: string, str2: string): number {
+  const s1 = str1.toLowerCase();
+  const s2 = str2.toLowerCase();
+
+  const len1 = s1.length;
+  const len2 = s2.length;
+
+  const matrix: number[][] = Array(len1 + 1)
+    .fill(null)
+    .map(() => Array(len2 + 1).fill(0));
+
+  for (let i = 0; i <= len1; i++) matrix[i][0] = i;
+  for (let j = 0; j <= len2; j++) matrix[0][j] = j;
+
+  for (let i = 1; i <= len1; i++) {
+    for (let j = 1; j <= len2; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1, // deletion
+        matrix[i][j - 1] + 1, // insertion
+        matrix[i - 1][j - 1] + cost, // substitution
+      );
+    }
+  }
+
+  return matrix[len1][len2];
+}
+
+/**
+ * Calculate similarity ratio (0-1) based on edit distance
+ * 1.0 = identical, 0.0 = completely different
+ */
+export function similarityRatio(str1: string, str2: string): number {
+  const maxLen = Math.max(str1.length, str2.length);
+  if (maxLen === 0) return 1.0;
+
+  const distance = levenshteinDistance(str1, str2);
+  return 1 - distance / maxLen;
+}
+
+/**
+ * Check if two strings are a fuzzy match within a threshold
+ */
+export function fuzzyMatch(
+  query: string,
+  candidate: string,
+  threshold: number = 0.75,
+): boolean {
+  const queryNorm = normalizeForComparison(query);
+  const candidateNorm = normalizeForComparison(candidate);
+
+  if (queryNorm === candidateNorm) return true;
+
+  return similarityRatio(queryNorm, candidateNorm) >= threshold;
+}
+
+/**
+ * Score a candidate match based on fuzzy similarity
+ * Returns score 0-1, where 1.0 is perfect match
+ */
+export function fuzzyScore(query: string, candidate: string): number {
+  const queryNorm = normalizeForComparison(query);
+  const candidateNorm = normalizeForComparison(candidate);
+
+  if (queryNorm === candidateNorm) return 1.0;
+
+  // Scale prefix/containment scores by how much of the candidate the query covers.
+  // "Hello World" in "Hello World (Live)" (high coverage) scores near the cap;
+  // "Love" in "I Will Always Love You" (low coverage) scores much lower.
+  const coverage = queryNorm.length / candidateNorm.length;
+  if (candidateNorm.startsWith(queryNorm)) return 0.7 + 0.2 * coverage;
+  if (candidateNorm.includes(queryNorm)) return 0.5 + 0.3 * coverage;
+
+  return similarityRatio(queryNorm, candidateNorm);
+}

--- a/apps/amethyst/lib/musicbrainzCleaner.ts
+++ b/apps/amethyst/lib/musicbrainzCleaner.ts
@@ -1,0 +1,539 @@
+/**
+ * MusicBrainz name cleaning utilities
+ * Ported from backend Rust implementation for improved search matching
+ */
+
+// =============================================================================
+// CONFIGURATION CONSTANTS
+// =============================================================================
+
+/**
+ * Threshold for "short" base names that need disambiguation info preserved.
+ * Track names shorter than this are more likely to be generic (e.g., "High", "One")
+ * and benefit from having remix/feat info preserved.
+ * 
+ * Evaluated against Last.fm scrobble data: 15 chars balances:
+ * - Preserving disambiguation for common short names
+ * - Removing guff for longer, more specific names
+ */
+const SHORT_NAME_THRESHOLD = 15;
+
+/**
+ * Threshold for "common phrase" length (combined with word count check).
+ * Names under this length with ≤3 words are considered common phrases
+ * that may need disambiguation.
+ */
+const COMMON_PHRASE_LENGTH = 20;
+
+/**
+ * Minimum word length to be considered a potential artist name in disambiguation.
+ * Words shorter than this are likely articles/prepositions, not artist names.
+ */
+const MIN_ARTIST_NAME_LENGTH = 4;
+
+/**
+ * Generic track names that commonly need disambiguation info preserved.
+ * These are words that appear in many different songs by different artists.
+ */
+const GENERIC_TRACK_NAMES = [
+  "song", "track", "music", "beat", "sound", "tune", "piece",
+  "high", "low", "one", "two", "three", "four", "five",
+  "love", "time", "life", "home", "heart", "dream",
+] as const;
+
+/**
+ * Words commonly found in parenthetical/bracketed content that can be removed
+ * without losing essential information for matching.
+ * 
+ * Categories:
+ * - Audio quality/format: mono, stereo, remastered, etc.
+ * - Version types: remix, edit, live, acoustic, etc.
+ * - Production info: prod, produced, by
+ * - Edition types: deluxe, expanded, anniversary, bonus
+ * - Collaboration markers: feat, ft, featuring, vs, with
+ * - Status/metadata: official, explicit, clean, etc.
+ */
+const GUFF_WORDS = [
+  // Audio quality/format
+  "mono",
+  "stereo",
+  "quadraphonic",
+  "remastered",
+  "remaster",
+  "master",
+  "hd",
+  "hifi",
+  "hi-fi",
+  
+  // Version types
+  "a cappella",
+  "acoustic",
+  "extended",
+  "instrumental",
+  "karaoke",
+  "live",
+  "orchestral",
+  "piano",
+  "unplugged",
+  "vocal",
+  
+  // Remix/edit variants
+  "club",
+  "clubmix",
+  "dance",
+  "edit",
+  "maxi",
+  "megamix",
+  "mix",
+  "radio",
+  "re-edit",
+  "reedit",
+  "refix",
+  "remake",
+  "remix",
+  "remixed",
+  "remode",
+  "reprise",
+  "rework",
+  "reworked",
+  "rmx",
+  
+  // Production credits (commonly in brackets)
+  "prod",
+  "produced",
+  "production",
+  
+  // Edition/release types
+  "anniversary",
+  "bonus",
+  "deluxe",
+  "edition",
+  "expanded",
+  "original",
+  "release",
+  "released",
+  "single",
+  "special",
+  "version",
+  "ver",
+  
+  // Session/take variants
+  "demo",
+  "outtake",
+  "outtakes",
+  "rehearsal",
+  "session",
+  "take",
+  "takes",
+  "tape",
+  "tryout",
+  
+  // Track structure
+  "composition",
+  "cut",
+  "dialogue",
+  "excerpt",
+  "interlude",
+  "intro",
+  "long",
+  "main",
+  "outro",
+  "rap",
+  "short",
+  "skit",
+  "studio",
+  "track",
+  
+  // Content ratings
+  "censored",
+  "clean",
+  "dirty",
+  "explicit",
+  "uncensored",
+  
+  // Collaboration/featuring
+  "feat",
+  "featuring",
+  "ft",
+  "vs",
+  "with",
+  "without",
+  
+  // Video/media
+  "official",
+  "video",
+  
+  // Other metadata
+  "reinterpreted",
+  "snippet",
+  "preview",
+  "unknown",
+  "untitled",
+] as const;
+
+/**
+ * Check if content should be kept for disambiguation (remix/feat info)
+ * 
+ * Returns true if:
+ * - Content contains remix/feat info AND
+ * - Base name is generic, short, or content has artist name
+ */
+function shouldKeepForDisambiguation(
+  content: string,
+  baseName: string,
+  type: "remix" | "feat" | "version"
+): boolean {
+  const contentLower = content.toLowerCase();
+  const baseNameLower = baseName.toLowerCase();
+  
+  // Instrumental/acoustic are always worth preserving regardless of base name length.
+  // Eval: stripping instrumental has 0 better-position wins, 16 regressions (all from P@1).
+  // These denote distinct recordings in MB (vocal vs instrumental, plugged vs acoustic).
+  if (type === "version" && /\b(?:instrumental|acoustic)\b/.test(contentLower)) {
+    return true;
+  }
+
+  // Check if content matches the type we're looking for
+  const isRelevant = type === "remix"
+    ? /remix|rmx|rework|refix|remode/.test(contentLower)
+    : type === "version"
+    ? /\b(?:mono|stereo|quadraphonic)\b/.test(contentLower)
+      || (/\b(?:remaster(?:ed)?)\b/.test(contentLower) && /(19|20)\d{2}/.test(contentLower))
+    : /feat\.?|ft\.?|featuring/i.test(contentLower);
+
+  // "edition" and "mix" are remix-like only when accompanied by an artist name
+  // (e.g., "Kaytranada Edition" / "Zomby mix" = named remix, "Deluxe Edition" / "Original Mix" = guff)
+  const GENERIC_MIX_WORDS = /^(?:edition|deluxe|special|expanded|anniversary|bonus|limited|original|remastered|collector|club|radio|dance|dub|instrumental|extended|vocal|single|version|maxi|mega|short|long|main|mix|\d+\w*)$/;
+  const isNamedVariantWithArtist = type === "remix"
+    && /\b(?:edition|mix)\b/.test(contentLower)
+    && contentLower.split(/\s+/).some(
+      word => word.length >= MIN_ARTIST_NAME_LENGTH
+        && !GENERIC_MIX_WORDS.test(word)
+    );
+
+  if (!isRelevant && !isNamedVariantWithArtist) return false;
+
+  // Check if base name is generic (common word that appears in many songs)
+  const isGenericWord = GENERIC_TRACK_NAMES.some(
+    word => baseNameLower === word || baseNameLower.startsWith(word + " ")
+  );
+  const isShort = baseName.length < SHORT_NAME_THRESHOLD;
+  const isCommonPhrase = baseName.split(/\s+/).length <= 3 && baseName.length < COMMON_PHRASE_LENGTH;
+
+  // Check if content contains artist name (word ≥ MIN_ARTIST_NAME_LENGTH that's not a keyword)
+  const keywordPattern = type === "remix"
+    ? /remix|rmx|rework|refix|remode|edition/i
+    : type === "version"
+    ? /mono|stereo|quadraphonic|remaster(?:ed)?/i
+    : /feat\.?|ft\.?|featuring/i;
+  const hasArtistName = contentLower.split(/\s+/).some(
+    word => word.length >= MIN_ARTIST_NAME_LENGTH && !keywordPattern.test(word)
+  );
+  
+  return isGenericWord || (isShort && isCommonPhrase) || hasArtistName;
+}
+
+/**
+ * Check if parenthetical content is likely "guff" that should be removed
+ */
+function isLikelyGuff(content: string): boolean {
+  const contentLower = content.toLowerCase();
+  const words = contentLower.split(/\s+/);
+
+  // Count guff words (strip trailing punctuation for matching: "prod." -> "prod")
+  const guffWordSet = new Set<string>(GUFF_WORDS);
+  const guffWordCount = words.filter((word) => {
+    const stripped = word.replace(/[.,!?;:]+$/, ""); // Strip trailing punctuation
+    return guffWordSet.has(word) || guffWordSet.has(stripped);
+  }).length;
+
+  // Check for years (19XX or 20XX)
+  const hasYear = /(19|20)\d{2}/.test(contentLower);
+
+  // Consider it guff if >50% are guff words, or if it contains years, or if it's short and common
+  return (
+    guffWordCount > words.length / 2 ||
+    hasYear ||
+    (words.length <= 2 &&
+      GUFF_WORDS.some((guff) => contentLower.includes(guff)))
+  );
+}
+
+/**
+ * Clean artist name by removing common variations and guff
+ */
+export function cleanArtistName(name: string): string {
+  let cleaned = name.trim();
+
+  // Remove common featuring patterns
+  const featPatterns = [
+    /\s+feat\.?\s+/i,
+    /\s+ft\.?\s+/i,
+    /\s+featuring\s+/i,
+  ];
+  for (const pattern of featPatterns) {
+    const match = cleaned.match(pattern);
+    if (match && match.index !== undefined) {
+      cleaned = cleaned.substring(0, match.index).trim();
+    }
+  }
+
+  // Remove parenthetical content if it looks like guff
+  // Match backend behavior: only remove first occurrence to handle nested parentheses correctly
+  if (cleaned.includes("(") && cleaned.includes(")")) {
+    const start = cleaned.indexOf("(");
+    // Find matching closing paren (handle nested)
+    let depth = 1;
+    let end = start + 1;
+    while (end < cleaned.length && depth > 0) {
+      if (cleaned[end] === "(") depth++;
+      else if (cleaned[end] === ")") depth--;
+      end++;
+    }
+    if (depth === 0) {
+      end--; // Adjust for final increment
+      const parenContent = cleaned.substring(start + 1, end).toLowerCase();
+      if (isLikelyGuff(parenContent)) {
+        cleaned = (cleaned.substring(0, start) + cleaned.substring(end + 1)).trim();
+        // Normalize whitespace after removal (fixes double spaces)
+        cleaned = cleaned.replace(/\s+/g, " ").trim();
+      }
+    }
+  }
+
+  // Remove brackets with guff
+  // Match backend behavior: only remove first occurrence
+  if (cleaned.includes("[") && cleaned.includes("]")) {
+    const start = cleaned.indexOf("[");
+    // Find matching closing bracket (handle nested)
+    let depth = 1;
+    let end = start + 1;
+    while (end < cleaned.length && depth > 0) {
+      if (cleaned[end] === "[") depth++;
+      else if (cleaned[end] === "]") depth--;
+      end++;
+    }
+    if (depth === 0) {
+      end--; // Adjust for final increment
+      const bracketContent = cleaned.substring(start + 1, end).toLowerCase();
+      if (isLikelyGuff(bracketContent)) {
+        cleaned = (cleaned.substring(0, start) + cleaned.substring(end + 1)).trim();
+        // Normalize whitespace after removal
+        cleaned = cleaned.replace(/\s+/g, " ").trim();
+      }
+    }
+  }
+
+  // Don't strip "The " prefix -- MusicBrainz indexes artists with "The"
+  // (e.g., "The Beatles", "The Rolling Stones") and stripping causes exact
+  // search misses that force unnecessary fuzzy/fallback stages.
+
+  return cleaned.trim();
+}
+
+/**
+ * Clean track name by removing common variations and guff
+ * 
+ * Smarter remix handling -- don't remove "remix" if it's the only distinguishing feature.
+ * (e.g., "High You Are (Branchez Remix)" - "Branchez Remix" distinguishes this from other versions)
+ */
+export function cleanTrackName(name: string): string {
+  let cleaned = name.trim();
+
+  // Strip leading/trailing decorative characters (* ~ · • ★ etc.)
+  const stripped = cleaned.replace(/^[\s*~·•★☆♪♫|_>]+/, "").replace(/[\s*~·•★☆♪♫|_<]+$/, "").trim();
+  if (stripped.length > 0) cleaned = stripped;
+
+  // Remove parenthetical content if it looks like guff.
+  // Process all top-level parenthetical groups right-to-left so removals don't shift
+  // earlier indices. Handles "Song (Remix) (Live Version)" removing "(Live Version)".
+  {
+    // Collect all top-level paren groups
+    const groups: Array<{ start: number; end: number; content: string }> = [];
+    let i = 0;
+    while (i < cleaned.length) {
+      if (cleaned[i] === "(") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < cleaned.length && depth > 0) {
+          if (cleaned[j] === "(") depth++;
+          else if (cleaned[j] === ")") depth--;
+          j++;
+        }
+        if (depth === 0) {
+          groups.push({ start: i, end: j - 1, content: cleaned.substring(i + 1, j - 1) });
+          i = j;
+        } else {
+          break;
+        }
+      } else {
+        i++;
+      }
+    }
+
+    // Process right-to-left
+    for (let g = groups.length - 1; g >= 0; g--) {
+      const { start, end, content } = groups[g];
+      const baseName = cleaned.substring(0, start).trim();
+      const shouldKeepRemix = shouldKeepForDisambiguation(content, baseName, "remix");
+      const shouldKeepFeat = shouldKeepForDisambiguation(content, baseName, "feat");
+      const shouldKeepVersion = shouldKeepForDisambiguation(content, baseName, "version");
+      const shouldKeep = shouldKeepRemix || shouldKeepFeat || shouldKeepVersion;
+      const wouldLeaveEmpty = baseName.length === 0 && cleaned.substring(end + 1).trim().length === 0;
+      if (isLikelyGuff(content.toLowerCase()) && !shouldKeep && !wouldLeaveEmpty) {
+        cleaned = (cleaned.substring(0, start) + cleaned.substring(end + 1)).trim();
+        cleaned = cleaned.replace(/\s+/g, " ").trim();
+      }
+    }
+  }
+
+  // Remove brackets with guff (same right-to-left logic as parentheses)
+  {
+    const groups: Array<{ start: number; end: number; content: string }> = [];
+    let bi = 0;
+    while (bi < cleaned.length) {
+      if (cleaned[bi] === "[") {
+        let depth = 1;
+        let bj = bi + 1;
+        while (bj < cleaned.length && depth > 0) {
+          if (cleaned[bj] === "[") depth++;
+          else if (cleaned[bj] === "]") depth--;
+          bj++;
+        }
+        if (depth === 0) {
+          groups.push({ start: bi, end: bj - 1, content: cleaned.substring(bi + 1, bj - 1) });
+          bi = bj;
+        } else {
+          break;
+        }
+      } else {
+        bi++;
+      }
+    }
+
+    for (let g = groups.length - 1; g >= 0; g--) {
+      const { start, end, content } = groups[g];
+      const baseName = cleaned.substring(0, start).trim();
+      const shouldKeepRemix = shouldKeepForDisambiguation(content, baseName, "remix");
+      const shouldKeepFeat = shouldKeepForDisambiguation(content, baseName, "feat");
+      const shouldKeepVersion = shouldKeepForDisambiguation(content, baseName, "version");
+      const shouldKeep = shouldKeepRemix || shouldKeepFeat || shouldKeepVersion;
+      const wouldLeaveEmpty = baseName.length === 0 && cleaned.substring(end + 1).trim().length === 0;
+      if (isLikelyGuff(content.toLowerCase()) && !shouldKeep && !wouldLeaveEmpty) {
+        cleaned = (cleaned.substring(0, start) + cleaned.substring(end + 1)).trim();
+        cleaned = cleaned.replace(/\s+/g, " ").trim();
+      }
+    }
+  }
+
+  // Remove dash-separated suffixes that look like guff or remix info.
+  // Common in Last.fm/scrobbler data: "Song - Single Version", "Song - Artist Remix"
+  // Must run BEFORE feat removal so "Song - feat. Artist" also gets handled.
+  const dashIndex = cleaned.indexOf(" - ");
+  if (dashIndex > 0) {
+    const baseName = cleaned.substring(0, dashIndex).trim();
+    const suffix = cleaned.substring(dashIndex + 3).trim();
+
+    if (baseName.length > 0 && suffix.length > 0) {
+      // Treat the suffix like parenthetical content: strip if guff and not needed for disambiguation
+      const shouldKeepRemix = shouldKeepForDisambiguation(suffix, baseName, "remix");
+      const shouldKeepFeat = shouldKeepForDisambiguation(suffix, baseName, "feat");
+      const shouldKeepVersion = shouldKeepForDisambiguation(suffix, baseName, "version");
+      const shouldKeep = shouldKeepRemix || shouldKeepFeat || shouldKeepVersion;
+
+      if (isLikelyGuff(suffix.toLowerCase()) && !shouldKeep) {
+        cleaned = baseName;
+      } else if (/\b(?:remix|rmx|rework|re-edit|reedit|mix)\b/i.test(suffix)) {
+        // Convert dash-separated remix/mix to parenthesized format.
+        // Last.fm uses "Track - Artist Remix" but MusicBrainz often uses "Track (Artist Remix)"
+        cleaned = `${baseName} (${suffix})`;
+      }
+    }
+  }
+
+  // Remove featuring artists from track titles
+  const featPatterns = [
+    /\s+feat\.?\s+/i,
+    /\s+ft\.?\s+/i,
+    /\s+featuring\s+/i,
+  ];
+
+  for (const pattern of featPatterns) {
+    const match = cleaned.match(pattern);
+    if (match && match.index !== undefined) {
+      const baseName = cleaned.substring(0, match.index).trim();
+      const featContent = cleaned.substring(match.index + match[0].length).trim();
+
+      // Only remove if not needed for disambiguation
+      const shouldKeep = shouldKeepForDisambiguation(featContent, baseName, "feat");
+      if (!shouldKeep) {
+        cleaned = baseName;
+      }
+      break;
+    }
+  }
+
+  return cleaned.trim();
+}
+
+/**
+ * Clean release/album name by removing common variations and guff
+ * 
+ * NOTE: Currently delegates to cleanTrackName. This is intentional because:
+ * - Albums often have similar "guff" patterns (remastered, deluxe, etc.)
+ * - The shouldKeepForDisambiguation logic works for both contexts
+ * - If album-specific cleaning is needed later, add it here
+ */
+export function cleanReleaseName(name: string): string {
+  return cleanTrackName(name);
+}
+
+/**
+ * Normalize text for comparison (remove special chars, lowercase, etc.)
+ * Enhanced with Unicode normalization for accent-insensitive matching.
+ *
+ * For Latin text: strips diacriticals, keeps [a-zA-Z0-9\s].
+ * For non-Latin text (CJK, Cyrillic, etc.): keeps all Unicode
+ * alphanumeric characters so that different non-Latin strings
+ * remain distinguishable.
+ */
+export function normalizeForComparison(text: string): string {
+  if (typeof text !== "string") {
+    return "";
+  }
+
+  // Step 1: NFD decomposition to separate base characters from accents
+  let normalized = text.normalize("NFD");
+
+  // Step 2: Remove combining diacritical marks (accents)
+  normalized = normalized.replace(/[\u0300-\u036f]/g, "");
+
+  // Step 3: Keep all Unicode alphanumeric characters and whitespace.
+  // This preserves CJK, Cyrillic, Arabic, etc. while still stripping
+  // punctuation and symbols.
+  const filtered = Array.from(normalized)
+    .filter((c) => isUnicodeAlphanumeric(c) || /\s/.test(c))
+    .join("");
+
+  // Step 4: Re-compose (NFC) so that decomposed Hangul jamo and other
+  // scripts round-trip correctly.
+  return filtered
+    .normalize("NFC")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Check if a character is alphanumeric in any script.
+ * Uses Unicode category awareness: letters (L*) and numbers (N*).
+ */
+function isUnicodeAlphanumeric(c: string): boolean {
+  // Fast path for ASCII
+  if (/[a-zA-Z0-9]/.test(c)) return true;
+  // Unicode letter or number (covers CJK, Cyrillic, Arabic, etc.)
+  // \p{L} = any Unicode letter, \p{N} = any Unicode number
+  return /[\p{L}\p{N}]/u.test(c);
+}

--- a/apps/amethyst/lib/musicbrainzRanking.ts
+++ b/apps/amethyst/lib/musicbrainzRanking.ts
@@ -1,0 +1,345 @@
+/**
+ * Client-side result ranking for MusicBrainz search results
+ *
+ * Scoring model: multiplicative boosts on a strategy base score.
+ * Uses MB's own relevance score (0-100) as a prior, then applies
+ * text-matching boosts for track, artist, and release fields.
+ *
+ * Constants tuned against 44k+ Last.fm scrobbles with ground-truth MBIDs;
+ * see scripts/eval/ for the evaluation harness and methodology.
+ */
+
+import type { MusicBrainzRecording } from "./oldStamp";
+import { normalizeForComparison } from "./musicbrainzCleaner";
+import { fuzzyScore } from "./fuzzyMatching";
+import type { SearchStrategy } from "./musicbrainzSearchUtils";
+
+// =============================================================================
+// SCORING CONSTANTS (14 tunable values)
+//
+// Multiplicative boosts applied to a base score of 1.0.
+// Tuned against Last.fm scrobble corpus (scripts/eval/).
+// =============================================================================
+
+// Strategy base: exact results are strongly preferred over fuzzy/partial.
+// Wide gap ensures fuzzy-stage P@1 rarely outscores exact-stage P@1.
+const STRATEGY_SCORE = { exact: 3.0, fuzzy: 0.6, partial: 0.4 } as const;
+
+// MB API priors
+const MB_SCORE_WEIGHT = 0.2;   // blend weight for MB's Lucene score (0 = ignore, 1 = trust fully)
+const POSITION_DECAY = 0.015;  // per-position penalty (pos 10 → 0.85x, floored at 0.6x)
+
+// Text match boosts (applied when normalized query text matches result text)
+const MATCH_EXACT = 2.2;       // exact string match
+const MATCH_PARTIAL = 1.3;     // startsWith or contains
+const MATCH_BOTH_FIELDS = 1.5; // bonus when BOTH track and artist match
+
+// Release signals
+const RELEASE_MATCH = 1.3;     // release title matches query
+const RELEASE_OFFICIAL = 1.08; // official release status (mild -- most recordings are official)
+const RELEASE_BOOTLEG = 0.92;  // bootleg / pseudo-release penalty
+
+// Variant/disambiguation handling
+const VARIANT_MATCH = 1.3;     // query mentions variant keyword and result has it
+const VARIANT_PENALTY = 0.92;  // result has variant info the query didn't ask for
+
+// Classical catalog number handling
+const CATALOG_MATCH = 1.8;     // catalog number (BWV, Op., K., etc.) matches
+const CATALOG_MISMATCH = 0.5;  // same catalog system but wrong number
+
+// Classical catalog number patterns: BWV 846, Op. 27, K. 331, HWV 56, etc.
+const CATALOG_PATTERN = /\b(BWV|Op\.?|K\.?|HWV|RV|D\.?|S\.?|Hob\.?|TrV|WAB|WoO)\s*(\d+)\b/i;
+
+/**
+ * Extract catalog identifier from a track title (e.g., "BWV 846" from
+ * "Prelude and Fugue No. 1 in C Major, BWV 846").
+ * Returns { system, number } or null.
+ */
+function extractCatalogNumber(text: string): { system: string; number: number } | null {
+  const match = text.match(CATALOG_PATTERN);
+  if (!match) return null;
+  return {
+    system: match[1].replace(/\.$/, "").toUpperCase(),
+    number: parseInt(match[2], 10),
+  };
+}
+
+// Variant keywords for matching query variants against result metadata
+const VARIANT_KEYWORDS = [
+  "live", "acoustic", "remix", "remaster", "remastered",
+  "mono", "stereo", "edit", "single", "version",
+  "extended", "demo", "dub", "instrumental", "orchestral",
+] as const;
+
+export interface RankingQuery {
+  track?: string;
+  artist?: string;
+  release?: string;
+  cleanedTrack?: string;
+  cleanedArtist?: string;
+  cleanedRelease?: string;
+}
+
+export type { SearchStrategy } from "./musicbrainzSearchUtils";
+
+// =============================================================================
+// FEATURING-ARTIST EXTRACTION
+// =============================================================================
+
+const FEAT_PATTERNS = [/\s+feat\.?\s+/i, /\s+ft\.?\s+/i, /\s+featuring\s+/i];
+
+/**
+ * Extract the featured artist name from a string.
+ * Checks parenthesized, bracketed, and inline "feat." patterns.
+ * Returns first 1-3 meaningful words (length > 2), or null.
+ */
+function extractFeaturedArtist(text: string): string | null {
+  const lower = text.toLowerCase();
+
+  for (const parenMatch of text.matchAll(/\(([^)]+)\)/g)) {
+    const found = extractFeatFromContent(parenMatch[1].toLowerCase());
+    if (found) return found;
+  }
+
+  for (const bracketMatch of text.matchAll(/\[([^\]]+)\]/g)) {
+    const found = extractFeatFromContent(bracketMatch[1].toLowerCase());
+    if (found) return found;
+  }
+
+  for (const pattern of FEAT_PATTERNS) {
+    const match = lower.match(pattern);
+    if (match && match.index !== undefined) {
+      const content = lower.substring(match.index + match[0].length).trim();
+      const words = content.split(/\s+/).filter((w) => w.length > 2);
+      if (words.length > 0) return words.slice(0, 3).join(" ");
+    }
+  }
+
+  return null;
+}
+
+function extractFeatFromContent(content: string): string | null {
+  for (const pattern of FEAT_PATTERNS) {
+    const match = content.match(pattern);
+    if (match && match.index !== undefined) {
+      const after = content.substring(match.index + match[0].length).trim();
+      const words = after.split(/\s+/).filter((w) => w.length > 2);
+      if (words.length > 0) return words.slice(0, 3).join(" ");
+    }
+  }
+  return null;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/** Compare two normalized strings: "exact", "partial" (startsWith/contains), or "none". */
+function matchLevel(query: string, result: string): "exact" | "partial" | "none" {
+  if (result === query) return "exact";
+  if (result.includes(query)) return "partial";
+  return "none";
+}
+
+/** Best match level across an array of candidates. */
+function bestMatch(query: string, candidates: string[]): "exact" | "partial" | "none" {
+  let best: "exact" | "partial" | "none" = "none";
+  for (const c of candidates) {
+    const level = matchLevel(query, c);
+    if (level === "exact") return "exact";
+    if (level === "partial") best = "partial";
+  }
+  return best;
+}
+
+// =============================================================================
+// SCORING
+// =============================================================================
+
+export function scoreResult(
+  result: MusicBrainzRecording,
+  query: RankingQuery,
+  searchStrategy: SearchStrategy,
+  /** 0-based position in MB's result list */
+  resultPosition?: number,
+): number {
+  let score = 1.0;
+
+  const resultTitle = result.title || "";
+  const credits = result["artist-credit"] ?? [];
+  const resultArtist = credits.length > 0
+    ? credits.map((c) => c.name).join(credits[0]?.joinphrase ?? " ")
+    : "";
+  const resultReleases = result.releases ?? [];
+
+  // --- MB API score prior ---
+  if (result.score != null && result.score > 0) {
+    const mbNorm = result.score / 100;
+    score *= (1 - MB_SCORE_WEIGHT) + MB_SCORE_WEIGHT * mbNorm;
+  }
+
+  // --- Position prior ---
+  if (resultPosition != null && resultPosition > 0) {
+    score *= Math.max(0.6, 1.0 - POSITION_DECAY * resultPosition);
+  }
+
+  // --- Strategy base ---
+  score *= STRATEGY_SCORE[searchStrategy] ?? STRATEGY_SCORE.partial;
+  if (searchStrategy === "fuzzy") {
+    if (query.track || query.cleanedTrack) {
+      score *= 0.5 + fuzzyScore(query.cleanedTrack || query.track!, resultTitle) * 0.5;
+    }
+    if (query.artist || query.cleanedArtist) {
+      score *= 0.5 + fuzzyScore(query.cleanedArtist || query.artist!, resultArtist) * 0.5;
+    }
+  }
+
+  // --- Normalized forms ---
+  const resultTitleNorm = normalizeForComparison(resultTitle);
+  const resultArtistNorm = normalizeForComparison(resultArtist);
+  const individualCreditNorms = credits.map((c) => normalizeForComparison(c.name));
+
+  // --- Track matching ---
+  const queryTrackNorm = normalizeForComparison(query.cleanedTrack || query.track || "");
+  let trackMatched = false;
+  if (queryTrackNorm) {
+    const level = matchLevel(queryTrackNorm, resultTitleNorm);
+    if (level === "exact") { score *= MATCH_EXACT; trackMatched = true; }
+    else if (level === "partial") { score *= MATCH_PARTIAL; trackMatched = true; }
+  }
+
+  // --- Artist matching (check full credit string + individual credits) ---
+  const queryArtistNorm = normalizeForComparison(query.cleanedArtist || query.artist || "");
+  let artistMatched = false;
+  if (queryArtistNorm) {
+    const level = bestMatch(queryArtistNorm, [resultArtistNorm, ...individualCreditNorms]);
+    if (level === "exact") { score *= MATCH_EXACT; artistMatched = true; }
+    else if (level === "partial") { score *= MATCH_PARTIAL; artistMatched = true; }
+  }
+
+  // --- Both fields match bonus ---
+  if (trackMatched && artistMatched) {
+    score *= MATCH_BOTH_FIELDS;
+  }
+
+  // --- Release matching (scan ALL releases, not just the first) ---
+  // MusicBrainz recordings appear on multiple releases (original, compilation, reissue).
+  // The query album might match a non-first release.
+  const queryReleaseNorm = normalizeForComparison(query.cleanedRelease || query.release || "");
+  if (queryReleaseNorm && resultReleases.length > 0) {
+    const releaseMatch = resultReleases.some((rel) => {
+      if (!rel.title) return false;
+      const relNorm = normalizeForComparison(rel.title);
+      // Bidirectional: "Street Songs" matches "Street Songs (Deluxe Edition)" and vice versa
+      return relNorm.includes(queryReleaseNorm) || queryReleaseNorm.includes(relNorm);
+    });
+    if (releaseMatch) {
+      score *= RELEASE_MATCH;
+    }
+  }
+
+  // --- Featuring artist bonus ---
+  const queryFeat = extractFeaturedArtist(query.track || query.cleanedTrack || "");
+  if (queryFeat) {
+    const resultFeat = extractFeaturedArtist(resultTitle);
+    if (resultFeat) {
+      const qNorm = normalizeForComparison(queryFeat);
+      const rNorm = normalizeForComparison(resultFeat);
+      if (rNorm.includes(qNorm) || qNorm.includes(rNorm)) {
+        score *= MATCH_PARTIAL;
+      }
+    }
+  }
+
+  // --- Classical catalog number matching ---
+  const queryTrackRaw = query.track || query.cleanedTrack || "";
+  const queryCatalog = extractCatalogNumber(queryTrackRaw);
+  if (queryCatalog) {
+    const resultCatalog = extractCatalogNumber(resultTitle);
+    if (resultCatalog && resultCatalog.system === queryCatalog.system) {
+      score *= resultCatalog.number === queryCatalog.number
+        ? CATALOG_MATCH
+        : CATALOG_MISMATCH;
+    }
+  }
+
+  // --- Variant version matching ---
+  const queryForVariants = (query.track || query.cleanedTrack || "").toLowerCase();
+  const resultTitleLower = resultTitle.toLowerCase();
+  const disambLower = (result.disambiguation && typeof result.disambiguation === "string")
+    ? result.disambiguation.toLowerCase().trim()
+    : "";
+  const resultVariantText = `${resultTitleLower} ${disambLower}`;
+
+  const queryVariants = VARIANT_KEYWORDS.filter((kw) => queryForVariants.includes(kw));
+
+  if (queryVariants.length > 0) {
+    const resultHasVariant = queryVariants.some((kw) => resultVariantText.includes(kw));
+    score *= resultHasVariant ? VARIANT_MATCH : VARIANT_PENALTY;
+  } else if (disambLower.length > 0) {
+    const resultHasVariant = VARIANT_KEYWORDS.some((kw) => disambLower.includes(kw));
+    if (resultHasVariant) score *= VARIANT_PENALTY;
+  }
+
+  // --- Release quality signals ---
+  const firstRelease = result.releases?.[0];
+  const releaseStatus = firstRelease?.status?.toLowerCase();
+  if (releaseStatus === "official") {
+    score *= RELEASE_OFFICIAL;
+  } else if (releaseStatus === "bootleg" || releaseStatus === "pseudo-release") {
+    score *= RELEASE_BOOTLEG;
+  }
+
+  return score;
+}
+
+/**
+ * Rank and sort search results by relevance
+ */
+export function rankResults(
+  results: MusicBrainzRecording[],
+  query: RankingQuery,
+  searchStrategy: SearchStrategy,
+): MusicBrainzRecording[] {
+  const ranked = results.map((result, idx) => ({
+    result,
+    score: scoreResult(result, query, searchStrategy, idx),
+  }));
+
+  ranked.sort((a, b) => {
+    if (Math.abs(a.score - b.score) > 0.01) return b.score - a.score;
+    return 0;
+  });
+
+  return ranked.map((r) => r.result);
+}
+
+/**
+ * Rank results from multiple search stages, deduplicating by ID.
+ * Keeps the highest-scored entry for each recording ID.
+ */
+export function rankMultiStageResults(
+  stageResults: Array<{
+    results: MusicBrainzRecording[];
+    strategy: SearchStrategy;
+  }>,
+  query: RankingQuery,
+): MusicBrainzRecording[] {
+  const bestByID = new Map<string, { result: MusicBrainzRecording; score: number }>();
+
+  for (const { results, strategy } of stageResults) {
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (!result.id) continue;
+      const score = scoreResult(result, query, strategy, i);
+      const existing = bestByID.get(result.id);
+      if (!existing || score > existing.score) {
+        bestByID.set(result.id, { result, score });
+      }
+    }
+  }
+
+  const allRanked = Array.from(bestByID.values());
+  allRanked.sort((a, b) => b.score - a.score);
+  return allRanked.map((r) => r.result);
+}

--- a/apps/amethyst/lib/musicbrainzSearchUtils.ts
+++ b/apps/amethyst/lib/musicbrainzSearchUtils.ts
@@ -1,0 +1,326 @@
+/**
+ * Shared utilities for MusicBrainz search
+ * Used by both frontend (oldStamp.tsx) and evaluation scripts
+ */
+
+import type { MusicBrainzRecording } from "./oldStamp";
+
+export type SearchStrategy = "exact" | "fuzzy" | "partial";
+
+/**
+ * Detect if a string contains CJK (Chinese/Japanese/Korean) characters.
+ * Covers CJK Unified Ideographs, Hiragana, Katakana, Hangul, and extensions.
+ */
+export function hasCJK(text: string): boolean {
+  return /[\u3000-\u9fff\uac00-\ud7af\uf900-\ufaff]/.test(text);
+}
+
+/**
+ * PARTIAL_THRESHOLD: minimum cumulative result count before skipping later stages.
+ * Set to 5 to match typical UI display (top 5 results visible).
+ * Can be overridden via process.env.PARTIAL_THRESHOLD for eval tuning.
+ */
+export const PARTIAL_THRESHOLD = (() => {
+  if (typeof process !== "undefined" && process.env?.PARTIAL_THRESHOLD) {
+    const parsed = parseInt(process.env.PARTIAL_THRESHOLD, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
+  }
+  return 5;
+})();
+
+export const PROXIMITY_DISTANCE = 3; // Words within 3 positions for proximity search
+export const MAX_RETRIES = 3; // Maximum retry attempts for rate limiting
+export const INITIAL_RETRY_DELAY = 1000; // Initial delay in milliseconds
+
+/**
+ * Escape Lucene special characters in search terms
+ * Special chars: + - && || ! ( ) { } [ ] ^ " ~ * ? : \
+ * 
+ * Don't escape apostrophes (') and dashes (-) when inside quoted phrases.
+ * MusicBrainz often stores names with apostrophes/dashes (e.g., "Dancin' Music", "V-Rally"),
+ * and escaping them prevents matches. Inside quoted phrases, these are safe.
+ * 
+ * However, we still escape them for safety in unquoted contexts (partial search).
+ */
+export function escapeLucene(text: string): string {
+  // Escape backslash first (must be first)
+  let escaped = text.replace(/\\/g, "\\\\");
+  
+  // Escape Lucene operators (these are always problematic)
+  escaped = escaped
+    .replace(/\+/g, "\\+")
+    .replace(/&&/g, "\\&&")
+    .replace(/\|\|/g, "\\||")
+    .replace(/!/g, "\\!")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/{/g, "\\{")
+    .replace(/}/g, "\\}")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\^/g, "\\^")
+    .replace(/"/g, '\\"')
+    .replace(/~/g, "\\~")
+    .replace(/\*/g, "\\*")
+    .replace(/\?/g, "\\?")
+    .replace(/:/g, "\\:");
+  
+  // NOTE: We intentionally DON'T escape dashes (-) and apostrophes (')
+  // when used in quoted phrases, as MusicBrainz often stores names with these characters.
+  // For example: "Dancin' Music", "V-Rally", "Howl's Moving Castle"
+  // Inside quoted phrases, these are safe and needed for matching.
+  // 
+  // If we need to escape them for unquoted contexts (partial search), we can add
+  // a parameter to this function to control escaping behavior.
+  
+  return escaped;
+}
+
+/**
+ * Build a single query part for a field (title, artist, release)
+ * 
+ * Strategies:
+ * - exact: Quoted phrase (handles spaces, special chars)
+ * - fuzzy: Proximity for multi-word, fuzzy operator for single word
+ * - partial: Unquoted (allows substring matching, escapes operators)
+ */
+export function buildQueryPart(
+  field: "title" | "artist" | "release",
+  value: string,
+  strategy: SearchStrategy,
+): string {
+  if (strategy === "exact") {
+    let escaped = value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"');
+    return `${field}:"${escaped}"`;
+  } else if (strategy === "fuzzy") {
+    const escaped = escapeLucene(value);
+    const words = value.split(/\s+/);
+    if (words.length > 1) {
+      return `${field}:"${escaped}"~${PROXIMITY_DISTANCE}`;
+    } else {
+      // Escape dashes for single-word fuzzy to prevent Lucene NOT operator
+      // (e.g., "Jay-Z~" would be parsed as "Jay NOT Z~")
+      let singleEscaped = escaped.replace(/-/g, "\\-");
+      return `${field}:${singleEscaped}~`;
+    }
+  } else {
+    // Partial: unquoted terms -- also escape dashes to avoid Lucene NOT operator
+    // (e.g., "Jay-Z" would otherwise be parsed as "Jay NOT Z")
+    let escaped = escapeLucene(value);
+    escaped = escaped.replace(/-/g, "\\-");
+    return `${field}:${escaped}`;
+  }
+}
+
+// Rate limiting: MusicBrainz requires max 1 request/second.
+// Override with MB_RATE_LIMIT_MS=0 when using a rotating proxy (e.g., eval harness).
+const MB_RATE_LIMIT_MS = (() => {
+  if (typeof process !== "undefined" && process.env?.MB_RATE_LIMIT_MS != null) {
+    const v = parseInt(process.env.MB_RATE_LIMIT_MS, 10);
+    return Number.isFinite(v) && v >= 0 ? v : 1100;
+  }
+  return 1100;
+})();
+let lastAPICallTime = 0;
+
+// In-memory cache for MusicBrainz search results.
+// Avoids redundant API calls within a session (rate-limited to 1 req/sec).
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_MAX_ENTRIES = 200;
+
+interface CacheEntry {
+  results: MusicBrainzRecording[];
+  timestamp: number;
+}
+
+const searchCache = new Map<string, CacheEntry>();
+const aliasCache = new Map<string, { value: string | null; timestamp: number }>();
+
+function getCached(key: string): MusicBrainzRecording[] | undefined {
+  const entry = searchCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    searchCache.delete(key);
+    return undefined;
+  }
+  return entry.results;
+}
+
+function setCache(key: string, results: MusicBrainzRecording[]): void {
+  // Evict oldest entries when at capacity
+  if (searchCache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = searchCache.keys().next().value;
+    if (oldest !== undefined) searchCache.delete(oldest);
+  }
+  searchCache.set(key, { results, timestamp: Date.now() });
+}
+
+/**
+ * Single search stage with specified matching strategy.
+ * Caches results in-memory to avoid redundant API calls (MB rate limit: 1 req/sec).
+ */
+export async function searchStage(
+  track: string | undefined,
+  artist: string | undefined,
+  release: string | undefined,
+  strategy: SearchStrategy,
+  options?: {
+    limit?: number;
+    userAgent?: string;
+    baseUrl?: string;
+  },
+): Promise<MusicBrainzRecording[]> {
+  const limit = options?.limit ?? 25;
+  const userAgent = options?.userAgent ?? "tealtracker/0.0.1 (https://github.com/teal-fm/teal)";
+  const baseUrl = options?.baseUrl ?? "https://musicbrainz.org/ws/2";
+
+  const queryParts: string[] = [];
+
+  if (track) {
+    queryParts.push(buildQueryPart("title", track, strategy));
+  }
+
+  if (artist) {
+    queryParts.push(buildQueryPart("artist", artist, strategy));
+  }
+
+  if (release) {
+    queryParts.push(buildQueryPart("release", release, strategy));
+  }
+
+  if (queryParts.length === 0) {
+    return [];
+  }
+
+  const query = queryParts.join(" AND ");
+
+  // Check cache first
+  const cacheKey = `${query}|${limit}`;
+  const cached = getCached(cacheKey);
+  if (cached) return cached;
+
+  // Enforce MusicBrainz rate limit (1 request/second) between API calls.
+  // Placed after cache check so cache hits are instant.
+  const now = Date.now();
+  const elapsed = now - lastAPICallTime;
+  if (elapsed < MB_RATE_LIMIT_MS && lastAPICallTime > 0) {
+    await new Promise((resolve) => setTimeout(resolve, MB_RATE_LIMIT_MS - elapsed));
+  }
+  lastAPICallTime = Date.now();
+
+  // Retry with exponential backoff for rate limiting
+  let retries = MAX_RETRIES;
+  let delay = INITIAL_RETRY_DELAY;
+
+  while (retries > 0) {
+    try {
+      const res = await fetch(
+        `${baseUrl}/recording?query=${encodeURIComponent(query)}&fmt=json&limit=${limit}`,
+        {
+          headers: {
+            "User-Agent": userAgent,
+          },
+        },
+      );
+
+      // Handle rate limiting (503)
+      if (res.status === 503) {
+        retries--;
+        if (retries > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          delay *= 2; // Exponential backoff
+          continue;
+        }
+        return [];
+      }
+
+      if (!res.ok) {
+        return [];
+      }
+
+      const data = await res.json();
+      const results: MusicBrainzRecording[] = data.recordings || [];
+      setCache(cacheKey, results);
+      return results;
+    } catch (error) {
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+      } else {
+        if (error instanceof Error) {
+          console.error(`Search stage ${strategy} failed:`, error.message);
+        }
+        return [];
+      }
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Look up an artist's canonical (romanized) name by alias search.
+ *
+ * MusicBrainz indexes artist aliases separately from credit names.
+ * When the input is CJK (e.g., "久石譲"), the primary artist name in MB
+ * is often romanized (e.g., "Joe Hisaishi"), so a recording search for
+ * artist:"久石譲" fails. This does an artist search on the alias field,
+ * then returns the canonical name for use in a recording search.
+ *
+ * Returns the best-matching artist name, or null if no match.
+ */
+export async function resolveArtistAlias(
+  artistName: string,
+  options?: {
+    userAgent?: string;
+    baseUrl?: string;
+  },
+): Promise<string | null> {
+  const userAgent = options?.userAgent ?? "tealtracker/0.0.1 (https://github.com/teal-fm/teal)";
+  const baseUrl = options?.baseUrl ?? "https://musicbrainz.org/ws/2";
+
+  // Search artist by alias
+  const escaped = artistName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const query = `alias:"${escaped}"`;
+
+  const cacheKey = `artist-alias|${query}`;
+  const cachedAlias = aliasCache.get(cacheKey);
+  if (cachedAlias && Date.now() - cachedAlias.timestamp <= CACHE_TTL_MS) {
+    return cachedAlias.value;
+  }
+
+  // Rate limit
+  const now = Date.now();
+  const elapsed = now - lastAPICallTime;
+  if (elapsed < MB_RATE_LIMIT_MS && lastAPICallTime > 0) {
+    await new Promise((resolve) => setTimeout(resolve, MB_RATE_LIMIT_MS - elapsed));
+  }
+  lastAPICallTime = Date.now();
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/artist?query=${encodeURIComponent(query)}&fmt=json&limit=3`,
+      { headers: { "User-Agent": userAgent } },
+    );
+
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const artists = data.artists || [];
+
+    if (artists.length === 0) {
+      aliasCache.set(cacheKey, { value: null, timestamp: Date.now() });
+      return null;
+    }
+
+    // Return the canonical name of the highest-scoring artist
+    const name: string | null = artists[0].name || null;
+    aliasCache.set(cacheKey, { value: name, timestamp: Date.now() });
+    return name;
+  } catch {
+    return null;
+  }
+}

--- a/apps/amethyst/lib/oldStamp.tsx
+++ b/apps/amethyst/lib/oldStamp.tsx
@@ -1,5 +1,9 @@
 import { Record as PlayRecord } from "@teal/lexicons/src/types/fm/teal/alpha/feed/play";
 
+// Re-export searchMusicbrainz from the orchestrator module.
+// This keeps backward compatibility for existing imports.
+export { searchMusicbrainz } from "./searchOrchestrator";
+
 // MusicBrainz API Types
 export interface MusicBrainzArtistCredit {
   artist: {
@@ -11,6 +15,12 @@ export interface MusicBrainzArtistCredit {
   name: string;
 }
 
+export interface MusicBrainzReleaseGroup {
+  id: string;
+  title?: string;
+  "primary-type"?: string;
+}
+
 export interface MusicBrainzRelease {
   id: string;
   title: string;
@@ -19,16 +29,20 @@ export interface MusicBrainzRelease {
   country?: string;
   disambiguation?: string;
   "track-count"?: number;
+  "release-group"?: MusicBrainzReleaseGroup;
 }
 
 export interface MusicBrainzRecording {
   id: string;
   title: string;
+  score?: number; // MB API relevance score (0-100)
   length?: number;
   isrcs?: string[];
+  disambiguation?: string;
+  "first-release-date"?: string;
   "artist-credit"?: MusicBrainzArtistCredit[];
   releases?: MusicBrainzRelease[];
-  selectedRelease?: MusicBrainzRelease; // Added for UI state
+  selectedRelease?: MusicBrainzRelease;
 }
 
 export interface SearchParams {
@@ -55,44 +69,3 @@ export interface PlaySubmittedData {
   blueskyPostUrl: string | null;
 }
 
-export async function searchMusicbrainz(
-  searchParams: SearchParams,
-): Promise<MusicBrainzRecording[]> {
-  try {
-    const queryParts: string[] = [];
-    if (searchParams.track) {
-      queryParts.push(`title:"${searchParams.track}"`);
-    }
-
-    if (searchParams.artist) {
-      queryParts.push(`artist:"${searchParams.artist}"`);
-    }
-
-    if (searchParams.release) {
-      queryParts.push(`release:"${searchParams.release}"`);
-    }
-
-    const query = queryParts.join(" AND ");
-
-    const res = await fetch(
-      `https://musicbrainz.org/ws/2/recording?query=${encodeURIComponent(
-        query,
-      )}&fmt=json`,
-      {
-        headers: {
-          "User-Agent": "tealtracker/0.0.1",
-        },
-      },
-    );
-
-    if (!res.ok) {
-      throw new Error(`MusicBrainz API returned ${res.status}`);
-    }
-
-    const data = await res.json();
-    return data.recordings || [];
-  } catch (error) {
-    console.error("Failed to fetch MusicBrainz data:", error);
-    return [];
-  }
-}

--- a/apps/amethyst/lib/searchOrchestrator.ts
+++ b/apps/amethyst/lib/searchOrchestrator.ts
@@ -1,0 +1,245 @@
+/**
+ * Multi-stage MusicBrainz search orchestrator
+ *
+ * Pipeline: clean input -> exact search -> (fallback if needed) -> rank
+ * Separated from UI code (oldStamp.tsx) for testability and clarity.
+ *
+ * Expected API calls per lookup:
+ *   Best case (track+artist, exact hit): 1-2 calls (with/without release)
+ *   Cleaning diverged, exact hit:        2-3 calls
+ *   Hard case (fuzzy fallback):           3-4 calls
+ *
+ * Rate limit: MusicBrainz requires max 1 request/second. We enforce this
+ * at the fetch layer (musicbrainzSearchUtils.ts) so cache hits are instant.
+ */
+
+import type { MusicBrainzRecording, SearchParams } from "./oldStamp";
+import {
+  cleanArtistName,
+  cleanTrackName,
+  cleanReleaseName,
+  normalizeForComparison,
+} from "./musicbrainzCleaner";
+import {
+  searchStage,
+  PARTIAL_THRESHOLD,
+  hasCJK,
+  resolveArtistAlias,
+} from "./musicbrainzSearchUtils";
+import {
+  rankMultiStageResults,
+  type RankingQuery,
+} from "./musicbrainzRanking";
+
+/**
+ * Check if exact search results are "good enough" to skip later stages.
+ *
+ * Uses MB's own relevance score as a confidence signal:
+ * - High MB score (>=70) with artist: sufficient
+ * - >= 3 results with artist: sufficient (multiple candidates to rank)
+ * - Track-only: need >= 2 results OR first result must match well
+ */
+function exactResultsSufficient(
+  results: MusicBrainzRecording[],
+  cleanedTrack: string | undefined,
+  hasArtist: boolean,
+): boolean {
+  if (results.length === 0) return false;
+
+  const topScore = results[0]?.score ?? 100;
+
+  if (hasArtist) {
+    return topScore >= 70 || results.length >= 3;
+  }
+
+  // Track-only: need >= 2 results OR first result must match well
+  if (results.length >= 2) return true;
+  const first = results[0];
+  if (first?.title && cleanedTrack) {
+    const norm = normalizeForComparison(first.title);
+    const trackNorm = normalizeForComparison(cleanedTrack);
+    return norm === trackNorm || norm.startsWith(trackNorm + " ");
+  }
+  return false;
+}
+
+/**
+ * Multi-stage MusicBrainz search with improved matching.
+ *
+ * Designed to minimize API calls: most lookups (track+artist, clean data)
+ * early-exit after 1 call. Later stages only fire when results are insufficient.
+ *
+ * Stage 1a: Exact match with release (narrows to specific recording on album)
+ * Stage 1b: Exact match without release (catches album-name mismatches)
+ * Stage 1c: Retry with originals if cleaning changed names and stages got 0
+ * Stage 2: Fuzzy match (typos, Unicode, word reordering) -- only if exact insufficient
+ * Stage 3: Track-only fallback (drops artist) -- only if still sparse
+ */
+export async function searchMusicbrainz(
+  searchParams: SearchParams,
+): Promise<MusicBrainzRecording[]> {
+  if (!searchParams.track && !searchParams.artist && !searchParams.release) {
+    return [];
+  }
+
+  try {
+    const cleanedTrack = searchParams.track
+      ? cleanTrackName(searchParams.track) || undefined
+      : undefined;
+    const cleanedArtist = searchParams.artist
+      ? cleanArtistName(searchParams.artist) || undefined
+      : undefined;
+    const cleanedRelease = searchParams.release
+      ? cleanReleaseName(searchParams.release) || undefined
+      : undefined;
+
+    const cleaningChangedTrack =
+      cleanedTrack !== undefined && cleanedTrack !== searchParams.track;
+    const cleaningChangedArtist =
+      cleanedArtist !== undefined && cleanedArtist !== searchParams.artist;
+
+    // Stage 1a: Exact match WITH release (if available).
+    // When release matches, this narrows to the specific recording on that album,
+    // which is critical for popular tracks with many recordings in MB.
+    let exactWithRelease: MusicBrainzRecording[] = [];
+    if (cleanedRelease) {
+      exactWithRelease = await searchStage(
+        cleanedTrack,
+        cleanedArtist,
+        cleanedRelease,
+        "exact",
+      );
+    }
+
+    // Stage 1b: Exact match WITHOUT release.
+    // Skip if 1a already got sufficient results (saves 1 API call in the common case).
+    // Still run if 1a got 0 results (release name might differ between scrobbler and MB).
+    let exactWithoutRelease: MusicBrainzRecording[] = [];
+    if (!exactResultsSufficient(exactWithRelease, cleanedTrack, !!cleanedArtist)) {
+      exactWithoutRelease = await searchStage(
+        cleanedTrack,
+        cleanedArtist,
+        undefined,
+        "exact",
+      );
+    }
+
+    // Stage 1c: If cleaning changed names and both stages got 0, retry with originals.
+    let originalExactResults: MusicBrainzRecording[] = [];
+    if (exactWithRelease.length === 0 && exactWithoutRelease.length === 0 &&
+        (cleaningChangedTrack || cleaningChangedArtist)) {
+      originalExactResults = await searchStage(
+        searchParams.track,
+        searchParams.artist,
+        undefined,
+        "exact",
+      );
+    }
+
+    // Stage 1d: CJK artist alias resolution.
+    // MB indexes artists by romanized name (e.g., "Joe Hisaishi"), but scrobblers
+    // often submit CJK (e.g., "久石譲"). Resolve via MB artist alias search,
+    // then re-search recordings with the romanized name.
+    let cjkAliasResults: MusicBrainzRecording[] = [];
+    const artistForSearch = cleanedArtist || searchParams.artist;
+    if (
+      exactWithRelease.length === 0 &&
+      exactWithoutRelease.length === 0 &&
+      originalExactResults.length === 0 &&
+      artistForSearch &&
+      hasCJK(artistForSearch)
+    ) {
+      const romanized = await resolveArtistAlias(artistForSearch);
+      if (romanized && romanized !== artistForSearch) {
+        cjkAliasResults = await searchStage(
+          cleanedTrack,
+          romanized,
+          cleanedRelease || undefined,
+          "exact",
+        );
+      }
+    }
+
+    const combinedExact = [
+      ...exactWithRelease,
+      ...exactWithoutRelease,
+      ...originalExactResults,
+      ...cjkAliasResults,
+    ];
+    const hasArtist = !!cleanedArtist;
+
+    // Early exit: good exact results -> skip later stages but still rank.
+    // Ranking applies variant matching, release quality, and text-match boosts
+    // that can improve on MB's default Lucene ordering.
+    if (exactResultsSufficient(combinedExact, cleanedTrack, hasArtist)) {
+      const rankingQuery: RankingQuery = {
+        track: searchParams.track,
+        artist: searchParams.artist,
+        release: searchParams.release,
+        cleanedTrack,
+        cleanedArtist,
+        cleanedRelease,
+      };
+      return rankMultiStageResults(
+        [{ results: combinedExact, strategy: "exact" as const }],
+        rankingQuery,
+      ).slice(0, 25);
+    }
+
+    const needsMoreStages =
+      combinedExact.length === 0 ||
+      (!hasArtist && combinedExact.length === 1);
+
+    // Stage 2: Fuzzy match (typos, Unicode, word reordering)
+    let fuzzyResults: MusicBrainzRecording[] = [];
+    if (needsMoreStages && (cleanedTrack || cleanedArtist)) {
+      fuzzyResults = await searchStage(
+        cleanedTrack,
+        cleanedArtist,
+        undefined,
+        "fuzzy",
+      );
+    }
+
+    // Stage 3: Track-only fallback (when artist name doesn't match MB's data)
+    let trackOnlyResults: MusicBrainzRecording[] = [];
+    const totalSoFar = combinedExact.length + fuzzyResults.length;
+    if (needsMoreStages && totalSoFar < PARTIAL_THRESHOLD &&
+        searchParams.track && searchParams.artist) {
+      trackOnlyResults = await searchStage(
+        cleanedTrack ?? searchParams.track,
+        undefined,
+        undefined,
+        "exact",
+      );
+    }
+
+    // Rank and combine all stages
+    const stageResults = [
+      { results: exactWithRelease, strategy: "exact" as const },
+      { results: exactWithoutRelease, strategy: "exact" as const },
+      { results: originalExactResults, strategy: "exact" as const },
+      { results: cjkAliasResults, strategy: "exact" as const },
+      { results: fuzzyResults, strategy: "fuzzy" as const },
+      { results: trackOnlyResults, strategy: "exact" as const },
+    ].filter((stage) => stage.results.length > 0);
+
+    const rankingQuery: RankingQuery = {
+      track: searchParams.track,
+      artist: searchParams.artist,
+      release: searchParams.release,
+      cleanedTrack,
+      cleanedArtist,
+      cleanedRelease,
+    };
+
+    return rankMultiStageResults(stageResults, rankingQuery).slice(0, 25);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Failed to fetch MusicBrainz data:", error.message);
+    } else {
+      console.error("Failed to fetch MusicBrainz data:", error);
+    }
+    return [];
+  }
+}

--- a/apps/amethyst/package.json
+++ b/apps/amethyst/package.json
@@ -98,6 +98,7 @@
     "react-refresh": "^0.16.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
+    "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },

--- a/apps/aqua/Cargo.toml
+++ b/apps/aqua/Cargo.toml
@@ -35,5 +35,5 @@ redis.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-vergen = { version = "9.0", features = ["build", "cargo", "rustc", "si"] }
+vergen = { version = "=9.0.6", features = ["build", "cargo", "rustc", "si"] }
 vergen-gitcl = "1.0.8"

--- a/apps/aqua/Dockerfile
+++ b/apps/aqua/Dockerfile
@@ -37,7 +37,7 @@ RUN ./scripts/setup-lexicons.sh
 
 # Install Node.js and pnpm for lexicon generation
 RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.15.0
 
 # Install dependencies and generate lexicons
 RUN pnpm install

--- a/apps/aqua/src/repos/actor_profile.rs
+++ b/apps/aqua/src/repos/actor_profile.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use jacquard_common::from_json_value;
 use serde_json::Value;
@@ -30,7 +28,7 @@ pub struct PgProfileRepoRows {
     pub status: Option<Value>,
 }
 
-impl From<PgProfileRepoRows> for ProfileView<'static> {
+impl From<PgProfileRepoRows> for ProfileView {
     fn from(row: PgProfileRepoRows) -> Self {
         Self {
             avatar: row.avatar.map(Into::into),
@@ -42,14 +40,14 @@ impl From<PgProfileRepoRows> for ProfileView<'static> {
             description: row.description.map(Into::into),
             description_facets: row
                 .description_facets
-                .and_then(|v| from_json_value::<Vec<Facet<'_>>>(v).ok()),
+                .and_then(|v| from_json_value::<Vec<Facet>>(v).ok()),
             did: row.did.map(Into::into),
             display_name: row.display_name.map(Into::into),
             featured_item: None,
             status: row
                 .status
-                .and_then(|v| from_json_value::<StatusView<'_>>(v).ok()),
-            extra_data: BTreeMap::new(),
+                .and_then(|v| from_json_value::<StatusView>(v).ok()),
+            extra_data: Default::default(),
         }
     }
 }

--- a/apps/aqua/src/repos/feed_play.rs
+++ b/apps/aqua/src/repos/feed_play.rs
@@ -17,32 +17,32 @@ pub trait FeedPlayRepo: Send + Sync {
 impl FeedPlayRepo for PgDataSource {
     async fn get_feed_play(&self, uri: &str) -> anyhow::Result<Option<PlayView>> {
         let row = sqlx::query!(
-                r#"
-                SELECT
-                    uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
-                    release_mbid, release_name, recording_mbid, submission_client_agent,
-                    music_service_base_domain, origin_url,
-                    COALESCE(
-                      json_agg(
-                        json_build_object(
-                          'artist_mbid', pta.artist_mbid,
-                          'artist_name', pta.artist_name
-                        )
-                      ) FILTER (WHERE pta.artist_name IS NOT NULL),
-                      '[]'
-                    ) AS artists
-                FROM plays
-                LEFT JOIN play_to_artists as pta ON uri = pta.play_uri
-                WHERE uri = $1
-                GROUP BY uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
-                         release_mbid, release_name, recording_mbid, submission_client_agent,
-                         music_service_base_domain, origin_url
-                ORDER BY processed_time desc
-                "#,
-                &uri.to_string()
-            )
-            .fetch_one(&self.db)
-            .await?;
+            r#"
+            SELECT
+                uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
+                release_mbid, release_name, recording_mbid, submission_client_agent,
+                music_service_base_domain, origin_url,
+                COALESCE(
+                  json_agg(
+                    json_build_object(
+                      'artist_mbid', pta.artist_mbid,
+                      'artist_name', pta.artist_name
+                    )
+                  ) FILTER (WHERE pta.artist_name IS NOT NULL),
+                  '[]'
+                ) AS artists
+            FROM plays
+            LEFT JOIN play_to_artists as pta ON uri = pta.play_uri
+            WHERE uri = $1
+            GROUP BY uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
+                     release_mbid, release_name, recording_mbid, submission_client_agent,
+                     music_service_base_domain, origin_url
+            ORDER BY processed_time desc
+            "#,
+            &uri.to_string()
+        )
+        .fetch_one(&self.db)
+        .await?;
 
         let artists: Vec<Artist> = match row.artists {
             Some(value) => from_json_value::<Vec<Artist>>(value).unwrap_or_default(),
@@ -73,32 +73,32 @@ impl FeedPlayRepo for PgDataSource {
         identities: &[String],
     ) -> anyhow::Result<Vec<PlayView>> {
         let rows = sqlx::query!(
-                r#"
-                SELECT
-                    uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
-                    release_mbid, release_name, recording_mbid, submission_client_agent,
-                    music_service_base_domain, origin_url,
-                    COALESCE(
-                      json_agg(
-                        json_build_object(
-                          'artist_mbid', pta.artist_mbid,
-                          'artist_name', pta.artist_name
-                        )
-                      ) FILTER (WHERE pta.artist_name IS NOT NULL),
-                      '[]'
-                    ) AS artists
-                FROM plays
-                LEFT JOIN play_to_artists as pta ON uri = pta.play_uri
-                WHERE did = ANY($1)
-                GROUP BY uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
-                         release_mbid, release_name, recording_mbid, submission_client_agent,
-                         music_service_base_domain, origin_url
-                ORDER BY processed_time desc
-                "#,
-                identities
-            )
-            .fetch_all(&self.db)
-            .await?;
+            r#"
+            SELECT
+                uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
+                release_mbid, release_name, recording_mbid, submission_client_agent,
+                music_service_base_domain, origin_url,
+                COALESCE(
+                  json_agg(
+                    json_build_object(
+                      'artist_mbid', pta.artist_mbid,
+                      'artist_name', pta.artist_name
+                    )
+                  ) FILTER (WHERE pta.artist_name IS NOT NULL),
+                  '[]'
+                ) AS artists
+            FROM plays
+            LEFT JOIN play_to_artists as pta ON uri = pta.play_uri
+            WHERE did = ANY($1)
+            GROUP BY uri, did, rkey, cid, isrc, duration, track_name, played_time, processed_time,
+                     release_mbid, release_name, recording_mbid, submission_client_agent,
+                     music_service_base_domain, origin_url
+            ORDER BY processed_time desc
+            "#,
+            identities
+        )
+        .fetch_all(&self.db)
+        .await?;
 
         let mut result = Vec::with_capacity(rows.len());
         for row in rows {

--- a/apps/aqua/src/repos/stats.rs
+++ b/apps/aqua/src/repos/stats.rs
@@ -216,10 +216,8 @@ impl StatsRepo for PgDataSource {
         let mut result = Vec::with_capacity(rows.len());
         for row in rows {
             let artists = match row.artists {
-                Some(value) => {
-                    from_json_value::<Vec<types::fm_teal::alpha::feed::Artist<'_>>>(value)
-                        .unwrap_or_default()
-                }
+                Some(value) => from_json_value::<Vec<types::fm_teal::alpha::feed::Artist>>(value)
+                    .unwrap_or_default(),
                 None => vec![],
             };
 

--- a/apps/aqua/src/xrpc/actor.rs
+++ b/apps/aqua/src/xrpc/actor.rs
@@ -17,8 +17,8 @@ pub struct GetProfileQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetProfileResponse<'a> {
-    profile: ProfileView<'a>,
+pub struct GetProfileResponse {
+    profile: ProfileView,
 }
 
 pub async fn get_actor(
@@ -50,8 +50,8 @@ pub struct GetProfilesQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetProfilesResponse<'a> {
-    profiles: Vec<ProfileView<'a>>,
+pub struct GetProfilesResponse {
+    profiles: Vec<ProfileView>,
 }
 
 pub async fn get_actors(

--- a/apps/aqua/src/xrpc/feed.rs
+++ b/apps/aqua/src/xrpc/feed.rs
@@ -17,8 +17,8 @@ pub struct GetFeedPlayQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetFeedPlayResponse<'a> {
-    play: PlayView<'a>,
+pub struct GetFeedPlayResponse {
+    play: PlayView,
 }
 
 pub async fn get_feed_play(
@@ -50,8 +50,8 @@ pub struct GetFeedPlaysQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetFeedPlaysResponse<'a> {
-    plays: Vec<PlayView<'a>>,
+pub struct GetFeedPlaysResponse {
+    plays: Vec<PlayView>,
 }
 
 pub async fn get_feed_plays(

--- a/apps/aqua/src/xrpc/stats.rs
+++ b/apps/aqua/src/xrpc/stats.rs
@@ -27,8 +27,8 @@ pub struct GetTopArtistsQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetTopArtistsResponse<'a> {
-    artists: Vec<ArtistView<'a>>,
+pub struct GetTopArtistsResponse {
+    artists: Vec<ArtistView>,
 }
 
 pub async fn get_top_artists(
@@ -51,8 +51,8 @@ pub struct GetTopReleasesQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetTopReleasesResponse<'a> {
-    releases: Vec<ReleaseView<'a>>,
+pub struct GetTopReleasesResponse {
+    releases: Vec<ReleaseView>,
 }
 
 pub async fn get_top_releases(
@@ -76,8 +76,8 @@ pub struct GetUserTopArtistsQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetUserTopArtistsResponse<'a> {
-    artists: Vec<ArtistView<'a>>,
+pub struct GetUserTopArtistsResponse {
+    artists: Vec<ArtistView>,
 }
 
 pub async fn get_user_top_artists(
@@ -105,8 +105,8 @@ pub struct GetUserTopReleasesQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetUserTopReleasesResponse<'a> {
-    releases: Vec<ReleaseView<'a>>,
+pub struct GetUserTopReleasesResponse {
+    releases: Vec<ReleaseView>,
 }
 
 pub async fn get_user_top_releases(
@@ -133,8 +133,8 @@ pub struct GetLatestQuery {
 }
 
 #[derive(Serialize)]
-pub struct GetLatestResponse<'a> {
-    plays: Vec<PlayView<'a>>,
+pub struct GetLatestResponse {
+    plays: Vec<PlayView>,
 }
 
 pub async fn get_latest(

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -37,7 +37,7 @@ services:
   cadet:
     build:
       context: .
-      dockerfile: apps/cadet/Dockerfile
+      dockerfile: services/cadet/Dockerfile
     container_name: cadet-app
     ports:
       - "3001:3000"

--- a/lexicons/fm.teal.alpha/actor/status.json
+++ b/lexicons/fm.teal.alpha/actor/status.json
@@ -13,12 +13,12 @@
           "time": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of when the item was recorded"
+            "description": "The RFC 3339 formatted time of when the item was recorded"
           },
           "expiry": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
+            "description": "The RFC 3339 formatted time of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
           },
           "item": {
             "type": "ref",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,11 @@
     "db:create": "sqlx database create",
     "db:drop": "sqlx database drop",
     "db:reset": "sqlx database drop && sqlx database create && sqlx migrate run",
-    "db:prepare": "sqlx prepare"
+    "db:prepare": "sqlx prepare",
+    "eval:auth": "tsx scripts/eval/evaluate.ts --auth-only",
+    "eval:run": "tsx scripts/eval/evaluate.ts",
+    "eval:resolve-lb": "tsx scripts/eval/listenbrainz-resolve.ts",
+    "test:musicbrainz": "pnpm test --filter=@teal/amethyst -- --testPathPattern=\"musicbrainz|fuzzy\" --passWithNoTests"
   },
   "dependencies": {
     "@atproto/oauth-client": "^0.3.8",
@@ -42,9 +46,13 @@
     "prettier-plugin-tailwindcss": "^0.6.11"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.17.10",
+    "better-sqlite3": "^12.5.0",
     "biome": "^0.3.3",
+    "dotenv": "^16.4.7",
     "rimraf": "^6.0.1",
+    "tsx": "^4.19.2",
     "turbo": "^2.3.3"
   },
   "workspaces": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,15 +21,27 @@ importers:
         specifier: ^0.6.11
         version: 0.6.14(@ianvs/prettier-plugin-sort-imports@4.7.0(prettier@3.6.2))(prettier@3.6.2)
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^20.17.10
         version: 20.19.19
+      better-sqlite3:
+        specifier: ^12.5.0
+        version: 12.5.0
       biome:
         specifier: ^0.3.3
         version: 0.3.3
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       turbo:
         specifier: ^2.3.3
         version: 2.5.8
@@ -143,7 +155,7 @@ importers:
         version: 0.507.0(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       nativewind:
         specifier: ^4.1.23
-        version: 4.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18)
+        version: 4.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0))
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -158,7 +170,7 @@ importers:
         version: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
       react-native-css-interop:
         specifier: ^0.1.18
-        version: 0.1.22(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18)
+        version: 0.1.22(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0))
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -201,7 +213,7 @@ importers:
         version: 54.0.4(expo@54.0.12)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.15
-        version: 0.5.17(react-refresh@0.16.0)(type-fest@0.21.3)(webpack@5.97.1)
+        version: 0.5.17(react-refresh@0.16.0)(type-fest@4.41.0)(webpack@5.97.1)
       '@react-native/typescript-config':
         specifier: ^0.76.5
         version: 0.76.9
@@ -246,10 +258,13 @@ importers:
         version: 0.16.0
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.18
+        version: 3.4.18(tsx@4.21.0)
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.18)
+        version: 1.0.7(tailwindcss@3.4.18(tsx@4.21.0))
+      ts-jest:
+        specifier: ^29.4.6
+        version: 29.4.6(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.2(@types/node@22.18.8)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.18.8)(typescript@5.9.3)
@@ -1167,6 +1182,162 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -2317,6 +2488,9 @@ packages:
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2991,6 +3165,10 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  better-sqlite3@12.5.0:
+    resolution: {integrity: sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -3002,9 +3180,15 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   biome@0.3.3:
     resolution: {integrity: sha512-4LXjrQYbn9iTXu9Y4SKT7ABzTV0WnLDHCVSd2fPUOKsy1gQ+E4xPFmlY1zcWexoi0j7fGHItlL6OWA2CZ/yYAQ==}
     hasBin: true
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
@@ -3041,6 +3225,10 @@ packages:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -3154,6 +3342,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -3453,6 +3644,10 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   dedent@1.7.0:
     resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
     peerDependencies:
@@ -3611,6 +3806,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
@@ -3673,6 +3871,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3869,6 +4072,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -4132,6 +4339,9 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4213,6 +4423,9 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@0.26.7:
     resolution: {integrity: sha512-waKu+1KumRhYv8D8gMRCKJGAMI9pRnPuEb1mvgYD0f7wBscg+h6bW4FDTmEZhB9VKxvoTtxW+Y7bnIlB7zja6Q==}
@@ -4297,6 +4510,9 @@ packages:
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4310,25 +4526,29 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -4359,6 +4579,11 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
 
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -5333,6 +5558,9 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -5501,6 +5729,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5539,6 +5771,9 @@ packages:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
     engines: {node: '>= 18'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -5573,6 +5808,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -5600,6 +5838,10 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
+
+  node-abi@3.85.0:
+    resolution: {integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==}
+    engines: {node: '>=10'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -5960,6 +6202,11 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -6080,6 +6327,9 @@ packages:
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6316,6 +6566,7 @@ packages:
   react-server-dom-webpack@19.0.0:
     resolution: {integrity: sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==}
     engines: {node: '>=0.10.0'}
+    deprecated: Critical Security Vulnerability in React Server Components
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6346,6 +6597,10 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readable-stream@4.5.2:
     resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
@@ -6588,6 +6843,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -6665,6 +6925,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-plist@1.3.1:
     resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
@@ -6924,6 +7190,13 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
@@ -7038,6 +7311,33 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-jest@29.4.6:
+    resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+
   ts-morph@16.0.0:
     resolution: {integrity: sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==}
 
@@ -7063,6 +7363,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -7124,6 +7429,10 @@ packages:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -7151,6 +7460,11 @@ packages:
 
   ua-parser-js@1.0.40:
     resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
+    hasBin: true
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
     hasBin: true
 
   uint8arrays@3.0.0:
@@ -7362,6 +7676,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -7412,6 +7727,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -8724,6 +9042,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -9053,7 +9449,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.2.0)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9132,7 +9528,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.4
       debug: 4.4.0
-      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.2.0)(react@19.2.0))(react@19.2.0)
       resolve-from: 5.0.0
       semver: 7.7.2
       xml2js: 0.6.0
@@ -9687,7 +10083,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.16.0)(type-fest@0.21.3)(webpack@5.97.1)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.16.0)(type-fest@4.41.0)(webpack@5.97.1)':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.39.0
@@ -9699,7 +10095,7 @@ snapshots:
       source-map: 0.7.4
       webpack: 5.97.1
     optionalDependencies:
-      type-fest: 0.21.3
+      type-fest: 4.41.0
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -10719,6 +11115,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.18.8
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -11474,7 +11874,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.2.0)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -11505,11 +11905,20 @@ snapshots:
     dependencies:
       open: 8.4.2
 
+  better-sqlite3@12.5.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   big-integer@1.6.52: {}
 
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   biome@0.3.3:
     dependencies:
@@ -11522,6 +11931,12 @@ snapshots:
       request-promise: 3.0.0
       untildify: 3.0.3
       user-home: 2.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   bluebird@3.7.2: {}
 
@@ -11576,6 +11991,10 @@ snapshots:
       electron-to-chromium: 1.5.230
       node-releases: 2.0.23
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
+
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
 
   bser@2.1.1:
     dependencies:
@@ -11705,6 +12124,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.0.2
+
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -11992,6 +12413,10 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.7.0: {}
 
   deep-extend@0.6.0: {}
@@ -12117,6 +12542,10 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -12245,6 +12674,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -12520,6 +12978,8 @@ snapshots:
   exit-x@0.2.2: {}
 
   exit@0.1.2: {}
+
+  expand-template@2.0.3: {}
 
   expect@29.7.0:
     dependencies:
@@ -13009,6 +13469,8 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -13109,6 +13571,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@0.26.7:
     dependencies:
       graceful-fs: 4.2.11
@@ -13208,6 +13672,8 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  github-from-package@0.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -13290,6 +13756,15 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
 
   har-schema@2.0.0: {}
 
@@ -14285,7 +14760,7 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       pretty-format: 30.2.0
-      semver: 7.7.2
+      semver: 7.7.4
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
@@ -14660,6 +15135,8 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.memoize@4.1.2: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.throttle@4.1.1: {}
@@ -14916,6 +15393,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.0.3:
@@ -14948,6 +15427,8 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -14972,14 +15453,16 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   napi-postinstall@0.3.4: {}
 
-  nativewind@4.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18):
+  nativewind@4.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0)):
     dependencies:
       comment-json: 4.2.5
       debug: 4.4.0
-      react-native-css-interop: 0.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18)
-      tailwindcss: 3.4.18
+      react-native-css-interop: 0.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0))
+      tailwindcss: 3.4.18(tsx@4.21.0)
     transitivePeerDependencies:
       - react
       - react-native
@@ -14997,6 +15480,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
+
+  node-abi@3.85.0:
+    dependencies:
+      semver: 7.7.2
 
   node-fetch@2.7.0:
     dependencies:
@@ -15308,12 +15795,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.4.49
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -15332,6 +15820,21 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.85.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
 
@@ -15396,6 +15899,11 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -15491,7 +15999,7 @@ snapshots:
 
   react-is@19.2.0: {}
 
-  react-native-css-interop@0.1.22(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18):
+  react-native-css-interop@0.1.22(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0)):
     dependencies:
       '@babel/helper-module-imports': 7.27.1
       '@babel/traverse': 7.28.4
@@ -15502,14 +16010,14 @@ snapshots:
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
       react-native-reanimated: 4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.7.2
-      tailwindcss: 3.4.18
+      tailwindcss: 3.4.18(tsx@4.21.0)
     optionalDependencies:
       react-native-safe-area-context: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg: 15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-css-interop@0.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18):
+  react-native-css-interop@0.2.1(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.18(tsx@4.21.0)):
     dependencies:
       '@babel/helper-module-imports': 7.25.9
       '@babel/traverse': 7.26.4
@@ -15520,7 +16028,7 @@ snapshots:
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
       react-native-reanimated: 4.1.2(@babel/core@7.28.4)(react-native-worklets@0.6.0(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.6.3
-      tailwindcss: 3.4.18
+      tailwindcss: 3.4.18(tsx@4.21.0)
     optionalDependencies:
       react-native-safe-area-context: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg: 15.12.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -15902,6 +16410,12 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.5.2:
     dependencies:
       abort-controller: 3.0.0
@@ -16173,6 +16687,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.4: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -16277,6 +16793,14 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-plist@1.3.1:
     dependencies:
@@ -16531,11 +17055,11 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.18):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.18(tsx@4.21.0)):
     dependencies:
-      tailwindcss: 3.4.18
+      tailwindcss: 3.4.18(tsx@4.21.0)
 
-  tailwindcss@3.4.18:
+  tailwindcss@3.4.18(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -16554,7 +17078,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.1.0(postcss@8.4.49)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -16564,6 +17088,21 @@ snapshots:
       - yaml
 
   tapable@2.3.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar@7.4.3:
     dependencies:
@@ -16675,6 +17214,26 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-jest@29.4.6(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.2(@types/node@22.18.8)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.2(@types/node@22.18.8)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.4)
+      jest-util: 30.2.0
+
   ts-morph@16.0.0:
     dependencies:
       '@ts-morph/common': 0.17.0
@@ -16711,6 +17270,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -16757,6 +17323,8 @@ snapshots:
 
   type-fest@0.7.1: {}
 
+  type-fest@4.41.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -16798,6 +17366,9 @@ snapshots:
   typescript@5.9.3: {}
 
   ua-parser-js@1.0.40: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   uint8arrays@3.0.0:
     dependencies:
@@ -17145,6 +17716,8 @@ snapshots:
   wonka@6.3.4: {}
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -1,0 +1,138 @@
+# MusicBrainz Matching Evaluation
+
+Measures how well our MusicBrainz search pipeline (cleaner, ranking,
+multi-stage orchestrator) finds the correct recording given a track
+name, artist, and album. Uses your own Last.fm scrobble history as
+ground truth (scrobbles carry MBIDs we can validate against). Results
+vary by listening habits -- the numbers in the PR reflect one person's
+library and are not universal benchmarks.
+
+## Quick Start
+
+```bash
+# 1. Add Last.fm API credentials to .env (see .env.template)
+#    Get a key at https://www.last.fm/api/account/create
+#    LASTFM_API_KEY=...
+#    LASTFM_API_SECRET=...
+
+# 2. Authenticate once (opens browser for Last.fm OAuth)
+pnpm eval:auth
+
+# 3. Run evaluation (1000 scrobbles is a good starting sample)
+pnpm eval:run -- --limit 1000
+
+# 4. Expand ground truth via ListenBrainz (recovers ~75% of 404 MBIDs)
+pnpm eval:resolve-lb
+
+# 5. Run on full cached history
+pnpm eval:run -- --all
+```
+
+## Full Workflow (for reliable results)
+
+```bash
+# First time: authenticate + fetch scrobbles + resolve ground truth
+pnpm eval:auth
+pnpm eval:run -- --all --use-additional-apis   # fetches scrobbles, resolves MBIDs
+pnpm eval:resolve-lb                            # batch-resolve 404 MBIDs via ListenBrainz
+
+# Re-run after code changes (uses cached searches, fast)
+pnpm eval:run -- --all
+
+# With a rotating proxy (faster MB API calls)
+MB_RATE_LIMIT_MS=200 pnpm eval:run -- --all --concurrency 5
+```
+
+## What It Measures
+
+Each scrobble with a valid MBID becomes a test case. The eval searches
+MusicBrainz using both a **baseline** (single Lucene query, 1 API call)
+and the **improved** pipeline (multi-stage search with cleaning and
+ranking, ~4.5 API calls/case on average). It checks whether the correct
+recording MBID appears in the results and at what position.
+
+Metrics reported: P@1, P@5, P@10, MRR, NDCG, win/loss ratio, and
+per-category breakdowns (remixes, featuring artists, CJK, etc.).
+
+## Ground Truth Sources
+
+MBIDs come from four independent sources (not from our own search):
+
+| Source | How obtained | Independence |
+|--------|-------------|--------------|
+| `track_data` | Last.fm scrobble's `.mbid` field | Independent |
+| `lastfm_track_info` | Last.fm `track.getInfo` API | Independent |
+| `lastfm_search` | Last.fm `track.search` API | Semi-independent |
+| `listenbrainz_acr` | ListenBrainz ACR canonical mapping | Independent |
+
+The `listenbrainz_acr` source is critical: ~72% of Last.fm MBIDs
+return HTTP 404 from MusicBrainz (deleted recordings). ListenBrainz's
+canonical mapping resolves ~75% of these to current recording MBIDs,
+nearly tripling the eval set. Run `pnpm eval:resolve-lb` to populate.
+
+## Options
+
+```
+--limit N              Evaluate N scrobbles (default: 1000)
+--all                  Evaluate all cached scrobbles
+--username USER        Use public API for username (skips OAuth)
+--auth-only            Perform OAuth only, then exit
+--no-cleaning          Disable name cleaning
+--no-fuzzy             Disable fuzzy matching
+--no-multistage        Disable multi-stage search
+--no-parallel          Disable parallel evaluation
+--concurrency N        Parallel concurrency (default: 5)
+--refresh-scrobbles    Force re-fetch scrobbles from Last.fm
+--use-additional-apis  Backfill missing MBIDs via extra API calls
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `evaluate.ts` | Main orchestrator |
+| `types.ts` | Shared types, MBIDSource provenance, GROUND_TRUTH_SOURCES |
+| `search.ts` | Baseline + improved search (mirrors production pipeline) |
+| `evaluate-lastfm-cache.ts` | SQLite cache (scrobbles, searches, validations) |
+| `mbid-resolution.ts` | MBID resolution with provenance tracking |
+| `listenbrainz-resolve.ts` | Batch 404 MBID resolution via ListenBrainz |
+| `reporting.ts` | Metrics computation + JSON output |
+| `statistics.ts` | Bootstrap CI, McNemar, Cohen's h, NDCG |
+| `lastfm-api.ts` | Last.fm API functions |
+| `auth.ts` | Last.fm OAuth + signature generation |
+
+## Caching
+
+SQLite cache at `~/.teal_eval_cache/lastfm_eval.db` with three layers:
+
+- **`mb_search_cache`**: Raw MB API responses. Keyed by (track, artist,
+  album, strategy). Never invalidated -- API responses don't change
+  with our code.
+- **`evaluation_result_cache`**: Eval outcomes per case. Keyed by
+  (track, artist, album, mbid, config, field_combo, VERSION). Bump
+  `EVALUATION_LOGIC_VERSION` in `evaluate-lastfm-cache.ts` after
+  ranking/search code changes.
+- **`mbid_validation_cache`**: MBID validity + canonical mapping for
+  merged recordings. Rarely invalidated.
+
+First run is slow (fills the search cache via MusicBrainz API at 1
+req/s). Expect ~3-4 hours per 10k cases. Subsequent runs are fast
+(seconds for 22k+ cases when fully cached).
+
+To speed up the initial cache fill, use a residential proxy to avoid
+the MB rate limit:
+
+```bash
+# In .env:
+PROXY_URL=http://user:pass@proxy-host:port
+
+# Then run with lower rate limit and higher concurrency:
+MB_RATE_LIMIT_MS=200 pnpm eval:run -- --all --concurrency 5
+```
+
+## Notes
+
+- Session key: `scripts/eval/.lastfm_session_key` (gitignored).
+- Results: `scripts/eval/results/archive/YYYY-MM-DD/` (gitignored).
+- Default MB rate limit: 1 req/s. Set `MB_RATE_LIMIT_MS=N` to override.
+- Proxy support: set `PROXY_URL` in `.env` for a residential/rotating proxy.

--- a/scripts/eval/analyze-regressions.ts
+++ b/scripts/eval/analyze-regressions.ts
@@ -1,0 +1,96 @@
+/**
+ * Quick analysis of eval regressions and unmatchable disambiguation cases.
+ * Run: npx tsx scripts/eval/analyze-regressions.ts
+ */
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+const resultsDir = new URL(".", import.meta.url).pathname;
+
+// Find the most recent results file
+const archiveDir = join(resultsDir, "results/archive");
+const dateDirs = readdirSync(archiveDir).filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d)).sort().reverse();
+if (dateDirs.length === 0) {
+  console.error("No eval results found in", archiveDir);
+  process.exit(1);
+}
+const latestDate = dateDirs[0];
+const resultsPath = join(archiveDir, latestDate, "lastfm-evaluation-results.json");
+console.log(`Using results from: ${latestDate}\n`);
+const data = JSON.parse(readFileSync(resultsPath, "utf-8"));
+const cases = data.cases;
+
+console.log("=== REGRESSION ANALYSIS ===\n");
+
+// Easy cases where baseline P@1 but improved is not
+const easyRegressions = cases.filter((c: any) =>
+  c.hardness === "easy" && c.baseline_pos === 0 && c.improved_pos !== 0
+);
+console.log(`Easy P@1 regressions: ${easyRegressions.length}`);
+for (const c of easyRegressions.slice(0, 15)) {
+  console.log(`  "${c.track}" by ${c.artist || "[no artist]"}`);
+  console.log(`    baseline: pos 0 -> improved: pos ${c.improved_pos}`);
+  console.log(`    failure: ${c.failure_mode}`);
+}
+
+// Cases lost entirely (baseline found, improved not)
+const lostCases = cases.filter((c: any) => c.baseline_found && !c.improved_found);
+console.log(`\nCases lost entirely (baseline found, improved not): ${lostCases.length}`);
+for (const c of lostCases.slice(0, 5)) {
+  console.log(`  "${c.track}" by ${c.artist || "[no artist]"}`);
+  console.log(`    baseline pos: ${c.baseline_pos}`);
+}
+
+// All regressions (improved worse than baseline)
+const allRegressions = cases.filter((c: any) => {
+  if (!c.baseline_found) return false;
+  if (!c.improved_found) return true;
+  return c.improved_pos > c.baseline_pos;
+});
+console.log(`\nAll regressions (any worsening): ${allRegressions.length}`);
+console.log(`  Lost entirely: ${allRegressions.filter((c: any) => !c.improved_found).length}`);
+console.log(`  Position worsened: ${allRegressions.filter((c: any) => c.improved_found && c.improved_pos > c.baseline_pos).length}`);
+
+// Group regressions by failure mode
+const regByMode: Record<string, number> = {};
+for (const c of allRegressions) {
+  const mode = (c as any).failure_mode || "unknown";
+  regByMode[mode] = (regByMode[mode] || 0) + 1;
+}
+console.log("  By failure mode:", JSON.stringify(regByMode));
+
+// Show the worst regressions (biggest position drop)
+const positionRegressions = allRegressions
+  .filter((c: any) => c.improved_found)
+  .map((c: any) => ({ ...c, drop: c.improved_pos - c.baseline_pos }))
+  .sort((a: any, b: any) => b.drop - a.drop);
+console.log("\nWorst position drops:");
+for (const c of positionRegressions.slice(0, 10)) {
+  console.log(`  "${c.track}" by ${c.artist || "[no artist]"}`);
+  console.log(`    pos ${c.baseline_pos} -> ${c.improved_pos} (drop: ${c.drop}), failure: ${c.failure_mode}`);
+}
+
+console.log("\n=== UNMATCHABLE ANALYSIS ===\n");
+
+const unmatchable = cases.filter((c: any) => c.matchability === "unmatchable");
+console.log(`Total unmatchable: ${unmatchable.length} / ${cases.length} (${(unmatchable.length / cases.length * 100).toFixed(1)}%)`);
+
+// Break down by artist presence
+const withArtist = unmatchable.filter((c: any) => c.artist);
+const noArtist = unmatchable.filter((c: any) => !c.artist);
+console.log(`  With artist: ${withArtist.length}`);
+console.log(`  Track-only (no artist): ${noArtist.length}`);
+
+// By failure mode
+const unmatchByMode: Record<string, number> = {};
+for (const c of unmatchable) {
+  const mode = (c as any).failure_mode || "unknown";
+  unmatchByMode[mode] = (unmatchByMode[mode] || 0) + 1;
+}
+console.log(`  By failure mode:`, JSON.stringify(unmatchByMode));
+
+// Sample some unmatchable with artist (the disambiguation candidates)
+console.log("\nSample unmatchable (track+artist) -- likely disambiguation:");
+for (const c of withArtist.slice(0, 10)) {
+  console.log(`  "${c.track}" by ${c.artist} [mbid: ${c.mbid?.slice(0, 8)}...]`);
+}

--- a/scripts/eval/auth.ts
+++ b/scripts/eval/auth.ts
@@ -1,0 +1,218 @@
+/**
+ * Last.fm OAuth authentication for the evaluation harness.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const SCRIPT_DIR =
+  import.meta.dirname ?? new URL(".", import.meta.url).pathname;
+export const SESSION_KEY_FILE = join(SCRIPT_DIR, ".lastfm_session_key");
+
+/**
+ * Generate Last.fm API signature.
+ * Signature is MD5 of: sorted parameter keys + values + API secret.
+ * api_sig and format are excluded from signature calculation (per Last.fm API docs).
+ */
+export async function generateSignature(
+  params: Record<string, string>,
+  apiSecret: string,
+): Promise<string> {
+  const crypto = await import("crypto");
+  const paramsForSig: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (key !== "api_sig" && key !== "format") {
+      paramsForSig[key] = value;
+    }
+  }
+
+  const sortedKeys = Object.keys(paramsForSig).sort();
+  const sigString =
+    sortedKeys.map((key) => `${key}${paramsForSig[key]}`).join("") + apiSecret;
+
+  return crypto.createHash("md5").update(sigString).digest("hex");
+}
+
+/**
+ * Get Last.fm session key via OAuth.
+ * Returns a cached session key if valid, otherwise initiates a new OAuth flow.
+ */
+export async function getLastFMSession(
+  apiKey: string,
+  apiSecret: string,
+): Promise<string> {
+  // Try to load existing session key
+  if (existsSync(SESSION_KEY_FILE)) {
+    const sessionKey = readFileSync(SESSION_KEY_FILE, "utf-8").trim();
+    if (sessionKey) {
+      try {
+        const testParams: Record<string, string> = {
+          method: "user.getInfo",
+          api_key: apiKey,
+          sk: sessionKey,
+          format: "json",
+        };
+        const testSig = await generateSignature(testParams, apiSecret);
+        testParams.api_sig = testSig;
+        const testUrl = `https://ws.audioscrobbler.com/2.0/?${new URLSearchParams(testParams).toString()}`;
+        const testRes = await fetch(testUrl);
+        if (testRes.ok) {
+          const data = await testRes.json();
+          if (data.user && !data.error) {
+            console.log(
+              `Using existing session key (authenticated as: ${data.user.name})`,
+            );
+            console.log(
+              `(To force re-authentication, delete ${SESSION_KEY_FILE})\n`,
+            );
+            return sessionKey;
+          }
+        }
+      } catch (e: unknown) {
+        console.log(`Existing session key invalid: ${e instanceof Error ? e.message : String(e)}`);
+        console.log("Starting new OAuth flow...\n");
+      }
+    }
+  }
+
+  // OAuth flow
+  console.log("\n=== Last.fm OAuth Authentication ===");
+  console.log("Step 1: Getting authentication token...");
+
+  const tokenUrl = `https://ws.audioscrobbler.com/2.0/?method=auth.getToken&api_key=${apiKey}&format=json`;
+  console.log(`  Fetching token from Last.fm API...`);
+  console.log(`  API Key: ${apiKey.substring(0, 8)}...`);
+
+  const tokenRes = await fetch(tokenUrl);
+  if (!tokenRes.ok) {
+    const errorText = await tokenRes.text();
+    throw new Error(
+      `Failed to get token: ${tokenRes.statusText} - ${errorText}`,
+    );
+  }
+
+  const tokenData = await tokenRes.json();
+  if (tokenData.error) {
+    throw new Error(
+      `Last.fm API error: ${tokenData.error} - ${tokenData.message || "Invalid API key or credentials"}`,
+    );
+  }
+
+  const token = tokenData.token;
+  if (!token) {
+    throw new Error(
+      `No token received from Last.fm API. Response: ${JSON.stringify(tokenData)}`,
+    );
+  }
+
+  console.log(`  Got token: ${token.substring(0, 10)}...`);
+
+  // Step 2: User authorizes
+  const authUrl = `https://www.last.fm/api/auth?api_key=${apiKey}&token=${token}`;
+  console.log(`\nStep 2: Opening browser for authorization...`);
+  console.log(`  URL: ${authUrl}`);
+  console.log(`\n  Instructions:`);
+  console.log(`  1. A browser window should open automatically`);
+  console.log(`  2. Log in to Last.fm if needed`);
+  console.log(`  3. Click "Allow access" to authorize this application`);
+  console.log(
+    `  4. The script will automatically detect when you've authorized\n`,
+  );
+
+  const { spawn } = await import("child_process");
+  const platform = process.platform;
+  let browserOpened = false;
+
+  try {
+    if (platform === "darwin") {
+      spawn("open", [authUrl], { detached: true, stdio: "ignore" }).unref();
+      browserOpened = true;
+    } else if (platform === "linux") {
+      spawn("xdg-open", [authUrl], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+      browserOpened = true;
+    } else if (platform === "win32") {
+      spawn("cmd", ["/c", "start", authUrl], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+      browserOpened = true;
+    } else {
+      console.log(
+        `  Platform ${platform} not supported for auto-opening browser.`,
+      );
+      console.log(`  Please manually visit: ${authUrl}\n`);
+    }
+    if (browserOpened) console.log(`  Browser opened successfully\n`);
+  } catch (e: unknown) {
+    console.error(`  Error opening browser: ${e instanceof Error ? e.message : String(e)}`);
+    console.error(`  Please manually visit: ${authUrl}\n`);
+  }
+
+  if (browserOpened) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  console.log("Step 3: Waiting for authorization...");
+  console.log("  (Polling Last.fm API every 2 seconds)\n");
+
+  // Step 3: Poll for session
+  const maxWait = 300000; // 5 minutes
+  const startTime = Date.now();
+  const pollInterval = 2000;
+  let pollCount = 0;
+
+  while (Date.now() - startTime < maxWait) {
+    pollCount++;
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+
+    const sig = await generateSignature(
+      { method: "auth.getSession", token, api_key: apiKey },
+      apiSecret,
+    );
+    const sessionUrl = `https://ws.audioscrobbler.com/2.0/?method=auth.getSession&api_key=${apiKey}&token=${token}&api_sig=${sig}&format=json`;
+
+    if (pollCount % 5 === 0) {
+      console.log(`  Poll #${pollCount}: Checking for authorization...`);
+    }
+
+    try {
+      const sessionRes = await fetch(sessionUrl);
+      if (sessionRes.ok) {
+        const sessionData = await sessionRes.json();
+        if (sessionData.session?.key) {
+          const sessionKey = sessionData.session.key;
+          writeFileSync(SESSION_KEY_FILE, sessionKey);
+          console.log(
+            `  Authorization received! (after ${pollCount} polls)`,
+          );
+          console.log(`  Session key saved to ${SESSION_KEY_FILE}\n`);
+          return sessionKey;
+        } else if (sessionData.error && pollCount === 1) {
+          console.log(`  (Waiting for user to authorize in browser...)`);
+        }
+      } else if (pollCount === 1) {
+        console.log(
+          `  API returned ${sessionRes.status}, waiting for authorization...`,
+        );
+      }
+    } catch (e: unknown) {
+      if (pollCount === 1) {
+        console.log(`  Error on first poll (expected): ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
+    if (elapsed > 0 && elapsed % 10 === 0) {
+      console.log(
+        `  Still waiting... (${elapsed}s elapsed, ${pollCount} polls)`,
+      );
+    }
+  }
+
+  throw new Error(
+    `OAuth timeout: No authorization received after ${Math.floor(maxWait / 1000)} seconds`,
+  );
+}

--- a/scripts/eval/evaluate-lastfm-cache.ts
+++ b/scripts/eval/evaluate-lastfm-cache.ts
@@ -1,0 +1,877 @@
+/**
+ * SQLite cache for Last.fm evaluation data
+ * Accumulates scrobbles and MBIDs over time, never clears
+ */
+
+import Database from "better-sqlite3";
+import { createHash } from "crypto";
+import { join } from "path";
+import { homedir } from "os";
+import { mkdirSync } from "fs";
+
+const CACHE_DIR = join(homedir(), ".teal_eval_cache");
+const DB_PATH = join(CACHE_DIR, "lastfm_eval.db");
+
+// Bump this when evaluation logic changes in a way that should invalidate cached evaluation results.
+const EVALUATION_LOGIC_VERSION = "2026-03-09-v27";
+
+// Ensure cache directory exists
+mkdirSync(CACHE_DIR, { recursive: true });
+
+export class LastFMCache {
+  private db: Database.Database;
+  // Prepared statements for performance (reuse instead of creating each time)
+  private stmtGetEvaluationResult: Database.Statement;
+  private stmtSetEvaluationResult: Database.Statement;
+
+  constructor() {
+    this.db = new Database(DB_PATH);
+    this.initSchema();
+    // Prepare statements once for reuse
+    this.stmtGetEvaluationResult = this.db.prepare(`
+      SELECT baseline_pos, improved_pos, baseline_found, improved_found,
+             baseline_ndcg, improved_ndcg, failure_mode, duplicate_count,
+             improved_top_ids, baseline_top_ids
+      FROM evaluation_result_cache
+      WHERE result_hash = ?
+    `);
+    this.stmtSetEvaluationResult = this.db.prepare(`
+      INSERT OR REPLACE INTO evaluation_result_cache (
+        result_hash, track, artist, album, mbid,
+        baseline_pos, improved_pos, baseline_found, improved_found,
+        baseline_ndcg, improved_ndcg, failure_mode, duplicate_count, search_config,
+        improved_top_ids, baseline_top_ids
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+  }
+
+  private initSchema() {
+    // Scrobbles table - accumulates over time
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS scrobbles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        album TEXT,
+        mbid TEXT,
+        timestamp TEXT NOT NULL,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(username, track, artist, timestamp)
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_scrobbles_username ON scrobbles(username);
+      CREATE INDEX IF NOT EXISTS idx_scrobbles_mbid ON scrobbles(mbid);
+      CREATE INDEX IF NOT EXISTS idx_scrobbles_timestamp ON scrobbles(timestamp DESC);
+    `);
+
+    // MBID lookups cache - avoid re-fetching MBIDs
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS mbid_cache (
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        mbid TEXT,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (track, artist)
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_mbid_cache_mbid ON mbid_cache(mbid);
+    `);
+
+    // MusicBrainz search results cache - avoid re-searching same queries
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS mb_search_cache (
+        query_hash TEXT PRIMARY KEY,
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        album TEXT,
+        results TEXT NOT NULL, -- JSON array of search results
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_mb_search_track_artist ON mb_search_cache(track, artist);
+    `);
+
+    // MBID validation cache - avoid re-validating same MBIDs
+    // Since evaluation has no time constraints, we can cache validation results
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS mbid_validation_cache (
+        mbid TEXT PRIMARY KEY,
+        is_valid INTEGER NOT NULL, -- 1 = valid, 0 = invalid
+        validated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        http_status INTEGER, -- Store HTTP status for debugging
+        error_message TEXT, -- Store error details if any
+        canonical_mbid TEXT -- If 301 redirect, the target MBID
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_mbid_validation_valid ON mbid_validation_cache(is_valid);
+    `);
+
+    // Add canonical_mbid column (non-destructive migration)
+    try {
+      this.db.exec(`ALTER TABLE mbid_validation_cache ADD COLUMN canonical_mbid TEXT`);
+    } catch (_) { /* column already exists */ }
+
+    // Evaluation result cache - cache final evaluation results per scrobble+config
+    // Key: hash of (track, artist, album, mbid, searchConfig)
+    // This makes re-runs truly instant when nothing has changed
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS evaluation_result_cache (
+        result_hash TEXT PRIMARY KEY,
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        album TEXT,
+        mbid TEXT NOT NULL,
+        baseline_pos INTEGER NOT NULL,
+        improved_pos INTEGER NOT NULL,
+        baseline_found INTEGER NOT NULL, -- 1 = found, 0 = not found
+        improved_found INTEGER NOT NULL,
+        baseline_ndcg REAL NOT NULL,
+        improved_ndcg REAL NOT NULL,
+        failure_mode TEXT,
+        duplicate_count INTEGER,
+        search_config TEXT NOT NULL, -- JSON of search config for cache invalidation
+        evaluated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_eval_result_track_artist ON evaluation_result_cache(track, artist);
+      CREATE INDEX IF NOT EXISTS idx_eval_result_mbid ON evaluation_result_cache(mbid);
+    `);
+
+    // Add top-ID columns for work-equivalence checks (non-destructive migration)
+    try {
+      this.db.exec(`ALTER TABLE evaluation_result_cache ADD COLUMN improved_top_ids TEXT`);
+    } catch (_) { /* column already exists */ }
+    try {
+      this.db.exec(`ALTER TABLE evaluation_result_cache ADD COLUMN baseline_top_ids TEXT`);
+    } catch (_) { /* column already exists */ }
+
+    // Track correction cache - cache Last.fm track corrections
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS track_correction_cache (
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        corrected_track TEXT,
+        corrected_artist TEXT,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (track, artist)
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_track_correction_corrected ON track_correction_cache(corrected_track, corrected_artist);
+    `);
+
+    // Artist info cache - cache Last.fm artist information (MBID, aliases)
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS artist_info_cache (
+        artist TEXT PRIMARY KEY,
+        mbid TEXT,
+        aliases_json TEXT, -- JSON array of aliases
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    // Album info cache - cache Last.fm album information (MBID)
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS album_info_cache (
+        artist TEXT NOT NULL,
+        album TEXT NOT NULL,
+        mbid TEXT,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (artist, album)
+      );
+    `);
+
+    // Loved tracks table - accumulates over time
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS loved_tracks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        track TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        mbid TEXT,
+        date TEXT NOT NULL,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(username, track, artist)
+      );
+      
+      CREATE INDEX IF NOT EXISTS idx_loved_tracks_username ON loved_tracks(username);
+      CREATE INDEX IF NOT EXISTS idx_loved_tracks_mbid ON loved_tracks(mbid);
+      CREATE INDEX IF NOT EXISTS idx_loved_tracks_date ON loved_tracks(date DESC);
+    `);
+
+    // Recording work cache - maps recording MBIDs to their work IDs
+    // Used for disambiguation: two recordings of the same work are equivalent
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS recording_work_cache (
+        recording_mbid TEXT PRIMARY KEY,
+        work_id TEXT, -- null = no work relation found
+        work_title TEXT,
+        fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    // Non-destructive migration: add mbid_source columns to track MBID provenance.
+    // Prevents ground-truth circularity: only MBIDs from independent sources
+    // (lastfm_track_info, lastfm_search, track_data) are safe for eval ground truth.
+    // MBIDs from "musicbrainz_search" are circular and must be excluded.
+    try {
+      this.db.exec(`ALTER TABLE scrobbles ADD COLUMN mbid_source TEXT`);
+    } catch (_) { /* column already exists */ }
+    try {
+      this.db.exec(`ALTER TABLE mbid_cache ADD COLUMN mbid_source TEXT`);
+    } catch (_) { /* column already exists */ }
+  }
+
+  /**
+   * Get scrobbles for a user, up to limit
+   * Returns most recent first
+   */
+  getScrobbles(username: string, limit: number): Array<{
+    track: string;
+    artist: string;
+    album?: string;
+    mbid: string | null;
+    mbid_source: string | null;
+    timestamp: string;
+  }> {
+    const stmt = this.db.prepare(`
+      SELECT track, artist, album, mbid, mbid_source, timestamp
+      FROM scrobbles
+      WHERE username = ?
+      ORDER BY timestamp DESC
+      LIMIT ?
+    `);
+    return stmt.all(username, limit) as Array<{
+      track: string;
+      artist: string;
+      album?: string;
+      mbid: string | null;
+      mbid_source: string | null;
+      timestamp: string;
+    }>;
+  }
+
+  /**
+   * Get loved tracks for a user, up to limit
+   * Returns most recent first (by date added)
+   */
+  getLovedTracks(username: string, limit: number): Array<{
+    track: string;
+    artist: string;
+    mbid: string | null;
+    date: string;
+  }> {
+    const stmt = this.db.prepare(`
+      SELECT track, artist, mbid, date
+      FROM loved_tracks
+      WHERE username = ?
+      ORDER BY date DESC
+      LIMIT ?
+    `);
+    return stmt.all(username, limit) as Array<{
+      track: string;
+      artist: string;
+      mbid: string | null;
+      date: string;
+    }>;
+  }
+
+  /**
+   * Add loved tracks (idempotent - ignores duplicates)
+   */
+  addLovedTracks(
+    username: string,
+    tracks: Array<{
+      track: string;
+      artist: string;
+      mbid: string | null;
+      date: string;
+    }>
+  ): number {
+    const stmt = this.db.prepare(`
+      INSERT OR IGNORE INTO loved_tracks (username, track, artist, mbid, date)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    
+    let added = 0;
+    const insert = this.db.transaction((tracks) => {
+      for (const t of tracks) {
+        const info = stmt.run(username, t.track, t.artist, t.mbid || null, t.date);
+        if (info.changes > 0) added++;
+      }
+    });
+    
+    insert(tracks);
+    return added;
+  }
+
+  /**
+   * Get count of scrobbles for a user
+   */
+  getScrobbleCount(username: string): number {
+    const stmt = this.db.prepare(`
+      SELECT COUNT(*) as count
+      FROM scrobbles
+      WHERE username = ?
+    `);
+    const result = stmt.get(username) as { count: number };
+    return result.count;
+  }
+
+  /**
+   * Add scrobbles (idempotent - ignores duplicates).
+   * Now accepts optional mbid_source for provenance tracking.
+   */
+  addScrobbles(
+    username: string,
+    scrobbles: Array<{
+      track: string;
+      artist: string;
+      album?: string;
+      mbid: string | null;
+      mbid_source?: string | null;
+      timestamp: string;
+    }>
+  ): number {
+    const stmt = this.db.prepare(`
+      INSERT OR IGNORE INTO scrobbles (username, track, artist, album, mbid, mbid_source, timestamp)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    let added = 0;
+    const insert = this.db.transaction((scrobbles) => {
+      for (const s of scrobbles) {
+        const info = stmt.run(username, s.track, s.artist, s.album || null, s.mbid || null, s.mbid_source || null, s.timestamp);
+        if (info.changes > 0) added++;
+      }
+    });
+
+    insert(scrobbles);
+    return added;
+  }
+
+  /**
+   * Get MBID from cache
+   */
+  getMBID(track: string, artist: string): string | null | undefined {
+    const stmt = this.db.prepare(`
+      SELECT mbid FROM mbid_cache WHERE track = ? AND artist = ?
+    `);
+    const result = stmt.get(track, artist) as { mbid: string | null } | undefined;
+    return result?.mbid;
+  }
+
+  /**
+   * Cache MBID lookup (null means we tried and it doesn't exist)
+   */
+  setMBID(track: string, artist: string, mbid: string | null) {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO mbid_cache (track, artist, mbid)
+      VALUES (?, ?, ?)
+    `);
+    stmt.run(track, artist, mbid);
+  }
+
+  /**
+   * Get MBID with source provenance from cache.
+   * Returns undefined if not cached.
+   */
+  getMBIDWithSource(track: string, artist: string): { mbid: string | null; source: string | null } | undefined {
+    const stmt = this.db.prepare(`
+      SELECT mbid, mbid_source FROM mbid_cache WHERE track = ? AND artist = ?
+    `);
+    const result = stmt.get(track, artist) as { mbid: string | null; mbid_source: string | null } | undefined;
+    if (result === undefined) return undefined;
+    return { mbid: result.mbid, source: result.mbid_source };
+  }
+
+  /**
+   * Cache MBID lookup with source provenance.
+   */
+  setMBIDWithSource(track: string, artist: string, mbid: string | null, source: string | null) {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO mbid_cache (track, artist, mbid, mbid_source)
+      VALUES (?, ?, ?, ?)
+    `);
+    stmt.run(track, artist, mbid, source);
+  }
+
+  /**
+   * Get cached Last.fm track correction.
+   * - undefined: not cached
+   * - null: cached "no correction"
+   * - object: corrected values
+   */
+  getTrackCorrection(
+    track: string,
+    artist: string
+  ): { correctedTrack: string; correctedArtist: string } | null | undefined {
+    const stmt = this.db.prepare(`
+      SELECT corrected_track, corrected_artist
+      FROM track_correction_cache
+      WHERE track = ? AND artist = ?
+    `);
+    const row = stmt.get(track, artist) as
+      | { corrected_track: string | null; corrected_artist: string | null }
+      | undefined;
+    if (!row) return undefined;
+    if (!row.corrected_track || !row.corrected_artist) return null;
+    return { correctedTrack: row.corrected_track, correctedArtist: row.corrected_artist };
+  }
+
+  setTrackCorrection(
+    track: string,
+    artist: string,
+    correctedTrack: string | null,
+    correctedArtist: string | null
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO track_correction_cache (track, artist, corrected_track, corrected_artist)
+      VALUES (?, ?, ?, ?)
+    `);
+    stmt.run(track, artist, correctedTrack, correctedArtist);
+  }
+
+  /**
+   * Get cached Last.fm artist info.
+   * - undefined: not cached
+   * - null: cached "no info"
+   * - object: info
+   */
+  getArtistInfo(artist: string): { mbid: string | null; aliases?: string[] } | null | undefined {
+    const stmt = this.db.prepare(`
+      SELECT mbid, aliases_json
+      FROM artist_info_cache
+      WHERE artist = ?
+    `);
+    const row = stmt.get(artist) as { mbid: string | null; aliases_json: string | null } | undefined;
+    if (!row) return undefined;
+    if (!row.mbid && !row.aliases_json) return null;
+    let aliases: string[] | undefined;
+    if (row.aliases_json) {
+      try {
+        const parsed = JSON.parse(row.aliases_json);
+        if (Array.isArray(parsed)) aliases = parsed.filter((x) => typeof x === "string");
+      } catch {
+        // ignore parse errors; treat as no aliases
+      }
+    }
+    return { mbid: row.mbid, aliases };
+  }
+
+  setArtistInfo(artist: string, info: { mbid: string | null; aliases?: string[] } | null): void {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO artist_info_cache (artist, mbid, aliases_json)
+      VALUES (?, ?, ?)
+    `);
+    if (!info) {
+      stmt.run(artist, null, null);
+      return;
+    }
+    stmt.run(artist, info.mbid, info.aliases ? JSON.stringify(info.aliases) : null);
+  }
+
+  /**
+   * Get cached Last.fm album info.
+   * - undefined: not cached
+   * - null: cached "no info"
+   * - object: info
+   */
+  getAlbumInfo(artist: string, album: string): { mbid: string | null } | null | undefined {
+    const stmt = this.db.prepare(`
+      SELECT mbid
+      FROM album_info_cache
+      WHERE artist = ? AND album = ?
+    `);
+    const row = stmt.get(artist, album) as { mbid: string | null } | undefined;
+    if (!row) return undefined;
+    if (!row.mbid) return null;
+    return { mbid: row.mbid };
+  }
+
+  setAlbumInfo(artist: string, album: string, info: { mbid: string | null } | null): void {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO album_info_cache (artist, album, mbid)
+      VALUES (?, ?, ?)
+    `);
+    stmt.run(artist, album, info?.mbid ?? null);
+  }
+
+  /**
+   * Get cached MusicBrainz search results
+   * Cache key includes search configuration to ensure idempotency across config changes
+   */
+  /**
+   * Get cached MusicBrainz search results.
+   * Cache key is (track, artist, album, strategy) -- the actual API query params.
+   * Config flags are NOT part of the key; the caller passes already-cleaned values.
+   * Legacy overload accepts extra boolean flags (ignored in hash).
+   */
+  getSearchResults(
+    track: string,
+    artist: string,
+    album?: string,
+    _enableCleaning?: boolean,
+    _enableFuzzy?: boolean,
+    _enableMultiStage?: boolean,
+    strategy?: string
+  ): any[] | null {
+    const queryHash = this.hashSearchQuery(track, artist, album, strategy);
+    const stmt = this.db.prepare(`
+      SELECT results FROM mb_search_cache WHERE query_hash = ?
+    `);
+    const result = stmt.get(queryHash) as { results: string } | undefined;
+    if (result) {
+      return JSON.parse(result.results);
+    }
+    return null;
+  }
+
+  /**
+   * Cache MusicBrainz search results.
+   * Key: (track, artist, album, strategy) -- the actual values sent to MB API.
+   */
+  setSearchResults(
+    track: string,
+    artist: string,
+    album: string | undefined,
+    results: any[],
+    _enableCleaning?: boolean,
+    _enableFuzzy?: boolean,
+    _enableMultiStage?: boolean,
+    strategy?: string
+  ) {
+    const queryHash = this.hashSearchQuery(track, artist, album, strategy);
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO mb_search_cache (query_hash, track, artist, album, results)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    stmt.run(queryHash, track, artist, album || null, JSON.stringify(results));
+  }
+
+  /**
+   * Hash search query for cache key.
+   * Key is (track, artist, album, strategy) -- the actual MB API request params.
+   * This means changing pipeline logic (adding/removing stages) doesn't invalidate
+   * cached per-stage API responses, only the "combined" final result.
+   */
+  private hashSearchQuery(
+    track: string,
+    artist: string,
+    album?: string,
+    strategy?: string
+  ): string {
+
+    const normalizedTrack = (track || "").toLowerCase().trim();
+    const normalizedArtist = (artist || "").toLowerCase().trim();
+    const normalizedAlbum = (album || "").toLowerCase().trim();
+    const stratStr = strategy || "default";
+    const str = `${normalizedTrack}|${normalizedArtist}|${normalizedAlbum}|${stratStr}`;
+    return createHash("md5").update(str).digest("hex");
+  }
+
+  /**
+   * Get MBID validation result from cache (boolean only, for backward compat)
+   */
+  getMBIDValidation(mbid: string): boolean | undefined {
+    const stmt = this.db.prepare(`
+      SELECT is_valid FROM mbid_validation_cache WHERE mbid = ?
+    `);
+    const result = stmt.get(mbid) as { is_valid: number } | undefined;
+    return result !== undefined ? result.is_valid === 1 : undefined;
+  }
+
+  /**
+   * Get MBID validation result with HTTP status (for distinguishing confirmed vs assumed)
+   */
+  getMBIDValidationDetailed(mbid: string): { isValid: boolean; httpStatus: number | null } | undefined {
+    const stmt = this.db.prepare(`
+      SELECT is_valid, http_status FROM mbid_validation_cache WHERE mbid = ?
+    `);
+    const result = stmt.get(mbid) as { is_valid: number; http_status: number | null } | undefined;
+    if (result === undefined) return undefined;
+    return { isValid: result.is_valid === 1, httpStatus: result.http_status };
+  }
+
+  /**
+   * Get MBID validation stats by HTTP status (for diagnostics)
+   */
+  getMBIDValidationStats(): Array<{ http_status: number | null; count: number; is_valid: number }> {
+    return this.db.prepare(`
+      SELECT http_status, is_valid, COUNT(*) as count
+      FROM mbid_validation_cache
+      GROUP BY http_status, is_valid
+      ORDER BY count DESC
+    `).all() as Array<{ http_status: number | null; count: number; is_valid: number }>;
+  }
+
+  /**
+   * Count stale validation entries (503/error that need re-validation)
+   */
+  countStaleValidations(): number {
+    const result = this.db.prepare(`
+      SELECT COUNT(*) as count FROM mbid_validation_cache
+      WHERE http_status IS NULL OR http_status NOT IN (200, 301, 404)
+    `).get() as { count: number };
+    return result.count;
+  }
+
+  /**
+   * Clear stale validation entries (503/error) so they get re-validated
+   */
+  clearStaleValidations(): number {
+    const result = this.db.prepare(`
+      DELETE FROM mbid_validation_cache
+      WHERE http_status IS NULL OR http_status NOT IN (200, 301, 404)
+    `).run();
+    return result.changes;
+  }
+
+  /**
+   * Cache MBID validation result
+   */
+  setMBIDValidation(mbid: string, isValid: boolean, httpStatus?: number, errorMessage?: string, canonicalMbid?: string) {
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO mbid_validation_cache (mbid, is_valid, http_status, error_message, canonical_mbid)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    stmt.run(mbid, isValid ? 1 : 0, httpStatus || null, errorMessage || null, canonicalMbid || null);
+  }
+
+  /**
+   * Get the canonical MBID for a potentially-merged recording.
+   * Returns the canonical ID if a 301 redirect was followed, otherwise the input MBID.
+   */
+  getCanonicalMBID(mbid: string): string {
+    const stmt = this.db.prepare(`
+      SELECT canonical_mbid FROM mbid_validation_cache WHERE mbid = ?
+    `);
+    const result = stmt.get(mbid) as { canonical_mbid: string | null } | undefined;
+    return result?.canonical_mbid || mbid;
+  }
+
+  /** Check if this MBID has been merge-checked (canonical_mbid stored, even if self-referencing) */
+  hasMergeCheckResult(mbid: string): boolean {
+    const stmt = this.db.prepare(`
+      SELECT canonical_mbid FROM mbid_validation_cache WHERE mbid = ?
+    `);
+    const result = stmt.get(mbid) as { canonical_mbid: string | null } | undefined;
+    return result?.canonical_mbid != null;
+  }
+
+  /**
+   * Get statistics
+   */
+  getStats(username: string): {
+    totalScrobbles: number;
+    scrobblesWithMBID: number;
+    cachedMBIDs: number;
+    cachedSearches: number;
+    cachedValidations: number;
+    cachedEvaluationResults: number;
+  } {
+    const scrobbleCount = this.getScrobbleCount(username);
+    const withMBID = this.db
+      .prepare(`SELECT COUNT(*) as count FROM scrobbles WHERE username = ? AND mbid IS NOT NULL`)
+      .get(username) as { count: number };
+    
+    const mbidCacheCount = this.db
+      .prepare(`SELECT COUNT(*) as count FROM mbid_cache`)
+      .get() as { count: number };
+    
+    const searchCacheCount = this.db
+      .prepare(`SELECT COUNT(*) as count FROM mb_search_cache`)
+      .get() as { count: number };
+
+    const validationCacheCount = this.db
+      .prepare(`SELECT COUNT(*) as count FROM mbid_validation_cache`)
+      .get() as { count: number };
+
+    const evaluationResultCacheCount = this.db
+      .prepare(`SELECT COUNT(*) as count FROM evaluation_result_cache`)
+      .get() as { count: number };
+
+    return {
+      totalScrobbles: scrobbleCount,
+      scrobblesWithMBID: withMBID.count,
+      cachedMBIDs: mbidCacheCount.count,
+      cachedSearches: searchCacheCount.count,
+      cachedValidations: validationCacheCount.count,
+      cachedEvaluationResults: evaluationResultCacheCount.count,
+    };
+  }
+
+  /**
+   * Hash evaluation case for cache key
+   * Includes track, artist, album, mbid, and search config
+   * Uses same normalization as hashQuery for consistency
+   */
+  private hashEvaluationCase(
+    track: string,
+    artist: string,
+    album: string | undefined,
+    mbid: string,
+    searchConfig: { enableCleaning: boolean; enableFuzzy: boolean; enableMultiStage: boolean },
+    fieldCombination: string
+  ): string {
+
+    // Use same normalization as hashQuery for consistency
+    const normalizedTrack = (track || "").toLowerCase().trim();
+    const normalizedArtist = (artist || "").toLowerCase().trim();
+    const normalizedAlbum = (album || "").toLowerCase().trim();
+    const normalizedMBID = (mbid || "").toLowerCase().trim();
+    const configStr = `${searchConfig.enableCleaning ? "1" : "0"}|${searchConfig.enableFuzzy ? "1" : "0"}|${searchConfig.enableMultiStage ? "1" : "0"}`;
+    // Include fieldCombination in hash to distinguish track-only vs track+artist
+    const str = `${normalizedTrack}|${normalizedArtist}|${normalizedAlbum}|${normalizedMBID}|${configStr}|${fieldCombination}|${EVALUATION_LOGIC_VERSION}`;
+    return createHash("md5").update(str).digest("hex");
+  }
+
+  /**
+   * Get cached evaluation result
+   * Returns null if not cached
+   */
+  getEvaluationResult(
+    track: string,
+    artist: string,
+    album: string | undefined,
+    mbid: string,
+    searchConfig: { enableCleaning: boolean; enableFuzzy: boolean; enableMultiStage: boolean },
+    fieldCombination: string
+  ): {
+    baselinePos: number;
+    improvedPos: number;
+    baselineFound: boolean;
+    improvedFound: boolean;
+    baselineNDCG: number;
+    improvedNDCG: number;
+    failureMode?: string;
+    duplicateCount?: number;
+    improvedTopIds?: string[];
+    baselineTopIds?: string[];
+  } | null {
+    try {
+      const resultHash = this.hashEvaluationCase(track, artist, album, mbid, searchConfig, fieldCombination);
+      const result = this.stmtGetEvaluationResult.get(resultHash) as {
+        baseline_pos: number;
+        improved_pos: number;
+        baseline_found: number;
+        improved_found: number;
+        baseline_ndcg: number;
+        improved_ndcg: number;
+        failure_mode: string | null;
+        duplicate_count: number | null;
+        improved_top_ids: string | null;
+        baseline_top_ids: string | null;
+      } | undefined;
+
+      if (result) {
+        return {
+          baselinePos: result.baseline_pos,
+          improvedPos: result.improved_pos,
+          baselineFound: result.baseline_found === 1,
+          improvedFound: result.improved_found === 1,
+          baselineNDCG: result.baseline_ndcg,
+          improvedNDCG: result.improved_ndcg,
+          failureMode: result.failure_mode ?? undefined,
+          duplicateCount: result.duplicate_count ?? undefined,
+          improvedTopIds: result.improved_top_ids ? JSON.parse(result.improved_top_ids) : undefined,
+          baselineTopIds: result.baseline_top_ids ? JSON.parse(result.baseline_top_ids) : undefined,
+        };
+      }
+      return null;
+    } catch (error) {
+      // If cache read fails, return null (graceful degradation)
+      console.warn(`Cache read error for evaluation result: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Cache evaluation result
+   */
+  setEvaluationResult(
+    track: string,
+    artist: string,
+    album: string | undefined,
+    mbid: string,
+    searchConfig: { enableCleaning: boolean; enableFuzzy: boolean; enableMultiStage: boolean },
+    result: {
+      baselinePos: number;
+      improvedPos: number;
+      baselineFound: boolean;
+      improvedFound: boolean;
+      baselineNDCG: number;
+      improvedNDCG: number;
+      failureMode?: string;
+      duplicateCount?: number;
+      improvedTopIds?: string[];
+      baselineTopIds?: string[];
+    },
+    fieldCombination: string
+  ) {
+    try {
+      const resultHash = this.hashEvaluationCase(track, artist, album, mbid, searchConfig, fieldCombination);
+      this.stmtSetEvaluationResult.run(
+        resultHash,
+        track,
+        artist,
+        album || null,
+        mbid,
+        result.baselinePos,
+        result.improvedPos,
+        result.baselineFound ? 1 : 0,
+        result.improvedFound ? 1 : 0,
+        result.baselineNDCG,
+        result.improvedNDCG,
+        result.failureMode ?? null,
+        result.duplicateCount ?? null,
+        JSON.stringify(searchConfig),
+        result.improvedTopIds ? JSON.stringify(result.improvedTopIds) : null,
+        result.baselineTopIds ? JSON.stringify(result.baselineTopIds) : null,
+      );
+    } catch (error) {
+      // If cache write fails, log warning but don't fail evaluation
+      console.warn(`Cache write error for evaluation result: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Clear evaluation result cache (useful when search logic changes)
+   */
+  clearEvaluationResultCache() {
+    try {
+      const stmt = this.db.prepare(`DELETE FROM evaluation_result_cache`);
+      stmt.run();
+    } catch (error) {
+      console.warn(`Error clearing evaluation result cache: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Get cached work ID for a recording MBID
+   */
+  getRecordingWork(recordingMbid: string): { workId: string | null; workTitle: string | null } | undefined {
+    const result = this.db.prepare(`
+      SELECT work_id, work_title FROM recording_work_cache WHERE recording_mbid = ?
+    `).get(recordingMbid) as { work_id: string | null; work_title: string | null } | undefined;
+    if (result === undefined) return undefined;
+    return { workId: result.work_id, workTitle: result.work_title };
+  }
+
+  /**
+   * Cache recording -> work mapping
+   */
+  setRecordingWork(recordingMbid: string, workId: string | null, workTitle: string | null) {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO recording_work_cache (recording_mbid, work_id, work_title)
+      VALUES (?, ?, ?)
+    `).run(recordingMbid, workId, workTitle);
+  }
+
+  close() {
+    this.db.close();
+  }
+}
+
+

--- a/scripts/eval/evaluate.ts
+++ b/scripts/eval/evaluate.ts
@@ -1,0 +1,1128 @@
+#!/usr/bin/env node
+/**
+ * Evaluate MusicBrainz matching using Last.fm scrobbles
+ *
+ * PURPOSE:
+ * - Measure if improved matching (cleaning + multi-stage) finds correct MBIDs better than baseline
+ * - Addresses original problem: "funny search string" and "song disambiguation is the hardest part"
+ * - Tests real-world scenarios: featuring artists, remixes, live versions, typos
+ *
+ * Usage:
+ *   pnpm tsx scripts/eval/evaluate.ts [--limit N] [--all] [--username USER] [--auth-only]
+ *
+ * Options:
+ *   --limit N              Number of scrobbles to evaluate (default: 1000)
+ *   --all                  Evaluate using all cached scrobbles for the user
+ *   --username USER        Use public API for username (skips OAuth)
+ *   --auth-only            Perform OAuth and cache the session key, then exit
+ *   --no-cleaning          Disable name cleaning
+ *   --no-fuzzy             Disable fuzzy matching
+ *   --no-multistage        Disable multi-stage search
+ *   --no-parallel          Disable parallel evaluation (parallel enabled by default)
+ *   --concurrency N        Parallel concurrency (default: 5)
+ *   --refresh-scrobbles    Force refresh cache (re-fetch scrobbles; still accumulates)
+ *   --use-additional-apis  Allow extra API calls to backfill missing MBIDs (slower)
+ *
+ * Caching:
+ *   SQLite cache at ~/.teal_eval_cache/lastfm_eval.db accumulates over time
+ */
+
+import { join } from "path";
+import { config } from "dotenv";
+import {
+  type SearchConfig,
+  type EvaluationCase,
+  type MBIDSource,
+  GROUND_TRUTH_SOURCES,
+  MUSICBRAINZ_BASE_URL,
+  USER_AGENT,
+  RATE_LIMIT_DELAY,
+  formatTime,
+  calculateETA,
+  createAPIMetrics,
+} from "./types.js";
+import { getLastFMSession } from "./auth.js";
+import { getRecentTracks } from "./lastfm-api.js";
+import { getTrackMBID, validateMBID, areRecordingsWorkEquivalent } from "./mbid-resolution.js";
+import { baselineSearch, improvedSearchWithConfig } from "./search.js";
+import { ndcg } from "./statistics.js";
+import { categorizeFailureMode, classifyHardness, reportResults } from "./reporting.js";
+import { LastFMCache } from "./evaluate-lastfm-cache.js";
+
+// Load .env from repo root
+const SCRIPT_DIR = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
+const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
+const envResult = config({ path: join(REPO_ROOT, ".env") });
+if (envResult.error) {
+  console.warn(`Warning: Could not load .env file: ${envResult.error.message}`);
+  console.warn(`  Expected at: ${join(REPO_ROOT, ".env")}`);
+  console.warn(`  Copy .env.template to .env and fill in your values.\n`);
+}
+
+// Proxy support: route all fetch calls through a proxy when PROXY_URL is set.
+function setupProxy() {
+  const proxyUrl = process.env.PROXY_URL;
+  if (!proxyUrl) return;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ProxyAgent, setGlobalDispatcher } = require("undici");
+    setGlobalDispatcher(new ProxyAgent(proxyUrl));
+    console.log(`Proxy enabled: ${proxyUrl.replace(/\/\/[^@]+@/, "//***@")}`);
+  } catch (e) {
+    console.warn(`Proxy setup failed: ${e instanceof Error ? e.message : e}`);
+    console.warn("Continuing without proxy.\n");
+  }
+}
+setupProxy();
+
+const LASTFM_API_KEY = process.env.LASTFM_API_KEY;
+const LASTFM_API_SECRET = process.env.LASTFM_API_SECRET;
+
+const HAS_LASTFM_KEYS = !!(LASTFM_API_KEY && LASTFM_API_SECRET);
+if (!HAS_LASTFM_KEYS) {
+  console.warn("Warning: LASTFM_API_KEY/LASTFM_API_SECRET not found in environment");
+  console.warn("Will attempt to run from cached scrobbles only.\n");
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const startTime = Date.now();
+  const args = process.argv.slice(2);
+
+  const limitArg = args.findIndex((a) => a === "--limit");
+  const limit = limitArg >= 0 ? parseInt(args[limitArg + 1]) || 1000 : 1000;
+  const useAll = args.includes("--all");
+  const authOnly = args.includes("--auth-only");
+
+  const cache = new LastFMCache();
+
+  const usernameArg = args.findIndex((a) => a === "--username");
+  const username = usernameArg >= 0 ? args[usernameArg + 1] : undefined;
+
+  const apiMetrics = createAPIMetrics();
+
+  // Feature flags
+  const noCleaning = args.includes("--no-cleaning");
+  const noFuzzy = args.includes("--no-fuzzy");
+  const noMultiStage = args.includes("--no-multistage");
+  const parallel = !args.includes("--no-parallel");
+  const concurrency = parallel
+    ? (args.findIndex((a) => a === "--concurrency") >= 0
+      ? parseInt(args[args.findIndex((a) => a === "--concurrency") + 1]) || 5
+      : 5)
+    : 1;
+  const useAdditionalAPIs = args.includes("--use-additional-apis");
+
+  const searchConfig: SearchConfig = {
+    enableCleaning: !noCleaning,
+    enableFuzzy: !noFuzzy,
+    enableMultiStage: !noMultiStage,
+  };
+
+  console.log("=".repeat(60));
+  console.log("MusicBrainz Matching Evaluation");
+  console.log("=".repeat(60));
+  console.log();
+
+  if (noCleaning || noFuzzy || noMultiStage || parallel || useAdditionalAPIs || useAll) {
+    console.log("CONFIGURATION:");
+    console.log(`  Cleaning: ${searchConfig.enableCleaning ? "enabled" : "disabled"}`);
+    console.log(`  Fuzzy matching: ${searchConfig.enableFuzzy ? "enabled" : "disabled"}`);
+    console.log(`  Multi-stage: ${searchConfig.enableMultiStage ? "enabled" : "disabled"}`);
+    if (parallel) {
+      console.log(`  Parallel: enabled (concurrency: ${concurrency})`);
+    } else {
+      console.log(`  Parallel: disabled (--no-parallel)`);
+    }
+    if (useAdditionalAPIs) {
+      console.log(`  Additional APIs: enabled (MusicBrainz ISRC lookup for MBID resolution)`);
+    }
+    if (useAll) {
+      console.log(`  Dataset: all cached scrobbles`);
+    }
+    console.log();
+  }
+
+  // ── Scrobble types (with provenance) ──────────────────────────────
+
+  let scrobbles: Array<{
+    track: string;
+    artist: string;
+    album?: string;
+    mbid: string | null;
+    mbid_source: MBIDSource | null;
+  }> = [];
+
+  let validScrobbles: typeof scrobbles = [];
+
+  // ── Authentication ────────────────────────────────────────────────
+
+  let sessionKey: string | undefined;
+  let targetUsername = username;
+
+  if (HAS_LASTFM_KEYS) {
+    if (!username) {
+      console.log("No username provided - using OAuth authentication\n");
+      try {
+        sessionKey = await getLastFMSession(LASTFM_API_KEY!, LASTFM_API_SECRET!);
+      } catch (error: unknown) {
+        console.error(`\n  OAuth Error: ${error instanceof Error ? error.message : String(error)}`);
+        console.log("\nTo use public API instead, set LASTFM_USERNAME in .env or use --username USER");
+        process.exit(1);
+      }
+    } else {
+      console.log(`Using public API for username: ${username}\n`);
+    }
+
+    if (authOnly) {
+      console.log("\nAuthenticated. Session key is cached locally.");
+      cache.close();
+      return;
+    }
+
+    if (sessionKey && !targetUsername) {
+      console.log("Using authenticated session (no username lookup needed)...");
+      targetUsername = "";
+    }
+  } else {
+    if (authOnly) {
+      console.error("Error: --auth-only requires LASTFM_API_KEY and LASTFM_API_SECRET");
+      process.exit(1);
+    }
+    targetUsername = targetUsername || "authenticated";
+    console.log(`Running in cache-only mode (no Last.fm API keys). Using cached user: "${targetUsername}"\n`);
+  }
+
+  if (!targetUsername && !sessionKey) {
+    throw new Error("No username available. Provide --username or authenticate via OAuth.");
+  }
+
+  const cacheUsername = targetUsername || (sessionKey ? "authenticated" : "");
+
+  // Show cache stats
+  const stats = cache.getStats(cacheUsername);
+  console.log("CACHE STATS (All accumulate over time, never cleared):");
+  console.log(`  Total scrobbles: ${stats.totalScrobbles}`);
+  console.log(`  With MBIDs: ${stats.scrobblesWithMBID}`);
+  console.log(`  Cached MBID lookups: ${stats.cachedMBIDs}`);
+  console.log(`  Cached MusicBrainz searches: ${stats.cachedSearches}`);
+  console.log(`  Cached MBID validations: ${stats.cachedValidations}\n`);
+
+  const desiredLimit = useAll ? stats.totalScrobbles : limit;
+
+  // ── Fetch scrobbles ───────────────────────────────────────────────
+
+  const cachedScrobbles = cache.getScrobbles(cacheUsername, desiredLimit);
+  const refresh = args.includes("--refresh-scrobbles");
+
+  let fromCache = 0;
+  let fetched = 0;
+  let added = 0;
+
+  if (!refresh && cachedScrobbles.length >= desiredLimit) {
+    scrobbles = cachedScrobbles.slice(0, desiredLimit).map((s) => ({
+      track: s.track,
+      artist: s.artist,
+      album: s.album,
+      mbid: s.mbid,
+      mbid_source: (s.mbid_source as MBIDSource) || null,
+    }));
+    fromCache = scrobbles.length;
+    console.log(`Using ${fromCache} scrobbles from cache (${stats.totalScrobbles} total available)\n`);
+  } else {
+    if (!HAS_LASTFM_KEYS) {
+      if (cachedScrobbles.length > 0) {
+        console.warn(`Only ${cachedScrobbles.length} cached scrobbles available (requested ${desiredLimit}).`);
+        console.log(`Falling back to ${cachedScrobbles.length} cached scrobbles (no Last.fm API keys).\n`);
+        scrobbles = cachedScrobbles.map((s) => ({
+          track: s.track,
+          artist: s.artist,
+          album: s.album,
+          mbid: s.mbid,
+          mbid_source: (s.mbid_source as MBIDSource) || null,
+        }));
+        fromCache = scrobbles.length;
+      } else {
+        console.error("Error: No cached scrobbles and no Last.fm API keys. Set LASTFM_API_KEY and LASTFM_API_SECRET.");
+        process.exit(1);
+      }
+    } else {
+      const needCount = useAll
+        ? Number.MAX_SAFE_INTEGER
+        : (refresh ? desiredLimit : Math.max(0, desiredLimit - cachedScrobbles.length));
+
+      if (needCount > 0) {
+        if (refresh) {
+          console.log(`Fetching ${needCount} fresh scrobbles (--refresh flag)...\n`);
+        } else {
+          console.log(`Fetching ${needCount} additional scrobbles (${cachedScrobbles.length} already cached)...\n`);
+        }
+
+        const pagesNeeded = useAll ? Number.MAX_SAFE_INTEGER : Math.ceil(needCount / 200);
+        const allTracks: Array<{
+          name: string;
+          artist: { "#text": string; mbid?: string };
+          album?: { "#text": string };
+          mbid?: string;
+          "@attr"?: { nowplaying?: string };
+          date?: { "#text": string; uts: string };
+        }> = [];
+
+        const fetchStartTime = Date.now();
+        for (let page = 1; page <= pagesNeeded && allTracks.length < needCount; page++) {
+          const pageLimit = Math.min(200, needCount - allTracks.length);
+          const pageStartTime = Date.now();
+          const pageTracks = await getRecentTracks(
+            LASTFM_API_KEY!,
+            LASTFM_API_SECRET!,
+            targetUsername || "",
+            pageLimit,
+            sessionKey,
+            page,
+          );
+          if (useAll && pageTracks.length === 0) break;
+          allTracks.push(...pageTracks);
+          fetched += pageTracks.length;
+
+          const pageElapsed = Date.now() - pageStartTime;
+          const totalElapsed = Date.now() - fetchStartTime;
+          const avgTimePerPage = totalElapsed / page;
+          const remainingPages = useAll ? 0 : (pagesNeeded - page);
+          const etaMs = avgTimePerPage * remainingPages;
+
+          if (!useAll) {
+            console.log(`  Page ${page}/${pagesNeeded}: ${fetched}/${needCount} scrobbles (${formatTime(pageElapsed)}, ETA: ${formatTime(etaMs)})`);
+          } else if (page % 25 === 0) {
+            console.log(`  Page ${page}: fetched=${fetched} (${formatTime(pageElapsed)})`);
+          }
+
+          if (page < pagesNeeded) {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+        }
+
+        const fetchElapsed = Date.now() - fetchStartTime;
+        console.log(`Downloaded ${fetched} scrobbles in ${formatTime(fetchElapsed)}\n`);
+
+        // ── Resolve MBIDs with provenance tracking ──────────────────
+
+        if (sessionKey) {
+          console.log("Resolving MBIDs (using cache + parallel fetching)...");
+
+          const scrobblesToAdd: Array<{
+            track: string;
+            artist: string;
+            album?: string;
+            mbid: string | null;
+            mbid_source: MBIDSource | null;
+            timestamp: string;
+          }> = [];
+
+          // First pass: check cache and extract from track data
+          // FIX: Only use track.mbid (recording MBID), NOT track.artist.mbid
+          // The artist MBID is NOT a recording MBID -- using it would store wrong data.
+          const tracksNeedingMBID: Array<{
+            track: typeof allTracks[0];
+            mbid: string | null;
+            mbid_source: MBIDSource | null;
+          }> = [];
+          let cacheHits = 0;
+
+          for (const track of allTracks) {
+            // Check provenance-aware cache first
+            const cached = cache.getMBIDWithSource(track.name, track.artist["#text"]);
+
+            if (cached !== undefined) {
+              cacheHits++;
+              tracksNeedingMBID.push({
+                track,
+                mbid: cached.mbid,
+                mbid_source: (cached.source as MBIDSource) || null,
+              });
+            } else if (track.mbid) {
+              // Track's own MBID (from Last.fm scrobble data) -- independent ground truth
+              cache.setMBIDWithSource(track.name, track.artist["#text"], track.mbid, "track_data");
+              tracksNeedingMBID.push({ track, mbid: track.mbid, mbid_source: "track_data" });
+            } else {
+              tracksNeedingMBID.push({ track, mbid: null, mbid_source: null });
+            }
+          }
+
+          if (cacheHits > 0) {
+            console.log(`  ${cacheHits}/${allTracks.length} MBIDs found in cache`);
+          }
+
+          const alreadyHaveMBID = tracksNeedingMBID.filter((t) => t.mbid).length;
+          const needMBID = tracksNeedingMBID.filter((t) => !t.mbid);
+
+          console.log(`  ${alreadyHaveMBID}/${allTracks.length} have MBIDs (from cache or track data)`);
+
+          if (needMBID.length > 0) {
+            console.log(`  Fetching MBIDs for ${needMBID.length} tracks in parallel (concurrency: ${concurrency})...`);
+            if (useAdditionalAPIs) {
+              console.log(`  Additional APIs enabled: MusicBrainz ISRC lookup (fallback if Last.fm fails)`);
+            }
+
+            const mbidChunks: Array<typeof needMBID> = [];
+            for (let i = 0; i < needMBID.length; i += concurrency) {
+              mbidChunks.push(needMBID.slice(i, i + concurrency));
+            }
+
+            const mbidFetchStartTime = Date.now();
+            for (let chunkIdx = 0; chunkIdx < mbidChunks.length; chunkIdx++) {
+              const chunk = mbidChunks[chunkIdx];
+              const chunkStartTime = Date.now();
+              const mbidPromises = chunk.map(async (item) => {
+                const result = await getTrackMBID(
+                  item.track.name,
+                  item.track.artist["#text"],
+                  LASTFM_API_KEY!,
+                  LASTFM_API_SECRET!,
+                  sessionKey!,
+                  cache,
+                  useAdditionalAPIs,
+                  apiMetrics,
+                );
+                return { ...item, mbid: result.mbid, mbid_source: result.source };
+              });
+
+              const results = await Promise.all(mbidPromises);
+              for (const result of results) {
+                const idx = tracksNeedingMBID.findIndex((t) => t.track === result.track);
+                if (idx >= 0) {
+                  tracksNeedingMBID[idx].mbid = result.mbid;
+                  tracksNeedingMBID[idx].mbid_source = result.mbid_source;
+                }
+              }
+
+              const chunkElapsed = Date.now() - chunkStartTime;
+              const totalElapsed = Date.now() - mbidFetchStartTime;
+              const fetchedCount = tracksNeedingMBID.filter((t) => t.mbid).length;
+
+              if (chunkIdx % 5 === 0 || chunkIdx === mbidChunks.length - 1) {
+                const avgTimePerChunk = totalElapsed / (chunkIdx + 1);
+                const remainingChunks = mbidChunks.length - (chunkIdx + 1);
+                const etaMs = avgTimePerChunk * remainingChunks;
+                const progress = ((fetchedCount / allTracks.length) * 100).toFixed(1);
+                console.log(`  Batch ${chunkIdx + 1}/${mbidChunks.length}: ${fetchedCount}/${allTracks.length} MBIDs (${progress}%, ${formatTime(chunkElapsed)}, ETA: ${formatTime(etaMs)})`);
+              }
+
+              if (chunkIdx < mbidChunks.length - 1) {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+              }
+            }
+
+            const mbidFetchElapsed = Date.now() - mbidFetchStartTime;
+            const finalFetched = tracksNeedingMBID.filter((t) => t.mbid).length;
+            console.log(`  MBID resolution complete: ${finalFetched}/${allTracks.length} in ${formatTime(mbidFetchElapsed)}`);
+          }
+
+          // Convert to scrobbles format and add to cache (with provenance)
+          for (const item of tracksNeedingMBID) {
+            const timestamp = item.track.date?.["#text"] || new Date().toISOString();
+            scrobblesToAdd.push({
+              track: item.track.name,
+              artist: item.track.artist["#text"],
+              album: item.track.album?.["#text"],
+              mbid: item.mbid || null,
+              mbid_source: item.mbid_source || null,
+              timestamp,
+            });
+          }
+
+          added = cache.addScrobbles(cacheUsername, scrobblesToAdd);
+          console.log(`  Added ${added} new scrobbles to cache (${scrobblesToAdd.length - added} were duplicates)\n`);
+
+          const mbidCount = tracksNeedingMBID.filter((t) => t.mbid).length;
+          console.log(`  ${mbidCount}/${allTracks.length} scrobbles have MBIDs (${(mbidCount / allTracks.length * 100).toFixed(1)}%)\n`);
+        } else {
+          // Public API path -- use track.mbid only (not artist MBID)
+          const scrobblesToAdd = allTracks.map((track) => ({
+            track: track.name,
+            artist: track.artist["#text"],
+            album: track.album?.["#text"],
+            mbid: track.mbid || null,
+            mbid_source: (track.mbid ? "track_data" : null) as MBIDSource | null,
+            timestamp: track.date?.["#text"] || new Date().toISOString(),
+          }));
+          added = cache.addScrobbles(cacheUsername, scrobblesToAdd);
+          console.log(`  Added ${added} new scrobbles to cache\n`);
+        }
+      }
+
+      // Get final scrobbles from cache (now includes newly added)
+      const finalScrobbles = cache.getScrobbles(cacheUsername, desiredLimit);
+      scrobbles = finalScrobbles.map((s) => ({
+        track: s.track,
+        artist: s.artist,
+        album: s.album,
+        mbid: s.mbid,
+        mbid_source: (s.mbid_source as MBIDSource) || null,
+      }));
+      fromCache = finalScrobbles.length;
+
+      if (added > 0) {
+        console.log(`Cache updated: ${added} new scrobbles added, ${fromCache} total available\n`);
+      }
+    } // end HAS_LASTFM_KEYS else
+  }
+
+  // ── Ground-truth filtering ────────────────────────────────────────
+  // CRITICAL FIX: Only use MBIDs with ground-truth-safe provenance.
+  // MBIDs obtained via MusicBrainz search are circular (we'd measure
+  // whether search finds the same result that search found).
+
+  console.log("Evaluating matching performance...\n");
+
+  if (validScrobbles.length === 0) {
+    validScrobbles = scrobbles.filter((s) => {
+      if (!s.mbid) return false;
+      // If we have provenance info, enforce ground-truth safety
+      if (s.mbid_source) {
+        return GROUND_TRUTH_SOURCES.has(s.mbid_source);
+      }
+      // Legacy data without provenance: allow (conservative -- these are
+      // pre-existing cache entries from before provenance tracking)
+      return true;
+    });
+  }
+
+  if (validScrobbles.length === 0) {
+    console.error("Error: No scrobbles with MBIDs found for evaluation");
+    console.error("  For Last.fm: Ensure you're authenticated (OAuth) to get MBIDs");
+    process.exit(1);
+  }
+
+  // ── MBID validation ───────────────────────────────────────────────
+
+  if (useAdditionalAPIs && validScrobbles.length > 0) {
+    console.log(`Validating ${validScrobbles.length} MBIDs against MusicBrainz (ensuring ground truth quality)...`);
+    const validationStartTime = Date.now();
+    let validatedCount = 0;
+    let invalidCount = 0;
+
+    const validationChunks: Array<typeof validScrobbles> = [];
+    const validationConcurrency = 3;
+    for (let i = 0; i < validScrobbles.length; i += validationConcurrency) {
+      validationChunks.push(validScrobbles.slice(i, i + validationConcurrency));
+    }
+
+    const validScrobblesSet = new Set<typeof validScrobbles[0]>();
+
+    for (let chunkIdx = 0; chunkIdx < validationChunks.length; chunkIdx++) {
+      const chunk = validationChunks[chunkIdx];
+      const validationPromises = chunk.map(async (s) => {
+        const isValid = await validateMBID(s.mbid!, cache, apiMetrics);
+        return { scrobble: s, isValid };
+      });
+
+      const results = await Promise.all(validationPromises);
+      for (const result of results) {
+        if (result.isValid) {
+          validatedCount++;
+          validScrobblesSet.add(result.scrobble);
+        } else {
+          invalidCount++;
+        }
+      }
+
+      if (chunkIdx % 50 === 0 || chunkIdx === validationChunks.length - 1) {
+        const progress = ((chunkIdx + 1) / validationChunks.length * 100).toFixed(1);
+        console.log(`  Validated ${chunkIdx + 1}/${validationChunks.length} chunks (${progress}%): ${validatedCount} valid, ${invalidCount} invalid`);
+      }
+    }
+
+    validScrobbles = Array.from(validScrobblesSet);
+
+    const validationElapsed = Date.now() - validationStartTime;
+    console.log(`MBID validation complete: ${validatedCount} valid, ${invalidCount} invalid (removed from evaluation) in ${formatTime(validationElapsed)}`);
+    if (invalidCount > 0) {
+      console.log(`  (Removed ${invalidCount} invalid MBIDs to ensure ground truth quality)\n`);
+    } else {
+      console.log();
+    }
+  }
+
+  if (validScrobbles.length === 0 && scrobbles.length > 0) {
+    validScrobbles = scrobbles.filter((s) => s.mbid);
+  }
+
+  // Pre-validate all MBIDs
+  if (validScrobbles.length > 0) {
+    console.log("Pre-validating MBIDs (ensures ground truth quality)...");
+    const preValidationStartTime = Date.now();
+
+    const validationStats = cache.getMBIDValidationStats();
+    if (validationStats.length > 0) {
+      console.log("  Validation cache breakdown:");
+      for (const row of validationStats) {
+        const status = row.http_status === null ? "unknown" : String(row.http_status);
+        const validity = row.is_valid ? "valid" : "invalid";
+        console.log(`    HTTP ${status} (${validity}): ${row.count}`);
+      }
+    }
+
+    const staleCount = cache.countStaleValidations();
+    if (staleCount > 0) {
+      const cleared = cache.clearStaleValidations();
+      console.log(`  Cleared ${cleared} stale validation entries (503/error) for re-validation`);
+    }
+
+    const mbidsToValidate = new Set<string>();
+    const mbidsConfirmedValid = new Set<string>();
+    const mbidsConfirmedInvalid = new Set<string>();
+
+    for (const s of validScrobbles) {
+      if (s.mbid) {
+        const cached = cache.getMBIDValidationDetailed(s.mbid);
+        if (cached === undefined) {
+          mbidsToValidate.add(s.mbid);
+        } else if (cached.httpStatus === 200 || cached.httpStatus === 301) {
+          mbidsConfirmedValid.add(s.mbid);
+        } else if (cached.httpStatus === 404) {
+          mbidsConfirmedInvalid.add(s.mbid);
+        } else {
+          mbidsToValidate.add(s.mbid);
+        }
+      }
+    }
+
+    const uniqueMBIDsToValidate = Array.from(mbidsToValidate);
+    console.log(`  ${mbidsConfirmedValid.size} confirmed valid (HTTP 200)`);
+    console.log(`  ${mbidsConfirmedInvalid.size} confirmed invalid (HTTP 404)`);
+    console.log(`  ${uniqueMBIDsToValidate.length} need validation`);
+
+    if (uniqueMBIDsToValidate.length > 0) {
+      console.log(`  Validating ${uniqueMBIDsToValidate.length} unique MBIDs (concurrency: ${concurrency})...`);
+
+      const validationChunks: string[][] = [];
+      for (let i = 0; i < uniqueMBIDsToValidate.length; i += concurrency) {
+        validationChunks.push(uniqueMBIDsToValidate.slice(i, i + concurrency));
+      }
+
+      let validatedCount = 0;
+      let invalidCount = 0;
+
+      for (let chunkIdx = 0; chunkIdx < validationChunks.length; chunkIdx++) {
+        const chunk = validationChunks[chunkIdx];
+        const validationPromises = chunk.map(async (mbid) => {
+          const isValid = await validateMBID(mbid, cache, apiMetrics);
+          return { mbid, isValid };
+        });
+
+        const results = await Promise.all(validationPromises);
+        for (const { isValid } of results) {
+          if (isValid) validatedCount++;
+          else invalidCount++;
+        }
+
+        if (chunkIdx % 50 === 0 || chunkIdx === validationChunks.length - 1) {
+          const progress = ((chunkIdx + 1) / validationChunks.length * 100).toFixed(1);
+          console.log(`  Validated ${chunkIdx + 1}/${validationChunks.length} chunks (${progress}%): ${validatedCount} valid, ${invalidCount} invalid`);
+        }
+      }
+
+      const preValidationElapsed = Date.now() - preValidationStartTime;
+      console.log(`Pre-validation: ${validatedCount} valid, ${invalidCount} invalid in ${formatTime(preValidationElapsed)}`);
+    } else {
+      console.log(`  All MBIDs already validated (cached)\n`);
+    }
+
+    // Detect merged recordings (HTTP 200 entries that are actually 301 redirects).
+    // Old code followed redirects transparently; new code uses redirect:"manual".
+    // Re-check valid MBIDs that lack canonical_mbid to catch merges.
+    const mbidsNeedingMergeCheck = new Set<string>();
+    for (const s of validScrobbles) {
+      if (!s.mbid) continue;
+      const cached = cache.getMBIDValidationDetailed(s.mbid);
+      if (cached?.httpStatus === 200 && !cache.hasMergeCheckResult(s.mbid)) {
+        // HTTP 200 but never merge-checked with redirect:"manual"
+        mbidsNeedingMergeCheck.add(s.mbid);
+      }
+    }
+
+    if (mbidsNeedingMergeCheck.size > 0) {
+      const mergeCheckMBIDs = Array.from(mbidsNeedingMergeCheck);
+      console.log(`Checking ${mergeCheckMBIDs.length} valid MBIDs for merged recordings...`);
+      let mergeCount = 0;
+
+      const mergeChunks: string[][] = [];
+      for (let i = 0; i < mergeCheckMBIDs.length; i += concurrency) {
+        mergeChunks.push(mergeCheckMBIDs.slice(i, i + concurrency));
+      }
+
+      for (let ci = 0; ci < mergeChunks.length; ci++) {
+        const chunk = mergeChunks[ci];
+        const promises = chunk.map(async (mbid) => {
+          const delay = RATE_LIMIT_DELAY;
+          await new Promise((resolve) => setTimeout(resolve, delay));
+
+          const lookupUrl = `${MUSICBRAINZ_BASE_URL}/recording/${mbid}?fmt=json`;
+          try {
+            const res = await fetch(lookupUrl, {
+              headers: { "User-Agent": USER_AGENT },
+              redirect: "manual",
+            });
+            if (apiMetrics) apiMetrics.musicbrainzCalls++;
+
+            if (res.status === 301) {
+              const location = res.headers.get("location");
+              let canonicalMbid: string | undefined;
+              if (location) {
+                const match = location.match(/\/recording\/([0-9a-f-]{36})/);
+                if (match) canonicalMbid = match[1];
+              }
+              if (canonicalMbid) {
+                cache.setMBIDValidation(mbid, true, 301, `merged -> ${canonicalMbid}`, canonicalMbid);
+                return true; // was merged
+              }
+            } else if (res.status === 200) {
+              // Confirmed not merged -- store self-reference so we don't re-check
+              cache.setMBIDValidation(mbid, true, 200, null, mbid);
+            }
+          } catch {
+            // Skip on error, keep existing cache entry
+          }
+          return false;
+        });
+
+        const results = await Promise.all(promises);
+        mergeCount += results.filter(Boolean).length;
+
+        if (ci % 100 === 0 || ci === mergeChunks.length - 1) {
+          const progress = ((ci + 1) / mergeChunks.length * 100).toFixed(1);
+          console.log(`  ${ci + 1}/${mergeChunks.length} chunks (${progress}%): ${mergeCount} merges found`);
+        }
+      }
+      console.log(`  Merge detection complete: ${mergeCount} merged recordings resolved\n`);
+    }
+
+    // Filter to only confirmed-valid MBIDs (HTTP 200 or 301 merged)
+    const invalidScrobbles: typeof validScrobbles = [];
+    validScrobbles = validScrobbles.filter((s) => {
+      if (!s.mbid) return false;
+      const cached = cache.getMBIDValidationDetailed(s.mbid);
+      const valid = cached !== undefined && (cached.httpStatus === 200 || cached.httpStatus === 301);
+      if (!valid && s.mbid) invalidScrobbles.push(s);
+      return valid;
+    });
+    console.log(`  Filtered to ${validScrobbles.length} scrobbles with confirmed-valid MBIDs`);
+
+    // Recover 404-MBID scrobbles via ListenBrainz ACR fallback.
+    // The listenbrainz-resolve.ts script populates mbid_cache with
+    // source="listenbrainz_acr" for tracks whose Last.fm MBID is 404.
+    if (invalidScrobbles.length > 0) {
+      let recovered = 0;
+      for (const s of invalidScrobbles) {
+        const lbResult = cache.getMBIDWithSource(s.track, s.artist);
+        if (lbResult?.mbid && lbResult.source === "listenbrainz_acr") {
+          validScrobbles.push({
+            ...s,
+            mbid: lbResult.mbid,
+            mbid_source: "listenbrainz_acr" as MBIDSource,
+          });
+          recovered++;
+        }
+      }
+      if (recovered > 0) {
+        console.log(`  Recovered ${recovered} scrobbles via ListenBrainz ACR fallback`);
+      }
+    }
+    console.log();
+  }
+
+  // ── No ground truth mode ──────────────────────────────────────────
+
+  if (validScrobbles.length === 0) {
+    console.log("No scrobbles with MBIDs found. Evaluating without ground truth...\n");
+    console.log("(This mode compares result counts, not accuracy)\n");
+
+    let baselineCount = 0;
+    let improvedCount = 0;
+    let baselineTotalResults = 0;
+    let improvedTotalResults = 0;
+
+    for (let i = 0; i < scrobbles.length; i++) {
+      const s = scrobbles[i];
+      if (i % 10 === 0 || i === scrobbles.length - 1) {
+        console.log(`  Evaluating ${i + 1}/${scrobbles.length}: "${s.track}" by ${s.artist}...`);
+      }
+      const baselineRes = await baselineSearch(s.track, s.artist, s.album, cache, apiMetrics);
+      const improvedRes = await improvedSearchWithConfig(s.track, s.artist, s.album, searchConfig, cache, apiMetrics);
+      if (baselineRes.length > 0) baselineCount++;
+      if (improvedRes.length > 0) improvedCount++;
+      baselineTotalResults += baselineRes.length;
+      improvedTotalResults += improvedRes.length;
+    }
+
+    console.log("\nBASELINE (Simple Query):");
+    console.log(`  Found results: ${baselineCount}/${scrobbles.length} (${(baselineCount / scrobbles.length * 100).toFixed(1)}%)`);
+    console.log(`  Avg results per query: ${(baselineTotalResults / scrobbles.length).toFixed(1)}`);
+    console.log("\nIMPROVED (Cleaning + Multi-Stage):");
+    console.log(`  Found results: ${improvedCount}/${scrobbles.length} (${(improvedCount / scrobbles.length * 100).toFixed(1)}%)`);
+    console.log(`  Avg results per query: ${(improvedTotalResults / scrobbles.length).toFixed(1)}`);
+    console.log(`\nIMPROVEMENT: +${improvedCount - baselineCount} scrobbles (${((improvedCount - baselineCount) / scrobbles.length * 100).toFixed(1)}%)`);
+    cache.close();
+    return;
+  }
+
+  // ── Evaluation with ground truth ──────────────────────────────────
+
+  // Deduplicate scrobbles by (track, artist, mbid)
+  const deduplicationKey = (s: typeof validScrobbles[0]) =>
+    `${s.track.toLowerCase().trim()}::${s.artist.toLowerCase().trim()}::${s.mbid}`;
+
+  const seen = new Map<string, typeof validScrobbles[0] & { count: number }>();
+  for (const s of validScrobbles) {
+    const key = deduplicationKey(s);
+    if (seen.has(key)) {
+      seen.get(key)!.count++;
+    } else {
+      seen.set(key, { ...s, count: 1 });
+    }
+  }
+
+  const uniqueScrobbles = Array.from(seen.values());
+  const duplicateStats = {
+    total: validScrobbles.length,
+    unique: uniqueScrobbles.length,
+    duplicates: validScrobbles.length - uniqueScrobbles.length,
+    maxDuplicates: Math.max(...uniqueScrobbles.map((s) => s.count)),
+  };
+
+  console.log(`\nDEDUPLICATION:`);
+  console.log(`  Total scrobbles: ${duplicateStats.total}`);
+  console.log(`  Unique (track+artist+mbid): ${duplicateStats.unique}`);
+  console.log(`  Duplicates removed: ${duplicateStats.duplicates} (${(duplicateStats.duplicates / duplicateStats.total * 100).toFixed(1)}%)`);
+  console.log(`  Max duplicates per track: ${duplicateStats.maxDuplicates}`);
+  console.log(`  Evaluation will use ${uniqueScrobbles.length} unique cases\n`);
+
+  // Expand with track-only searches
+  const expandedCases: Array<typeof uniqueScrobbles[0] & { fieldCombination: string }> = [];
+
+  for (const scrobble of uniqueScrobbles) {
+    expandedCases.push({ ...scrobble, fieldCombination: "track+artist" });
+    if (scrobble.track && scrobble.track.trim().length >= 3) {
+      expandedCases.push({
+        ...scrobble,
+        artist: "",
+        fieldCombination: "track_only",
+      });
+    }
+  }
+
+  console.log(`INPUT SPACE EXPANSION:`);
+  console.log(`  Original cases: ${uniqueScrobbles.length} (track+artist)`);
+  console.log(`  Expanded cases: ${expandedCases.length} (includes track-only searches)`);
+  console.log(`  Track-only cases: ${expandedCases.filter((c) => c.fieldCombination === "track_only").length}\n`);
+
+  // ── Evaluation loop ───────────────────────────────────────────────
+
+  const cases: EvaluationCase[] = [];
+  const evaluationStartTime = Date.now();
+  let lastLogTime = evaluationStartTime;
+
+  async function evaluateCase(
+    s: typeof expandedCases[0],
+    index: number,
+    total: number,
+  ): Promise<EvaluationCase> {
+    const caseStartTime = Date.now();
+    const logInterval = total > 200 ? 50 : total > 50 ? 25 : 10;
+
+    const fieldCombo = s.fieldCombination || (s.artist ? "track+artist" : "track_only");
+    const cachedResult = cache.getEvaluationResult(
+      s.track,
+      s.artist || "",
+      s.album,
+      s.mbid!,
+      searchConfig,
+      fieldCombo,
+    );
+
+    if (cachedResult) {
+      const now = Date.now();
+      const shouldLog = index % logInterval === 0 || index === total - 1 || (now - lastLogTime) > 2000;
+      if (shouldLog) {
+        const progress = ((index + 1) / total * 100).toFixed(1);
+        const elapsed = now - evaluationStartTime;
+        const dupInfo = s.count > 1 ? ` (${s.count}x)` : "";
+        console.log(`  ${index + 1}/${total} (${progress}%): "${s.track}" by ${s.artist}${dupInfo} [evaluation cached] [ETA: ${calculateETA(elapsed, index + 1, total)}]`);
+        lastLogTime = now;
+      }
+
+      const hardness = classifyHardness(
+        s.track,
+        s.artist || "",
+        cachedResult.failureMode || "standard",
+        cachedResult.baselinePos,
+        cachedResult.baselineFound,
+      );
+      return {
+        track: s.track,
+        artist: s.artist,
+        album: s.album,
+        mbid: s.mbid!,
+        baselinePos: cachedResult.baselinePos,
+        improvedPos: cachedResult.improvedPos,
+        baselineFound: cachedResult.baselineFound,
+        improvedFound: cachedResult.improvedFound,
+        baselineNDCG: cachedResult.baselineNDCG,
+        improvedNDCG: cachedResult.improvedNDCG,
+        failureMode: cachedResult.failureMode,
+        hardness,
+        duplicateCount: cachedResult.duplicateCount,
+        fieldCombination: fieldCombo,
+        workEquivalentPos: -1,
+        workEquivalentSource: null,
+        baselineCacheHit: true,
+        improvedCacheHit: true,
+        apiCallsImproved: 0,
+        improvedTopIds: cachedResult.improvedTopIds,
+        baselineTopIds: cachedResult.baselineTopIds,
+      };
+    }
+
+    // Not cached -- run search
+    const baselineCached = cache.getSearchResults(s.track, s.artist || undefined, s.album, false, false, false) !== null;
+    const baselineRes = await baselineSearch(s.track, s.artist || "", s.album, cache, apiMetrics);
+
+    const mbCallsBefore = apiMetrics.musicbrainzCalls;
+    const improvedRes = await improvedSearchWithConfig(s.track, s.artist || "", s.album, searchConfig, cache, apiMetrics);
+    const apiCallsImproved = apiMetrics.musicbrainzCalls - mbCallsBefore;
+
+    const now = Date.now();
+    const caseElapsed = now - caseStartTime;
+    const shouldLog = index % logInterval === 0 || index === total - 1 || (now - lastLogTime) > 2000;
+    if (shouldLog) {
+      const progress = ((index + 1) / total * 100).toFixed(1);
+      const elapsed = now - evaluationStartTime;
+      const dupInfo = s.count > 1 ? ` (${s.count}x)` : "";
+      const cacheInfo = baselineCached ? " [partial]" : "";
+      console.log(`  ${index + 1}/${total} (${progress}%): "${s.track}" by ${s.artist}${dupInfo}${cacheInfo} [${formatTime(caseElapsed)}/case, ETA: ${calculateETA(elapsed, index + 1, total)}]`);
+      lastLogTime = now;
+    }
+
+    const baselineIds = baselineRes.slice(0, 25).map((r) => r.id).filter((id): id is string => !!id);
+    const improvedIds = improvedRes.slice(0, 25).map((r) => r.id).filter((id): id is string => !!id);
+
+    // Use canonical MBID (follows 301 merges) for comparison
+    const targetMbid = cache.getCanonicalMBID(s.mbid!);
+
+    const baselinePos = baselineIds.indexOf(targetMbid);
+    const improvedPos = improvedIds.indexOf(targetMbid);
+    const baselineFoundAnywhere = baselinePos >= 0;
+    const improvedFoundAnywhere = improvedPos >= 0;
+
+    const baselineRelevance = baselineIds.map((id) => id === targetMbid ? 1 : 0);
+    const improvedRelevance = improvedIds.map((id) => id === targetMbid ? 1 : 0);
+    const baselineNDCG = ndcg(baselineRelevance, 25);
+    const improvedNDCG = ndcg(improvedRelevance, 25);
+
+    const failureMode = s.artist ? categorizeFailureMode(s.track, s.artist) : "track_only";
+    const hardness = classifyHardness(s.track, s.artist || "", failureMode, baselinePos, baselineFoundAnywhere);
+
+    const result: EvaluationCase = {
+      track: s.track,
+      artist: s.artist || "",
+      album: s.album,
+      mbid: s.mbid!,
+      baselinePos,
+      improvedPos,
+      baselineFound: baselineFoundAnywhere,
+      improvedFound: improvedFoundAnywhere,
+      workEquivalentPos: -1,
+      workEquivalentSource: null,
+      baselineNDCG,
+      improvedNDCG,
+      failureMode,
+      hardness,
+      duplicateCount: s.count,
+      fieldCombination: fieldCombo,
+      baselineCacheHit: baselineCached,
+      improvedCacheHit: false,
+      apiCallsImproved,
+      improvedTopIds: improvedIds.slice(0, 5),
+      baselineTopIds: baselineIds.slice(0, 5),
+    };
+
+    cache.setEvaluationResult(
+      s.track,
+      s.artist,
+      s.album,
+      s.mbid!,
+      searchConfig,
+      {
+        baselinePos,
+        improvedPos,
+        baselineFound: baselineFoundAnywhere,
+        improvedFound: improvedFoundAnywhere,
+        baselineNDCG,
+        improvedNDCG,
+        failureMode,
+        duplicateCount: s.count,
+        improvedTopIds: improvedIds.slice(0, 5),
+        baselineTopIds: baselineIds.slice(0, 5),
+      },
+      fieldCombo,
+    );
+
+    return result;
+  }
+
+  // ── Execute evaluation (parallel or sequential) ───────────────────
+
+  let baselineCacheHits = 0;
+  let improvedCacheHits = 0;
+  let evaluationResultCacheHits = 0;
+  let totalSearches = 0;
+
+  if (parallel && concurrency > 1) {
+    console.log(`  Using parallel evaluation (concurrency: ${concurrency})...\n`);
+    const chunks: Array<typeof expandedCases[0]>[] = [];
+    for (let i = 0; i < expandedCases.length; i += concurrency) {
+      chunks.push(expandedCases.slice(i, i + concurrency));
+    }
+
+    for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
+      const chunk = chunks[chunkIdx];
+      const chunkCases = await Promise.all(
+        chunk.map((s, idx) => evaluateCase(s, chunkIdx * concurrency + idx, expandedCases.length)),
+      );
+
+      for (const caseResult of chunkCases) {
+        if (caseResult.baselineCacheHit) baselineCacheHits++;
+        if (caseResult.improvedCacheHit) improvedCacheHits++;
+        if (caseResult.baselineCacheHit && caseResult.improvedCacheHit) {
+          evaluationResultCacheHits++;
+        }
+        totalSearches += 2;
+
+        const hardness = classifyHardness(
+          caseResult.track,
+          caseResult.artist,
+          caseResult.failureMode || "standard",
+          caseResult.baselinePos,
+          caseResult.baselineFound,
+        );
+        cases.push({ ...caseResult, hardness });
+      }
+    }
+  } else {
+    for (let i = 0; i < expandedCases.length; i++) {
+      const caseResult = await evaluateCase(expandedCases[i], i, expandedCases.length);
+      if (caseResult.baselineCacheHit) baselineCacheHits++;
+      if (caseResult.improvedCacheHit) improvedCacheHits++;
+      if (caseResult.baselineCacheHit && caseResult.improvedCacheHit) {
+        evaluationResultCacheHits++;
+      }
+      totalSearches += 2;
+
+      const hardness = classifyHardness(
+        caseResult.track,
+        caseResult.artist,
+        caseResult.failureMode || "standard",
+        caseResult.baselinePos,
+        caseResult.baselineFound,
+      );
+      cases.push({ ...caseResult, hardness });
+    }
+  }
+
+  const evaluationElapsed = Date.now() - evaluationStartTime;
+  const avgTimePerCase = cases.length > 0 ? evaluationElapsed / cases.length : 0;
+  console.log(`\nEvaluation complete: ${cases.length} cases in ${formatTime(evaluationElapsed)} (avg: ${formatTime(avgTimePerCase)}/case)\n`);
+
+  // ── Work-equivalence post-processing ──────────────────────────────
+
+  const unmatchableForWorkCheck = cases.filter((c) => !c.improvedFound || !c.baselineFound);
+  if (unmatchableForWorkCheck.length > 0) {
+    console.log(`Work-equivalence post-processing: checking ${unmatchableForWorkCheck.length} unmatchable cases...`);
+    let workEquivFound = 0;
+    let workChecksPerformed = 0;
+    const workStartTime = Date.now();
+
+    for (let i = 0; i < unmatchableForWorkCheck.length; i++) {
+      const c = unmatchableForWorkCheck[i];
+
+      if (!c.improvedFound && c.improvedTopIds && c.improvedTopIds.length > 0) {
+        for (let j = 0; j < c.improvedTopIds.length; j++) {
+          workChecksPerformed++;
+          const equiv = await areRecordingsWorkEquivalent(c.mbid, c.improvedTopIds[j], cache, apiMetrics);
+          if (equiv) {
+            c.workEquivalentPos = j;
+            c.workEquivalentSource = "improved";
+            workEquivFound++;
+            break;
+          }
+        }
+      }
+
+      if (c.workEquivalentPos < 0 && !c.baselineFound && c.baselineTopIds && c.baselineTopIds.length > 0) {
+        for (let j = 0; j < c.baselineTopIds.length; j++) {
+          workChecksPerformed++;
+          const equiv = await areRecordingsWorkEquivalent(c.mbid, c.baselineTopIds[j], cache, apiMetrics);
+          if (equiv) {
+            c.workEquivalentPos = j;
+            c.workEquivalentSource = "baseline";
+            workEquivFound++;
+            break;
+          }
+        }
+      }
+
+      if ((i + 1) % 100 === 0 || i === unmatchableForWorkCheck.length - 1) {
+        const elapsed = Date.now() - workStartTime;
+        console.log(`  ${i + 1}/${unmatchableForWorkCheck.length} checked, ${workEquivFound} work-equivalent found (${workChecksPerformed} API checks, ${formatTime(elapsed)})`);
+      }
+    }
+
+    const workElapsed = Date.now() - workStartTime;
+    console.log(`Work-equivalence complete: ${workEquivFound} disambiguation cases found in ${formatTime(workElapsed)} (${workChecksPerformed} recording-work lookups)\n`);
+  }
+
+  // ── Duplicate distribution ────────────────────────────────────────
+
+  const duplicateDistribution: Record<number, number> = {};
+  for (const c of cases) {
+    const count = c.duplicateCount || 1;
+    duplicateDistribution[count] = (duplicateDistribution[count] || 0) + 1;
+  }
+
+  // ── Report results ────────────────────────────────────────────────
+
+  reportResults({
+    cases,
+    scrobblesTotal: scrobbles.length,
+    validScrobblesCount: validScrobbles.length,
+    duplicateStats,
+    duplicateDistribution,
+    searchConfig,
+    apiMetrics,
+    startTime,
+    evaluationStartTime,
+    baselineCacheHits,
+    improvedCacheHits,
+    evaluationResultCacheHits,
+    totalSearches,
+  });
+
+  // Show final cache stats
+  const finalStats = cache.getStats(cacheUsername);
+  console.log("\nFINAL CACHE STATS (All accumulate over time, never cleared):");
+  console.log(`  Total scrobbles: ${finalStats.totalScrobbles}`);
+  console.log(`  With MBIDs: ${finalStats.scrobblesWithMBID}`);
+  console.log(`  Cached MBID lookups: ${finalStats.cachedMBIDs}`);
+  console.log(`  Cached MusicBrainz searches: ${finalStats.cachedSearches}`);
+  console.log(`  Cached MBID validations: ${finalStats.cachedValidations}`);
+  console.log(`  Cached evaluation results: ${finalStats.cachedEvaluationResults} (enables instant re-runs)`);
+
+  const totalElapsedFinal = Date.now() - startTime;
+  console.log(`\nTotal execution time: ${formatTime(totalElapsedFinal)}`);
+  console.log(`  Average: ${formatTime(totalElapsedFinal / cases.length)} per evaluation case`);
+
+  cache.close();
+}
+
+main().catch(console.error);

--- a/scripts/eval/lastfm-api.ts
+++ b/scripts/eval/lastfm-api.ts
@@ -1,0 +1,404 @@
+/**
+ * Last.fm API functions for the evaluation harness.
+ * All functions take apiKey/apiSecret as parameters (no module-level globals).
+ */
+
+import type { LastFMTrack, LastFMResponse, APIMetrics } from "./types.js";
+import type { LastFMCache } from "./evaluate-lastfm-cache.js";
+import { generateSignature } from "./auth.js";
+
+/**
+ * Get user's recent tracks from Last.fm.
+ * Handles pagination, retries, and rate limiting.
+ */
+export async function getRecentTracks(
+  apiKey: string,
+  apiSecret: string,
+  username: string,
+  limit: number,
+  sessionKey?: string,
+  page: number = 1,
+): Promise<LastFMTrack[]> {
+  const params: Record<string, string> = {
+    method: "user.getRecentTracks",
+    api_key: apiKey,
+    limit: Math.min(limit, 200).toString(),
+    page: page.toString(),
+    format: "json",
+  };
+
+  if (username) params.user = username;
+
+  if (sessionKey) {
+    params.sk = sessionKey;
+    const sig = await generateSignature(params, apiSecret);
+    params.api_sig = sig;
+  }
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  let retries = 3;
+  let delay = 1000;
+  while (retries > 0) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data: LastFMResponse = await res.json();
+        if (data.recenttracks?.track) {
+          const tracks = data.recenttracks.track;
+          return Array.isArray(tracks) ? tracks : [tracks];
+        }
+        return [];
+      }
+
+      if (res.status >= 500 && retries > 1) {
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+
+      const errorText = await res.text();
+      throw new Error(`Last.fm API error: ${res.statusText} - ${errorText}`);
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : "";
+      if (
+        retries > 1 &&
+        (errorMsg.includes("500") ||
+          errorMsg.includes("503") ||
+          errorMsg.includes("Internal Server Error"))
+      ) {
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Get track correction from Last.fm (canonical name).
+ */
+export async function getTrackCorrection(
+  track: string,
+  artist: string,
+  apiKey: string,
+  apiSecret: string,
+  sessionKey: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<{ track: string; artist: string } | null> {
+  if (cache) {
+    const cached = cache.getTrackCorrection(track, artist);
+    if (cached !== undefined) {
+      return cached
+        ? { track: cached.correctedTrack, artist: cached.correctedArtist }
+        : null;
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const params: Record<string, string> = {
+    method: "track.getCorrection",
+    track,
+    artist,
+    api_key: apiKey,
+    sk: sessionKey,
+    format: "json",
+  };
+
+  const sig = await generateSignature(params, apiSecret);
+  params.api_sig = sig;
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  let retries = 3;
+  let delay = 200;
+  while (retries > 0) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.corrections?.correction?.track) {
+          const corrected = data.corrections.correction.track;
+          const correctedTrack = corrected.name || track;
+          const correctedArtist = corrected.artist?.name || artist;
+          if (cache)
+            cache.setTrackCorrection(
+              track,
+              artist,
+              correctedTrack,
+              correctedArtist,
+            );
+          return { track: correctedTrack, artist: correctedArtist };
+        }
+        break;
+      }
+
+      if (res.status >= 500 && retries > 1) {
+        if (apiMetrics) apiMetrics.lastfmErrors++;
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+
+      if (apiMetrics && res.status >= 400) apiMetrics.lastfmErrors++;
+      break;
+    } catch (e) {
+      if (apiMetrics) apiMetrics.lastfmErrors++;
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      break;
+    }
+  }
+
+  if (cache) cache.setTrackCorrection(track, artist, null, null);
+  return null;
+}
+
+/**
+ * Search for tracks on Last.fm.
+ */
+export async function searchTracksOnLastFM(
+  track: string,
+  artist: string,
+  apiKey: string,
+  apiSecret: string,
+  sessionKey: string,
+  limit: number = 10,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<Array<{ track: string; artist: string; mbid: string | null }>> {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const params: Record<string, string> = {
+    method: "track.search",
+    track: `${track} ${artist}`,
+    api_key: apiKey,
+    limit: limit.toString(),
+    format: "json",
+  };
+
+  if (sessionKey) {
+    params.sk = sessionKey;
+    const sig = await generateSignature(params, apiSecret);
+    params.api_sig = sig;
+  }
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  let retries = 3;
+  let delay = 200;
+  while (retries > 0) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.results?.trackmatches?.track) {
+          const tracks = Array.isArray(data.results.trackmatches.track)
+            ? data.results.trackmatches.track
+            : [data.results.trackmatches.track];
+          return tracks.map((t: any) => ({
+            track: t.name,
+            artist: t.artist,
+            mbid: t.mbid || null,
+          }));
+        }
+        return [];
+      }
+
+      if (res.status >= 500 && retries > 1) {
+        if (apiMetrics) apiMetrics.lastfmErrors++;
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+
+      if (apiMetrics && res.status >= 400) apiMetrics.lastfmErrors++;
+      return [];
+    } catch (e) {
+      if (apiMetrics) apiMetrics.lastfmErrors++;
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      return [];
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Get artist info from Last.fm (including MBID and aliases).
+ */
+export async function getArtistInfo(
+  artist: string,
+  apiKey: string,
+  apiSecret: string,
+  sessionKey: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<{ mbid: string | null; aliases: string[] } | null> {
+  if (cache) {
+    const cached = cache.getArtistInfo(artist);
+    if (cached !== undefined) return cached;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const params: Record<string, string> = {
+    method: "artist.getInfo",
+    artist,
+    api_key: apiKey,
+    sk: sessionKey,
+    format: "json",
+  };
+
+  const sig = await generateSignature(params, apiSecret);
+  params.api_sig = sig;
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  let retries = 3;
+  let delay = 200;
+  while (retries > 0) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.artist) {
+          const mbid = data.artist.mbid || null;
+          const aliases = data.artist.alias
+            ? (Array.isArray(data.artist.alias)
+                ? data.artist.alias
+                : [data.artist.alias]
+              ).map((a: any) =>
+                typeof a === "string" ? a : a["#text"] || a,
+              )
+            : [];
+
+          const result = { mbid, aliases };
+          if (cache) cache.setArtistInfo(artist, result);
+          return result;
+        }
+        break;
+      }
+
+      if (res.status >= 500 && retries > 1) {
+        if (apiMetrics) apiMetrics.lastfmErrors++;
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+
+      if (apiMetrics && res.status >= 400) apiMetrics.lastfmErrors++;
+      break;
+    } catch (e) {
+      if (apiMetrics) apiMetrics.lastfmErrors++;
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      break;
+    }
+  }
+
+  if (cache) cache.setArtistInfo(artist, null);
+  return null;
+}
+
+/**
+ * Get album info from Last.fm (including MBID).
+ */
+export async function getAlbumInfo(
+  artist: string,
+  album: string,
+  apiKey: string,
+  apiSecret: string,
+  sessionKey: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<{ mbid: string | null } | null> {
+  if (cache) {
+    const cached = cache.getAlbumInfo(artist, album);
+    if (cached !== undefined) return cached;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const params: Record<string, string> = {
+    method: "album.getInfo",
+    artist,
+    album,
+    api_key: apiKey,
+    sk: sessionKey,
+    format: "json",
+  };
+
+  const sig = await generateSignature(params, apiSecret);
+  params.api_sig = sig;
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  let retries = 3;
+  let delay = 200;
+  while (retries > 0) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.album) {
+          const result = { mbid: data.album.mbid || null };
+          if (cache) cache.setAlbumInfo(artist, album, result);
+          return result;
+        }
+        break;
+      }
+
+      if (res.status >= 500 && retries > 1) {
+        if (apiMetrics) apiMetrics.lastfmErrors++;
+        retries--;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+
+      if (apiMetrics && res.status >= 400) apiMetrics.lastfmErrors++;
+      break;
+    } catch (e) {
+      if (apiMetrics) apiMetrics.lastfmErrors++;
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      break;
+    }
+  }
+
+  if (cache) cache.setAlbumInfo(artist, album, null);
+  return null;
+}

--- a/scripts/eval/listenbrainz-resolve.ts
+++ b/scripts/eval/listenbrainz-resolve.ts
@@ -1,0 +1,209 @@
+/**
+ * Resolve 404 MBIDs via ListenBrainz ACR (Artist Credit Recording) lookup.
+ *
+ * Last.fm stores MBIDs that have since been deleted from MusicBrainz (~72% of
+ * all MBIDs in our corpus return HTTP 404). ListenBrainz maintains a canonical
+ * mapping that can resolve (artist, track) pairs to current recording MBIDs.
+ *
+ * This script:
+ * 1. Finds all scrobbles whose Last.fm MBID returns 404 from MusicBrainz
+ * 2. Batch-resolves them via the ListenBrainz labs ACR lookup endpoint
+ * 3. Stores resolved MBIDs in mbid_cache with source "listenbrainz_acr"
+ * 4. Updates scrobble rows with the new MBID + source
+ *
+ * The ACR endpoint is public (no auth), supports batch POST, and is fast
+ * (~0.7s per 100 items). Rate limit appears generous but we cap at 100/batch.
+ *
+ * Usage: npx tsx scripts/eval/listenbrainz-resolve.ts [--dry-run] [--limit N]
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { homedir } from "os";
+
+const CACHE_DIR = join(homedir(), ".teal_eval_cache");
+const DB_PATH = join(CACHE_DIR, "lastfm_eval.db");
+
+const ACR_ENDPOINT = "https://labs.api.listenbrainz.org/acr-lookup/json";
+const BATCH_SIZE = 100;
+// Pause between batches to be a good citizen
+const BATCH_DELAY_MS = 500;
+
+interface ACRRequest {
+  artist_credit_name: string;
+  recording_name: string;
+}
+
+interface ACRResponse {
+  index: number;
+  artist_credit_arg: string;
+  recording_arg: string;
+  artist_credit_name?: string;
+  recording_name?: string;
+  recording_mbid?: string;
+  release_name?: string;
+  release_mbid?: string;
+  artist_credit_id?: number;
+  artist_mbids?: string[];
+}
+
+async function acrLookupBatch(items: ACRRequest[]): Promise<ACRResponse[]> {
+  const res = await fetch(ACR_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(items),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ACR lookup failed (${res.status}): ${text}`);
+  }
+
+  return res.json();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const limitIdx = args.indexOf("--limit");
+  const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : undefined;
+
+  const db = new Database(DB_PATH);
+  db.pragma("journal_mode = WAL");
+
+  // Find unique (track, artist) pairs where the Last.fm MBID is 404
+  // and we don't already have a listenbrainz_acr result cached
+  const query = `
+    SELECT DISTINCT s.track, s.artist
+    FROM scrobbles s
+    JOIN mbid_validation_cache v ON s.mbid = v.mbid
+    WHERE v.http_status = 404
+      AND s.track <> ''
+      AND s.artist <> ''
+      AND NOT EXISTS (
+        SELECT 1 FROM mbid_cache mc
+        WHERE mc.track = s.track AND mc.artist = s.artist
+        AND mc.mbid_source = 'listenbrainz_acr'
+      )
+    ${limit ? `LIMIT ${limit}` : ""}
+  `;
+
+  const pairs = db.prepare(query).all() as Array<{ track: string; artist: string }>;
+  console.log(`Found ${pairs.length} unique (track, artist) pairs with 404 MBIDs to resolve`);
+
+  if (pairs.length === 0) {
+    console.log("Nothing to resolve.");
+    db.close();
+    return;
+  }
+
+  if (dryRun) {
+    console.log("Dry run -- would resolve these pairs:");
+    for (const p of pairs.slice(0, 20)) {
+      console.log(`  ${p.artist} - ${p.track}`);
+    }
+    if (pairs.length > 20) console.log(`  ... and ${pairs.length - 20} more`);
+    db.close();
+    return;
+  }
+
+  // Prepare statement -- store in mbid_cache only (not scrobbles).
+  // The eval harness reads mbid_cache as a fallback for 404 MBIDs.
+  // We don't mutate scrobbles because the original Last.fm MBID is
+  // still useful for diagnostics.
+  const upsertMbidCache = db.prepare(`
+    INSERT OR REPLACE INTO mbid_cache (track, artist, mbid, mbid_source)
+    VALUES (?, ?, ?, 'listenbrainz_acr')
+  `);
+
+  let totalResolved = 0;
+  let totalMissed = 0;
+  let totalBatches = 0;
+  const startTime = Date.now();
+
+  // Process in batches
+  for (let i = 0; i < pairs.length; i += BATCH_SIZE) {
+    const batch = pairs.slice(i, i + BATCH_SIZE);
+    totalBatches++;
+
+    const requests: ACRRequest[] = batch.map(p => ({
+      artist_credit_name: p.artist,
+      recording_name: p.track,
+    }));
+
+    try {
+      const results = await acrLookupBatch(requests);
+
+      // Build a map from (artist, track) -> recording_mbid
+      const resolvedMap = new Map<string, string>();
+      for (const r of results) {
+        if (r.recording_mbid) {
+          const key = `${r.artist_credit_arg}\0${r.recording_arg}`;
+          resolvedMap.set(key, r.recording_mbid);
+        }
+      }
+
+      // Apply results in a transaction
+      const applyBatch = db.transaction(() => {
+        for (const p of batch) {
+          const key = `${p.artist}\0${p.track}`;
+          const mbid = resolvedMap.get(key);
+
+          if (mbid) {
+            upsertMbidCache.run(p.track, p.artist, mbid);
+            totalResolved++;
+          } else {
+            // Cache the miss so we don't retry
+            upsertMbidCache.run(p.track, p.artist, null);
+            totalMissed++;
+          }
+        }
+      });
+      applyBatch();
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      const progress = Math.min(i + BATCH_SIZE, pairs.length);
+      const rate = totalResolved / (parseFloat(elapsed) || 1);
+      console.log(
+        `Batch ${totalBatches}: ${progress}/${pairs.length} processed, ` +
+        `${totalResolved} resolved, ${totalMissed} missed ` +
+        `(${elapsed}s, ${rate.toFixed(1)}/s)`
+      );
+    } catch (err) {
+      console.error(`Batch ${totalBatches} failed:`, err instanceof Error ? err.message : err);
+      // Continue with next batch
+    }
+
+    // Rate limit between batches
+    if (i + BATCH_SIZE < pairs.length) {
+      await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+    }
+  }
+
+  const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+  const resolveRate = pairs.length > 0
+    ? ((totalResolved / pairs.length) * 100).toFixed(1)
+    : "0";
+
+  console.log("\n--- ListenBrainz ACR Resolution Summary ---");
+  console.log(`Total pairs:    ${pairs.length}`);
+  console.log(`Resolved:       ${totalResolved} (${resolveRate}%)`);
+  console.log(`Missed:         ${totalMissed}`);
+  console.log(`Batches:        ${totalBatches}`);
+  console.log(`Time:           ${totalTime}s`);
+
+  // Show how many scrobbles now have ground truth
+  const newGroundTruth = db.prepare(`
+    SELECT COUNT(DISTINCT track || '|' || artist) as count
+    FROM mbid_cache
+    WHERE mbid_source = 'listenbrainz_acr' AND mbid IS NOT NULL
+  `).get() as { count: number };
+  console.log(`\nNew ground-truth pairs (listenbrainz_acr): ${newGroundTruth.count}`);
+
+  db.close();
+}
+
+main().catch(err => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/eval/mbid-resolution.ts
+++ b/scripts/eval/mbid-resolution.ts
@@ -1,0 +1,513 @@
+/**
+ * MBID resolution functions for the evaluation harness.
+ *
+ * Key design: every function that returns an MBID also returns its *source*
+ * (MBIDSource), so callers can decide whether it is safe to use as ground
+ * truth. Only "lastfm_track_info", "lastfm_search", and "track_data" are
+ * independent of MusicBrainz search; "musicbrainz_search" is circular.
+ */
+
+import {
+  MUSICBRAINZ_BASE_URL,
+  USER_AGENT,
+  RATE_LIMIT_DELAY,
+  type APIMetrics,
+  type MBIDResult,
+  type MBIDSource,
+} from "./types.js";
+import {
+  cleanTrackName,
+  cleanArtistName,
+} from "../../apps/amethyst/lib/musicbrainzCleaner.js";
+import { escapeLucene } from "../../apps/amethyst/lib/musicbrainzSearchUtils.js";
+import type { LastFMCache } from "./evaluate-lastfm-cache.js";
+import { generateSignature } from "./auth.js";
+import {
+  getTrackCorrection,
+  searchTracksOnLastFM,
+} from "./lastfm-api.js";
+
+// ── MusicBrainz search (source: "musicbrainz_search") ─────────────────
+
+/**
+ * Search MusicBrainz for a recording MBID using multiple strategies.
+ * Previously named getMBIDViaISRC (misleading -- no ISRC logic).
+ *
+ * WARNING: Results from this function are search-derived and MUST NOT
+ * be used as ground truth for evaluating search quality (circular).
+ */
+async function searchMusicBrainzForMBID(
+  track: string,
+  artist: string,
+): Promise<string | null> {
+  const cleanedTrack = cleanTrackName(track);
+  const cleanedArtist = cleanArtistName(artist);
+
+  // Strategy 1: Exact match with cleaned names
+  if (cleanedTrack && cleanedArtist) {
+    const q = `recording:"${escapeLucene(cleanedTrack)}" AND artist:"${escapeLucene(cleanedArtist)}"`;
+    const mbid = await tryMusicBrainzSearch(q, cleanedTrack, cleanedArtist);
+    if (mbid) return mbid;
+  }
+
+  // Strategy 2: Exact match with original names
+  const q2 = `recording:"${escapeLucene(track)}" AND artist:"${escapeLucene(artist)}"`;
+  let mbid = await tryMusicBrainzSearch(q2, track, artist);
+  if (mbid) return mbid;
+
+  // Strategy 3: Fuzzy match
+  const searchTrack = cleanedTrack || track;
+  const searchArtist = cleanedArtist || artist;
+  const trackWords = searchTrack.split(" ");
+  const artistWords = searchArtist.split(" ");
+
+  if (trackWords.length > 1) {
+    const fuzzyTrackQuery = `recording:"${escapeLucene(searchTrack)}"~3`;
+    const fuzzyArtistQuery =
+      artistWords.length > 1
+        ? `artist:"${escapeLucene(searchArtist)}"~3`
+        : `artist:${escapeLucene(searchArtist)}~`;
+    mbid = await tryMusicBrainzSearch(
+      `${fuzzyTrackQuery} AND ${fuzzyArtistQuery}`,
+      searchTrack,
+      searchArtist,
+    );
+  } else {
+    mbid = await tryMusicBrainzSearch(
+      `recording:${escapeLucene(searchTrack)}~ AND artist:${escapeLucene(searchArtist)}~`,
+      searchTrack,
+      searchArtist,
+    );
+  }
+  if (mbid) return mbid;
+
+  // Strategy 4: Partial match (word-by-word)
+  mbid = await tryMusicBrainzSearch(
+    `recording:${escapeLucene(searchTrack)} AND artist:${escapeLucene(searchArtist)}`,
+    searchTrack,
+    searchArtist,
+  );
+  if (mbid) return mbid;
+
+  // Strategy 5: Artist-only search
+  mbid = await tryMusicBrainzSearch(
+    `artist:"${escapeLucene(searchArtist)}"`,
+    searchTrack,
+    searchArtist,
+    true,
+  );
+  return mbid;
+}
+
+/** Helper: try a single MusicBrainz search query. */
+async function tryMusicBrainzSearch(
+  query: string,
+  originalTrack: string,
+  originalArtist: string,
+  checkISRC: boolean = false,
+): Promise<string | null> {
+  try {
+    await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+    const url = `${MUSICBRAINZ_BASE_URL}/recording?query=${encodeURIComponent(query)}&limit=10&fmt=json`;
+    const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+
+    if (res.ok) {
+      const data = await res.json();
+      if (data.recordings?.length > 0) {
+        for (const recording of data.recordings) {
+          if (checkISRC) {
+            const recUrl = `${MUSICBRAINZ_BASE_URL}/recording/${recording.id}?inc=isrcs&fmt=json`;
+            await new Promise((resolve) =>
+              setTimeout(resolve, RATE_LIMIT_DELAY),
+            );
+            const recRes = await fetch(recUrl, {
+              headers: { "User-Agent": USER_AGENT },
+            });
+            if (recRes.ok) {
+              const recData = await recRes.json();
+              if (recData.isrcs?.length > 0) return recording.id;
+            }
+          }
+          if (!checkISRC) return recording.id;
+        }
+        return data.recordings[0].id;
+      }
+    }
+  } catch {
+    // Ignore errors, try next strategy
+  }
+  return null;
+}
+
+// ── MBID validation ────────────────────────────────────────────────────
+
+/**
+ * Validate that an MBID exists in MusicBrainz.
+ * Retries on 503 with exponential backoff.
+ */
+export async function validateMBID(
+  mbid: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<boolean> {
+  if (cache) {
+    const cached = cache.getMBIDValidationDetailed(mbid);
+    if (cached !== undefined) {
+      if (cached.httpStatus === 200 || cached.httpStatus === 301 || cached.httpStatus === 404) {
+        return cached.isValid;
+      }
+    }
+  }
+
+  const MAX_RETRIES = 3;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const delay =
+        RATE_LIMIT_DELAY * (attempt === 0 ? 1 : Math.pow(2, attempt));
+      await new Promise((resolve) => setTimeout(resolve, delay));
+
+      const lookupUrl = `${MUSICBRAINZ_BASE_URL}/recording/${mbid}?fmt=json`;
+      const apiCallStart = Date.now();
+      // Use redirect: "manual" to detect 301 (merged recordings)
+      const res = await fetch(lookupUrl, {
+        headers: { "User-Agent": USER_AGENT },
+        redirect: "manual",
+      });
+      const apiCallTime = Date.now() - apiCallStart;
+
+      if (apiMetrics) {
+        apiMetrics.musicbrainzCalls++;
+        apiMetrics.totalAPICallTime += apiCallTime;
+      }
+
+      if (res.status === 404) {
+        if (cache) cache.setMBIDValidation(mbid, false, 404, "404 Not Found");
+        return false;
+      }
+
+      if (res.status === 301) {
+        // Merged recording -- follow redirect to get canonical MBID
+        // MB redirects: /ws/2/recording/<old>?fmt=json -> /ws/2/recording/<new>?fmt=json
+        const location = res.headers.get("location");
+        let canonicalMbid: string | undefined;
+        if (location) {
+          const match = location.match(/\/recording\/([0-9a-f-]{36})/);
+          if (match) canonicalMbid = match[1];
+        }
+        if (!canonicalMbid) {
+          // Fallback: follow the redirect to read the response body
+          await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+          const followRes = await fetch(lookupUrl, {
+            headers: { "User-Agent": USER_AGENT },
+            redirect: "follow",
+          });
+          if (apiMetrics) apiMetrics.musicbrainzCalls++;
+          if (followRes.ok) {
+            const data = await followRes.json();
+            canonicalMbid = data.id;
+          }
+        }
+        if (cache) cache.setMBIDValidation(mbid, true, 301, `merged -> ${canonicalMbid || "unknown"}`, canonicalMbid);
+        return true;
+      }
+
+      if (res.ok) {
+        if (cache) cache.setMBIDValidation(mbid, true, 200);
+        return true;
+      }
+      if (res.status === 503) {
+        if (apiMetrics) apiMetrics.musicbrainzRateLimits++;
+        if (attempt < MAX_RETRIES - 1) continue;
+        return true; // conservative fallback, uncached
+      }
+
+      if (apiMetrics) apiMetrics.musicbrainzErrors++;
+      if (attempt < MAX_RETRIES - 1) continue;
+      return true;
+    } catch {
+      if (apiMetrics) apiMetrics.musicbrainzErrors++;
+      if (attempt < MAX_RETRIES - 1) continue;
+      return true;
+    }
+  }
+  return true;
+}
+
+// ── Work-equivalence ───────────────────────────────────────────────────
+
+/**
+ * Fetch the work ID linked to a MusicBrainz recording.
+ */
+export async function getRecordingWorkId(
+  recordingMbid: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<string | null> {
+  if (cache) {
+    const cached = cache.getRecordingWork(recordingMbid);
+    if (cached !== undefined) return cached.workId;
+  }
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+    const url = `${MUSICBRAINZ_BASE_URL}/recording/${recordingMbid}?inc=work-rels&fmt=json`;
+    const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+    if (apiMetrics) apiMetrics.musicbrainzCalls++;
+
+    if (!res.ok) {
+      if (res.status === 503 && apiMetrics)
+        apiMetrics.musicbrainzRateLimits++;
+      return null;
+    }
+
+    const data = (await res.json()) as any;
+    const workRel = data.relations?.find(
+      (r: any) => r.type === "performance" && r.work,
+    );
+    const workId = workRel?.work?.id ?? null;
+    const workTitle = workRel?.work?.title ?? null;
+
+    if (cache) cache.setRecordingWork(recordingMbid, workId, workTitle);
+    return workId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if two recordings are work-equivalent (same underlying composition).
+ */
+export async function areRecordingsWorkEquivalent(
+  mbidA: string,
+  mbidB: string,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<boolean> {
+  const workA = await getRecordingWorkId(mbidA, cache, apiMetrics);
+  if (!workA) return false;
+  const workB = await getRecordingWorkId(mbidB, cache, apiMetrics);
+  if (!workB) return false;
+  return workA === workB;
+}
+
+// ── Main MBID resolution ──────────────────────────────────────────────
+
+/**
+ * Get track MBID from Last.fm, with source provenance tracking.
+ *
+ * Returns {mbid, source} where source indicates how the MBID was obtained.
+ * Only MBIDs with source !== "musicbrainz_search" are safe as ground truth.
+ *
+ * Methods tried in order:
+ * 0. track.getCorrection (canonical name)
+ * 1. track.getInfo (Last.fm authenticated) -> source: "lastfm_track_info"
+ * 2. track.search (Last.fm search) -> source: "lastfm_search"
+ * 3. MusicBrainz recording search (if useAdditionalAPIs) -> source: "musicbrainz_search"
+ */
+export async function getTrackMBID(
+  track: string,
+  artist: string,
+  apiKey: string,
+  apiSecret: string,
+  sessionKey: string,
+  cache?: LastFMCache,
+  useAdditionalAPIs: boolean = false,
+  apiMetrics?: APIMetrics,
+): Promise<MBIDResult> {
+  // Check cache first
+  if (cache) {
+    const cached = cache.getMBIDWithSource(track, artist);
+    if (cached !== undefined) {
+      return { mbid: cached.mbid, source: cached.source };
+    }
+  }
+
+  // Method 0: Try track.getCorrection first (get canonical name)
+  const correction = await getTrackCorrection(
+    track,
+    artist,
+    apiKey,
+    apiSecret,
+    sessionKey,
+    cache,
+    apiMetrics,
+  );
+  let searchTrack = track;
+  let searchArtist = artist;
+  if (correction) {
+    searchTrack = correction.track;
+    searchArtist = correction.artist;
+    if (apiMetrics) apiMetrics.lastfmCalls++;
+  }
+
+  // Method 1: Try track.getInfo (Last.fm authenticated)
+  if (apiMetrics) apiMetrics.lastfmCalls++;
+  const params: Record<string, string> = {
+    method: "track.getInfo",
+    track: searchTrack,
+    artist: searchArtist,
+    api_key: apiKey,
+    sk: sessionKey,
+    format: "json",
+  };
+
+  const sig = await generateSignature(params, apiSecret);
+  params.api_sig = sig;
+
+  const queryString = new URLSearchParams(params).toString();
+  const url = `https://ws.audioscrobbler.com/2.0/?${queryString}`;
+
+  try {
+    const res = await fetch(url);
+    if (res.ok) {
+      const data = await res.json();
+      if (data.track?.mbid) {
+        const mbid = data.track.mbid;
+        if (useAdditionalAPIs) {
+          const isValid = await validateMBID(mbid, cache, apiMetrics);
+          if (isValid) {
+            if (cache) {
+              cache.setMBIDWithSource(track, artist, mbid, "lastfm_track_info");
+              if (correction)
+                cache.setMBIDWithSource(
+                  searchTrack,
+                  searchArtist,
+                  mbid,
+                  "lastfm_track_info",
+                );
+            }
+            return { mbid, source: "lastfm_track_info" };
+          }
+        } else {
+          if (cache) {
+            cache.setMBIDWithSource(track, artist, mbid, "lastfm_track_info");
+            if (correction)
+              cache.setMBIDWithSource(
+                searchTrack,
+                searchArtist,
+                mbid,
+                "lastfm_track_info",
+              );
+          }
+          return { mbid, source: "lastfm_track_info" };
+        }
+      }
+
+      // Try corrected name from response
+      if (data.track?.name && data.track.name !== searchTrack) {
+        const correctedParams: Record<string, string> = {
+          method: "track.getInfo",
+          track: data.track.name,
+          artist: data.track.artist?.name || searchArtist,
+          api_key: apiKey,
+          sk: sessionKey,
+          format: "json",
+        };
+        const correctedSig = await generateSignature(correctedParams, apiSecret);
+        correctedParams.api_sig = correctedSig;
+        const correctedUrl = `https://ws.audioscrobbler.com/2.0/?${new URLSearchParams(correctedParams).toString()}`;
+        const correctedRes = await fetch(correctedUrl);
+        if (correctedRes.ok) {
+          const correctedData = await correctedRes.json();
+          if (correctedData.track?.mbid) {
+            const mbid = correctedData.track.mbid;
+            if (useAdditionalAPIs) {
+              const isValid = await validateMBID(mbid, cache, apiMetrics);
+              if (isValid) {
+                if (cache)
+                  cache.setMBIDWithSource(
+                    track,
+                    artist,
+                    mbid,
+                    "lastfm_track_info",
+                  );
+                return { mbid, source: "lastfm_track_info" };
+              }
+            } else {
+              if (cache)
+                cache.setMBIDWithSource(
+                  track,
+                  artist,
+                  mbid,
+                  "lastfm_track_info",
+                );
+              return { mbid, source: "lastfm_track_info" };
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // Method 2: Try track.search (Last.fm search)
+  if (apiMetrics) apiMetrics.lastfmCalls++;
+  const searchResults = await searchTracksOnLastFM(
+    searchTrack,
+    searchArtist,
+    apiKey,
+    apiSecret,
+    sessionKey,
+    10,
+    cache,
+    apiMetrics,
+  );
+  for (const result of searchResults) {
+    const trackMatch =
+      result.track.toLowerCase() === searchTrack.toLowerCase() ||
+      result.track.toLowerCase().includes(searchTrack.toLowerCase()) ||
+      searchTrack.toLowerCase().includes(result.track.toLowerCase());
+    const artistMatch =
+      result.artist.toLowerCase() === searchArtist.toLowerCase() ||
+      result.artist.toLowerCase().includes(searchArtist.toLowerCase()) ||
+      searchArtist.toLowerCase().includes(result.artist.toLowerCase());
+
+    if (trackMatch && artistMatch && result.mbid) {
+      if (useAdditionalAPIs && apiMetrics) {
+        const isValid = await validateMBID(result.mbid, cache, apiMetrics);
+        if (isValid) {
+          if (cache)
+            cache.setMBIDWithSource(
+              track,
+              artist,
+              result.mbid,
+              "lastfm_search",
+            );
+          return { mbid: result.mbid, source: "lastfm_search" };
+        }
+      } else {
+        if (cache)
+          cache.setMBIDWithSource(
+            track,
+            artist,
+            result.mbid,
+            "lastfm_search",
+          );
+        return { mbid: result.mbid, source: "lastfm_search" };
+      }
+    }
+  }
+
+  // Method 3: MusicBrainz search (CIRCULAR -- marked as such)
+  if (useAdditionalAPIs) {
+    const mbidViaMB = await searchMusicBrainzForMBID(track, artist);
+    if (mbidViaMB) {
+      const isValid = await validateMBID(mbidViaMB, cache, apiMetrics);
+      if (isValid) {
+        if (cache)
+          cache.setMBIDWithSource(
+            track,
+            artist,
+            mbidViaMB,
+            "musicbrainz_search",
+          );
+        return { mbid: mbidViaMB, source: "musicbrainz_search" };
+      }
+    }
+  }
+
+  // No MBID found
+  if (cache) cache.setMBIDWithSource(track, artist, null, null);
+  return { mbid: null, source: null };
+}

--- a/scripts/eval/reporting.ts
+++ b/scripts/eval/reporting.ts
@@ -1,0 +1,503 @@
+/**
+ * Evaluation reporting and failure-mode analysis.
+ */
+
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import {
+  type EvaluationCase,
+  type SearchConfig,
+  type APIMetrics,
+  formatTime,
+} from "./types.js";
+import {
+  bootstrapCI,
+  mcnemarTest,
+  cohensH,
+} from "./statistics.js";
+
+// ── Failure-mode classification ────────────────────────────────────────
+
+export function categorizeFailureMode(track: string, artist: string): string {
+  if (
+    /\bfeat\.?\b|\bft\.?\b|\bfeaturing\b/i.test(track) ||
+    /\bfeat\.?\b|\bft\.?\b|\bfeaturing\b/i.test(artist) ||
+    /\(feat\.|\(ft\.|\(featuring/i.test(track)
+  ) {
+    return "featuring";
+  }
+  if (/\bremix\b|\brmx\b|\bre-?mix/i.test(track) || /\(remix\)|\[remix\]/i.test(track)) {
+    return "remix";
+  }
+  if (/\blive\b/i.test(track) || /\(live\)|\[live\]/i.test(track)) {
+    return "live";
+  }
+  if (/\([^)]+\)|\[[^\]]+\]/.test(track)) {
+    return "parenthetical";
+  }
+  if (/[^\w\s\-'&]/.test(track) || /[^\w\s\-'&]/.test(artist)) {
+    return "special_chars";
+  }
+  if (track.length < 5 || artist.length < 5) {
+    return "short_name";
+  }
+  return "standard";
+}
+
+const AMBIGUOUS_WORDS = new Set([
+  "air","one","two","three","four","five","six","seven","eight","nine","ten",
+  "song","track","music","beat","sound","tune","piece","high","low","new","old",
+  "love","time","life","day","night","sun","moon","star","sky","sea","water",
+  "fire","wind","earth","light","dark","red","blue","green","black","white",
+  "big","small","good","bad","yes","no","ok","okay","hi","hey","hello","bye",
+  "go","come","get","take","give","make","do","be","see","know","think","say",
+  "want","need","like","can","will","may","must","should","could","would",
+]);
+
+export function classifyHardness(
+  track: string,
+  artist: string,
+  _failureMode: string,
+  baselinePos: number,
+  baselineFound: boolean,
+): "easy" | "medium" | "hard" {
+  const trackLower = track.toLowerCase().trim();
+  const trackWords = trackLower.split(/\s+/).filter((w) => w.length > 0);
+
+  if (baselineFound && baselinePos >= 0 && baselinePos < 5) return "easy";
+  if (baselineFound && baselinePos >= 5 && baselinePos < 25) return "medium";
+
+  if (!baselineFound) {
+    if (artist.length < 3 || track.length < 3) return "hard";
+    if (track.length < 4) return "hard";
+    if (/^\d+$/.test(track.trim())) return "hard";
+    if (trackWords.length === 1 && AMBIGUOUS_WORDS.has(trackWords[0])) return "hard";
+
+    if (artist && artist.length >= 3 && track.length >= 4) {
+      if (trackWords.length > 1) return "medium";
+      if (trackWords.length === 1 && !AMBIGUOUS_WORDS.has(trackWords[0])) return "medium";
+    }
+
+    if (!artist || artist.trim().length === 0) {
+      if (track.length < 6 || (trackWords.length === 1 && AMBIGUOUS_WORDS.has(trackWords[0]))) return "hard";
+      if (trackWords.length > 1 && track.length >= 6) return "medium";
+      if (trackWords.length === 1 && !AMBIGUOUS_WORDS.has(trackWords[0]) && track.length >= 6) return "medium";
+      return "hard";
+    }
+
+    return "hard";
+  }
+
+  return "medium";
+}
+
+// ── EvaluationOutput bag ───────────────────────────────────────────────
+
+export interface EvaluationOutput {
+  cases: EvaluationCase[];
+  scrobblesTotal: number;
+  validScrobblesCount: number;
+  duplicateStats: {
+    total: number;
+    unique: number;
+    duplicates: number;
+    maxDuplicates: number;
+  };
+  duplicateDistribution: Record<number, number>;
+  searchConfig: SearchConfig;
+  apiMetrics: APIMetrics;
+  startTime: number;
+  evaluationStartTime: number;
+  baselineCacheHits: number;
+  improvedCacheHits: number;
+  evaluationResultCacheHits: number;
+  totalSearches: number;
+}
+
+// ── Main reporting function ────────────────────────────────────────────
+
+export function reportResults(output: EvaluationOutput): void {
+  const {
+    cases,
+    scrobblesTotal,
+    validScrobblesCount,
+    duplicateStats,
+    duplicateDistribution,
+    searchConfig,
+    apiMetrics,
+    startTime,
+    baselineCacheHits,
+    improvedCacheHits,
+    evaluationResultCacheHits,
+    totalSearches,
+  } = output;
+
+  // Calculate all metrics from cases
+  let baselineP1 = 0, baselineP5 = 0, baselineP10 = 0, baselineP25 = 0, baselineFound = 0;
+  let improvedP1 = 0, improvedP5 = 0, improvedP10 = 0, improvedP25 = 0, improvedFound = 0;
+  let baselineBetter = 0, improvedBetter = 0, bothSame = 0;
+  let baselineMRR = 0, improvedMRR = 0;
+  let baselineNDCGSum = 0, improvedNDCGSum = 0;
+  const baselinePositions: number[] = [];
+  const improvedPositions: number[] = [];
+  const trackLengths: number[] = [];
+  const artistLengths: number[] = [];
+  const positionByFieldCombo: Record<string, { baseline: number[]; improved: number[] }> = {};
+
+  for (const c of cases) {
+    const combo = c.fieldCombination || "track+artist";
+    if (!positionByFieldCombo[combo]) positionByFieldCombo[combo] = { baseline: [], improved: [] };
+    positionByFieldCombo[combo].baseline.push(c.baselinePos);
+    positionByFieldCombo[combo].improved.push(c.improvedPos);
+
+    if (c.baselinePos === 0) baselineP1++;
+    if (c.baselinePos >= 0 && c.baselinePos < 5) baselineP5++;
+    if (c.baselinePos >= 0 && c.baselinePos < 10) baselineP10++;
+    if (c.baselinePos >= 0 && c.baselinePos < 25) baselineP25++;
+    if (c.baselineFound) baselineFound++;
+
+    if (c.improvedPos === 0) improvedP1++;
+    if (c.improvedPos >= 0 && c.improvedPos < 5) improvedP5++;
+    if (c.improvedPos >= 0 && c.improvedPos < 10) improvedP10++;
+    if (c.improvedPos >= 0 && c.improvedPos < 25) improvedP25++;
+    if (c.improvedFound) improvedFound++;
+
+    baselineMRR += c.baselineFound ? 1 / (c.baselinePos + 1) : 0;
+    improvedMRR += c.improvedFound ? 1 / (c.improvedPos + 1) : 0;
+    baselineNDCGSum += c.baselineNDCG;
+    improvedNDCGSum += c.improvedNDCG;
+    baselinePositions.push(c.baselineFound ? c.baselinePos : -1);
+    improvedPositions.push(c.improvedFound ? c.improvedPos : -1);
+    trackLengths.push(c.track.length);
+    artistLengths.push(c.artist.length);
+
+    if (c.baselineFound && !c.improvedFound) baselineBetter++;
+    else if (c.improvedFound && !c.baselineFound) improvedBetter++;
+    else if (c.baselineFound && c.improvedFound) {
+      if (c.baselinePos < c.improvedPos) baselineBetter++;
+      else if (c.improvedPos < c.baselinePos) improvedBetter++;
+      else bothSame++;
+    } else bothSame++;
+  }
+
+  baselineMRR /= cases.length;
+  improvedMRR /= cases.length;
+  const baselineNDCG = baselineNDCGSum / cases.length;
+  const improvedNDCG = improvedNDCGSum / cases.length;
+
+  // Boolean arrays for statistical tests
+  const pctMetric = (vals: boolean[]) => (vals.filter((v) => v).length / vals.length) * 100;
+  const baselineP1Arr = cases.map((c) => c.baselinePos === 0);
+  const baselineP5Arr = cases.map((c) => c.baselinePos >= 0 && c.baselinePos < 5);
+  const baselineP10Arr = cases.map((c) => c.baselinePos >= 0 && c.baselinePos < 10);
+  const baselineP25Arr = cases.map((c) => c.baselinePos >= 0 && c.baselinePos < 25);
+  const baselineFoundArr = cases.map((c) => c.baselineFound);
+  const improvedP1Arr = cases.map((c) => c.improvedPos === 0);
+  const improvedP5Arr = cases.map((c) => c.improvedPos >= 0 && c.improvedPos < 5);
+  const improvedP10Arr = cases.map((c) => c.improvedPos >= 0 && c.improvedPos < 10);
+  const improvedP25Arr = cases.map((c) => c.improvedPos >= 0 && c.improvedPos < 25);
+  const improvedFoundArr = cases.map((c) => c.improvedFound);
+
+  const [bP1Pt, bP1Lo, bP1Hi] = bootstrapCI(baselineP1Arr, pctMetric);
+  const [bP5Pt, bP5Lo, bP5Hi] = bootstrapCI(baselineP5Arr, pctMetric);
+  const [bP10Pt, bP10Lo, bP10Hi] = bootstrapCI(baselineP10Arr, pctMetric);
+  const [bP25Pt, bP25Lo, bP25Hi] = bootstrapCI(baselineP25Arr, pctMetric);
+  const [bFPt, bFLo, bFHi] = bootstrapCI(baselineFoundArr, pctMetric);
+  const [iP1Pt, iP1Lo, iP1Hi] = bootstrapCI(improvedP1Arr, pctMetric);
+  const [iP5Pt, iP5Lo, iP5Hi] = bootstrapCI(improvedP5Arr, pctMetric);
+  const [iP10Pt, iP10Lo, iP10Hi] = bootstrapCI(improvedP10Arr, pctMetric);
+  const [iP25Pt, iP25Lo, iP25Hi] = bootstrapCI(improvedP25Arr, pctMetric);
+  const [iFPt, iFLo, iFHi] = bootstrapCI(improvedFoundArr, pctMetric);
+
+  const mcnP1 = mcnemarTest(baselineP1Arr, improvedP1Arr);
+  const mcnP5 = mcnemarTest(baselineP5Arr, improvedP5Arr);
+  const mcnF = mcnemarTest(baselineFoundArr, improvedFoundArr);
+
+  const effP1 = cohensH(bP1Pt, iP1Pt);
+  const effP5 = cohensH(bP5Pt, iP5Pt);
+  const effF = cohensH(bFPt, iFPt);
+
+  const diffP1Arr = improvedP1Arr.map((imp, i) => imp && !baselineP1Arr[i]);
+  const diffP5Arr = improvedP5Arr.map((imp, i) => imp && !baselineP5Arr[i]);
+  const diffFArr = improvedFoundArr.map((imp, i) => imp && !baselineFoundArr[i]);
+  const [, dP1Lo, dP1Hi] = bootstrapCI(diffP1Arr, pctMetric);
+  const [, dP5Lo, dP5Hi] = bootstrapCI(diffP5Arr, pctMetric);
+  const [, dFLo, dFHi] = bootstrapCI(diffFArr, pctMetric);
+
+  const totalElapsed = Date.now() - startTime;
+
+  // API call metrics
+  if (apiMetrics.musicbrainzCalls > 0 || apiMetrics.lastfmCalls > 0) {
+    console.log("\nAPI CALL METRICS:");
+    console.log(`  MusicBrainz: ${apiMetrics.musicbrainzCalls} calls`);
+    if (apiMetrics.musicbrainzRateLimits > 0)
+      console.log(`    Rate limits: ${apiMetrics.musicbrainzRateLimits} (${((apiMetrics.musicbrainzRateLimits / apiMetrics.musicbrainzCalls) * 100).toFixed(1)}%)`);
+    if (apiMetrics.musicbrainzErrors > 0)
+      console.log(`    Errors: ${apiMetrics.musicbrainzErrors} (${((apiMetrics.musicbrainzErrors / apiMetrics.musicbrainzCalls) * 100).toFixed(1)}%)`);
+    if (apiMetrics.lastfmCalls > 0) {
+      console.log(`  Last.fm: ${apiMetrics.lastfmCalls} calls`);
+      if (apiMetrics.lastfmErrors > 0)
+        console.log(`    Errors: ${apiMetrics.lastfmErrors} (${((apiMetrics.lastfmErrors / apiMetrics.lastfmCalls) * 100).toFixed(1)}%)`);
+    }
+    if (apiMetrics.totalAPICallTime > 0) {
+      const avg = apiMetrics.totalAPICallTime / (apiMetrics.musicbrainzCalls + apiMetrics.lastfmCalls);
+      console.log(`  Total API time: ${formatTime(apiMetrics.totalAPICallTime)} (avg: ${formatTime(avg)}/call)`);
+    }
+    console.log();
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log("EVALUATION RESULTS (DEDUPLICATED)");
+  console.log("=".repeat(60));
+  console.log(`\nTest set: ${cases.length} unique scrobbles (from ${validScrobblesCount} total with MBIDs)`);
+  console.log(`Total scrobbles: ${scrobblesTotal}`);
+  console.log(`Deduplication: ${duplicateStats.duplicates} duplicates removed (${(duplicateStats.duplicates / duplicateStats.total * 100).toFixed(1)}%)`);
+  if (totalSearches > 0) {
+    console.log(`Cache performance: Baseline ${((baselineCacheHits / cases.length) * 100).toFixed(1)}% hits, Improved ${((improvedCacheHits / cases.length) * 100).toFixed(1)}% hits`);
+    if (evaluationResultCacheHits > 0)
+      console.log(`  Evaluation results: ${evaluationResultCacheHits}/${cases.length} (${((evaluationResultCacheHits / cases.length) * 100).toFixed(1)}% fully cached)`);
+  }
+  // Per-case API call distribution
+  const uncached = cases.filter((c) => !c.improvedCacheHit);
+  if (uncached.length > 0) {
+    const calls = uncached.map((c) => c.apiCallsImproved).sort((a, b) => a - b);
+    const sum = calls.reduce((a, b) => a + b, 0);
+    const pct = (p: number) => calls[Math.min(Math.floor(calls.length * p), calls.length - 1)];
+    console.log(`API calls/case (n=${calls.length} uncached): mean=${(sum / calls.length).toFixed(2)}, p50=${pct(0.5)}, p90=${pct(0.9)}, p99=${pct(0.99)}, min=${calls[0]}, max=${calls[calls.length - 1]}`);
+  }
+  console.log(`Total time: ${formatTime(totalElapsed)}`);
+  if (cases.length > 0) {
+    console.log(`Performance: ${formatTime(totalElapsed / cases.length)}/case, ${(cases.length / (totalElapsed / 1000)).toFixed(2)} cases/sec`);
+  }
+  console.log();
+
+  const p1Imp = iP1Pt - bP1Pt;
+  const p5Imp = iP5Pt - bP5Pt;
+  const p10Imp = iP10Pt - bP10Pt;
+  const p25Imp = iP25Pt - bP25Pt;
+  const fImp = iFPt - bFPt;
+  const mrrImp = improvedMRR - baselineMRR;
+  const ndcgImp = improvedNDCG - baselineNDCG;
+
+  console.log("BASELINE (Simple Query):");
+  console.log(`  Precision@1: ${bP1Pt.toFixed(1)}% [${bP1Lo.toFixed(1)}%, ${bP1Hi.toFixed(1)}%] (${baselineP1}/${cases.length})`);
+  console.log(`  Precision@5: ${bP5Pt.toFixed(1)}% [${bP5Lo.toFixed(1)}%, ${bP5Hi.toFixed(1)}%] (${baselineP5}/${cases.length})`);
+  console.log(`  Precision@10: ${bP10Pt.toFixed(1)}% [${bP10Lo.toFixed(1)}%, ${bP10Hi.toFixed(1)}%] (${baselineP10}/${cases.length})`);
+  console.log(`  Precision@25: ${bP25Pt.toFixed(1)}% [${bP25Lo.toFixed(1)}%, ${bP25Hi.toFixed(1)}%] (${baselineP25}/${cases.length})`);
+  console.log(`  Findability: ${bFPt.toFixed(1)}% [${bFLo.toFixed(1)}%, ${bFHi.toFixed(1)}%] (${baselineFound}/${cases.length})`);
+  console.log(`  MRR: ${baselineMRR.toFixed(3)}, NDCG@25: ${baselineNDCG.toFixed(3)}\n`);
+
+  const configDesc = [
+    searchConfig.enableCleaning ? "cleaning" : "no-cleaning",
+    searchConfig.enableFuzzy ? "fuzzy" : "no-fuzzy",
+    searchConfig.enableMultiStage ? "multistage" : "no-multistage",
+  ].join(" + ");
+
+  console.log(`IMPROVED (${configDesc}):`);
+  console.log(`  Precision@1: ${iP1Pt.toFixed(1)}% [${iP1Lo.toFixed(1)}%, ${iP1Hi.toFixed(1)}%] (${improvedP1}/${cases.length})`);
+  console.log(`  Precision@5: ${iP5Pt.toFixed(1)}% [${iP5Lo.toFixed(1)}%, ${iP5Hi.toFixed(1)}%] (${improvedP5}/${cases.length})`);
+  console.log(`  Precision@10: ${iP10Pt.toFixed(1)}% [${iP10Lo.toFixed(1)}%, ${iP10Hi.toFixed(1)}%] (${improvedP10}/${cases.length})`);
+  console.log(`  Precision@25: ${iP25Pt.toFixed(1)}% [${iP25Lo.toFixed(1)}%, ${iP25Hi.toFixed(1)}%] (${improvedP25}/${cases.length})`);
+  console.log(`  Findability: ${iFPt.toFixed(1)}% [${iFLo.toFixed(1)}%, ${iFHi.toFixed(1)}%] (${improvedFound}/${cases.length})`);
+  console.log(`  MRR: ${improvedMRR.toFixed(3)}, NDCG@25: ${improvedNDCG.toFixed(3)}\n`);
+
+  console.log("IMPROVEMENT (Primary Metrics):");
+  console.log(`  Precision@1: ${p1Imp > 0 ? "+" : ""}${p1Imp.toFixed(1)}% [${dP1Lo.toFixed(1)}%, ${dP1Hi.toFixed(1)}%]`);
+  console.log(`  Precision@5: ${p5Imp > 0 ? "+" : ""}${p5Imp.toFixed(1)}% [${dP5Lo.toFixed(1)}%, ${dP5Hi.toFixed(1)}%]`);
+  console.log(`  Precision@10: ${p10Imp > 0 ? "+" : ""}${p10Imp.toFixed(1)}%`);
+  console.log(`  Precision@25: ${p25Imp > 0 ? "+" : ""}${p25Imp.toFixed(1)}%`);
+  console.log(`  Findability: ${fImp > 0 ? "+" : ""}${fImp.toFixed(1)}% [${dFLo.toFixed(1)}%, ${dFHi.toFixed(1)}%]`);
+  console.log(`  MRR: ${mrrImp > 0 ? "+" : ""}${mrrImp.toFixed(3)}, NDCG@25: ${ndcgImp > 0 ? "+" : ""}${ndcgImp.toFixed(3)}`);
+
+  console.log("\nSTATISTICAL SIGNIFICANCE:");
+  console.log(`  P@1: ${mcnP1.significant ? "SIGNIFICANT" : "not significant"} (p=${mcnP1.pValue.toFixed(4)})`);
+  console.log(`  P@5: ${mcnP5.significant ? "SIGNIFICANT" : "not significant"} (p=${mcnP5.pValue.toFixed(4)})`);
+  console.log(`  Findability: ${mcnF.significant ? "SIGNIFICANT" : "not significant"} (p=${mcnF.pValue.toFixed(4)})`);
+  console.log(`  Effect size (Cohen's h): P@1=${effP1.toFixed(3)}, P@5=${effP5.toFixed(3)}, Found=${effF.toFixed(3)}\n`);
+
+  // Effective metrics
+  const matchable = cases.filter((c) => c.baselineFound || c.improvedFound);
+  const unmatchable = cases.filter((c) => !c.baselineFound && !c.improvedFound);
+
+  if (matchable.length > 0 && unmatchable.length > 0) {
+    console.log("EFFECTIVE METRICS (excluding unmatchable cases):");
+    console.log(`  Unmatchable: ${unmatchable.length}/${cases.length} (${(unmatchable.length / cases.length * 100).toFixed(1)}%)`);
+    console.log(`  Effective baseline P@1: ${(matchable.filter((c) => c.baselinePos === 0).length / matchable.length * 100).toFixed(1)}%`);
+    console.log(`  Effective improved P@1: ${(matchable.filter((c) => c.improvedPos === 0).length / matchable.length * 100).toFixed(1)}%\n`);
+  }
+
+  // Work-equivalence
+  const workEquiv = cases.filter((c) => c.workEquivalentPos >= 0);
+  if (workEquiv.length > 0) {
+    const disambiguatable = unmatchable.filter((c) => c.workEquivalentPos >= 0);
+    const trulyUnmatchable = unmatchable.filter((c) => c.workEquivalentPos < 0);
+    console.log("RECORDING DISAMBIGUATION (work-equivalence):");
+    console.log(`  Cases with same work, different recording: ${workEquiv.length}`);
+    console.log(`  Adjusted unmatchable rate: ${(trulyUnmatchable.length / cases.length * 100).toFixed(1)}% (was ${(unmatchable.length / cases.length * 100).toFixed(1)}%)\n`);
+  }
+
+  console.log("COMPARATIVE PERFORMANCE:");
+  console.log(`  Baseline better: ${baselineBetter}, Improved better: ${improvedBetter}, Same: ${bothSame}`);
+  if (cases.length > 0) {
+    console.log(`  Improved win rate: ${(improvedBetter / cases.length * 100).toFixed(1)}%\n`);
+  }
+
+  // Position distribution
+  const bPosDist = {
+    notFound: baselinePositions.filter((p) => p === -1).length,
+    pos1: baselinePositions.filter((p) => p === 0).length,
+    pos2to5: baselinePositions.filter((p) => p >= 1 && p < 5).length,
+    pos6to10: baselinePositions.filter((p) => p >= 5 && p < 10).length,
+    pos11to25: baselinePositions.filter((p) => p >= 10 && p < 25).length,
+  };
+  const iPosDist = {
+    notFound: improvedPositions.filter((p) => p === -1).length,
+    pos1: improvedPositions.filter((p) => p === 0).length,
+    pos2to5: improvedPositions.filter((p) => p >= 1 && p < 5).length,
+    pos6to10: improvedPositions.filter((p) => p >= 5 && p < 10).length,
+    pos11to25: improvedPositions.filter((p) => p >= 10 && p < 25).length,
+  };
+
+  console.log("POSITION DISTRIBUTION:");
+  console.log("  Baseline:");
+  console.log(`    Not found: ${bPosDist.notFound} (${(bPosDist.notFound / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 1: ${bPosDist.pos1} (${(bPosDist.pos1 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 2-5: ${bPosDist.pos2to5} (${(bPosDist.pos2to5 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 6-10: ${bPosDist.pos6to10} (${(bPosDist.pos6to10 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 11-25: ${bPosDist.pos11to25} (${(bPosDist.pos11to25 / cases.length * 100).toFixed(1)}%)`);
+  console.log("  Improved:");
+  console.log(`    Not found: ${iPosDist.notFound} (${(iPosDist.notFound / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 1: ${iPosDist.pos1} (${(iPosDist.pos1 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 2-5: ${iPosDist.pos2to5} (${(iPosDist.pos2to5 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 6-10: ${iPosDist.pos6to10} (${(iPosDist.pos6to10 / cases.length * 100).toFixed(1)}%)`);
+  console.log(`    Position 11-25: ${iPosDist.pos11to25} (${(iPosDist.pos11to25 / cases.length * 100).toFixed(1)}%)\n`);
+
+  // Hardness-stratified metrics
+  const hardnessStats: Record<string, { count: number; bP1: number; iP1: number; bP5: number; iP5: number; bF: number; iF: number }> = {
+    easy: { count: 0, bP1: 0, iP1: 0, bP5: 0, iP5: 0, bF: 0, iF: 0 },
+    medium: { count: 0, bP1: 0, iP1: 0, bP5: 0, iP5: 0, bF: 0, iF: 0 },
+    hard: { count: 0, bP1: 0, iP1: 0, bP5: 0, iP5: 0, bF: 0, iF: 0 },
+  };
+  for (const c of cases) {
+    const h = c.hardness || "medium";
+    const s = hardnessStats[h];
+    s.count++;
+    if (c.baselinePos === 0) s.bP1++;
+    if (c.improvedPos === 0) s.iP1++;
+    if (c.baselinePos >= 0 && c.baselinePos < 5) s.bP5++;
+    if (c.improvedPos >= 0 && c.improvedPos < 5) s.iP5++;
+    if (c.baselineFound) s.bF++;
+    if (c.improvedFound) s.iF++;
+  }
+
+  console.log("QUERY HARDNESS-STRATIFIED METRICS:\n");
+  for (const [level, s] of Object.entries(hardnessStats)) {
+    if (s.count === 0) continue;
+    const bP1 = (s.bP1 / s.count * 100).toFixed(1);
+    const iP1 = (s.iP1 / s.count * 100).toFixed(1);
+    const bP5 = (s.bP5 / s.count * 100).toFixed(1);
+    const iP5 = (s.iP5 / s.count * 100).toFixed(1);
+    const bFound = (s.bF / s.count * 100).toFixed(1);
+    const iFound = (s.iF / s.count * 100).toFixed(1);
+    console.log(`  ${level.toUpperCase()} (${s.count} cases, ${(s.count / cases.length * 100).toFixed(1)}%):`);
+    console.log(`    Baseline: P@1=${bP1}%, P@5=${bP5}%, Found=${bFound}%`);
+    console.log(`    Improved: P@1=${iP1}%, P@5=${iP5}%, Found=${iFound}%\n`);
+  }
+
+  // Failure mode analysis
+  const failureModes = ["featuring", "remix", "live", "parenthetical", "special_chars", "short_name", "standard"];
+  console.log("STRATIFIED FAILURE MODE ANALYSIS:\n");
+  for (const mode of failureModes) {
+    const modeCases = cases.filter((c) => c.failureMode === mode);
+    if (modeCases.length === 0) continue;
+    const bP1 = (modeCases.filter((c) => c.baselinePos === 0).length / modeCases.length * 100).toFixed(1);
+    const iP1 = (modeCases.filter((c) => c.improvedPos === 0).length / modeCases.length * 100).toFixed(1);
+    const bF = (modeCases.filter((c) => c.baselineFound).length / modeCases.length * 100).toFixed(1);
+    const iF = (modeCases.filter((c) => c.improvedFound).length / modeCases.length * 100).toFixed(1);
+    console.log(`  ${mode.toUpperCase().replace(/_/g, " ")} (${modeCases.length} cases):`);
+    console.log(`    Baseline: P@1=${bP1}%, Found=${bF}%`);
+    console.log(`    Improved: P@1=${iP1}%, Found=${iF}%\n`);
+  }
+
+  // Improvement examples
+  const improvements = cases.filter(
+    (c) => (!c.baselineFound && c.improvedFound) || (c.baselineFound && c.improvedFound && c.improvedPos < c.baselinePos),
+  );
+  if (improvements.length > 0) {
+    console.log(`IMPROVEMENT EXAMPLES (${Math.min(5, improvements.length)} of ${improvements.length}):`);
+    for (let i = 0; i < Math.min(5, improvements.length); i++) {
+      const ex = improvements[i];
+      console.log(`  "${ex.track}" by ${ex.artist || "[no artist]"}`);
+      console.log(`    Baseline: ${ex.baselineFound ? `position ${ex.baselinePos + 1}` : "not found"}`);
+      console.log(`    Improved: ${ex.improvedFound ? `position ${ex.improvedPos + 1}` : "not found"}`);
+    }
+  }
+
+  // Regression examples
+  const regressions = cases.filter(
+    (c) => (c.baselineFound && !c.improvedFound) || (c.baselineFound && c.improvedFound && c.baselinePos < c.improvedPos),
+  );
+  if (regressions.length > 0) {
+    console.log(`\nREGRESSION EXAMPLES (${Math.min(3, regressions.length)} of ${regressions.length}):`);
+    for (let i = 0; i < Math.min(3, regressions.length); i++) {
+      const ex = regressions[i];
+      console.log(`  "${ex.track}" by ${ex.artist}`);
+      console.log(`    Baseline: ${ex.baselineFound ? `position ${ex.baselinePos + 1}` : "not found"}`);
+      console.log(`    Improved: ${ex.improvedFound ? `position ${ex.improvedPos + 1}` : "not found"}`);
+    }
+  }
+
+  // Save results JSON
+  const archiveDir = join(process.cwd(), "scripts", "eval", "results", "archive", new Date().toISOString().split("T")[0]);
+  mkdirSync(archiveDir, { recursive: true });
+  const resultsFile = join(archiveDir, "lastfm-evaluation-results.json");
+  writeFileSync(
+    resultsFile,
+    JSON.stringify(
+      {
+        timestamp: new Date().toISOString(),
+        scrobbles_total: scrobblesTotal,
+        scrobbles_with_mbid: validScrobblesCount,
+        deduplication: { ...duplicateStats, distribution: duplicateDistribution },
+        metrics: {
+          baseline_p1: bP1Pt, baseline_p5: bP5Pt, baseline_p10: bP10Pt, baseline_p25: bP25Pt,
+          baseline_findability: bFPt,
+          improved_p1: iP1Pt, improved_p5: iP5Pt, improved_p10: iP10Pt, improved_p25: iP25Pt,
+          improved_findability: iFPt,
+          p1_improvement: p1Imp, p5_improvement: p5Imp, p10_improvement: p10Imp,
+          p25_improvement: p25Imp, findability_improvement: fImp,
+          baseline_mrr: baselineMRR, improved_mrr: improvedMRR, mrr_improvement: mrrImp,
+          baseline_ndcg: baselineNDCG, improved_ndcg: improvedNDCG, ndcg_improvement: ndcgImp,
+          baseline_better: baselineBetter, improved_better: improvedBetter, same_result: bothSame,
+          avg_api_calls_improved: (() => {
+            const uncached = cases.filter((c) => !c.improvedCacheHit);
+            if (uncached.length === 0) return null;
+            const sum = uncached.reduce((a, c) => a + c.apiCallsImproved, 0);
+            return Math.round((sum / uncached.length) * 100) / 100;
+          })(),
+        },
+        api_metrics: {
+          musicbrainz_calls: apiMetrics.musicbrainzCalls,
+          musicbrainz_rate_limits: apiMetrics.musicbrainzRateLimits,
+          musicbrainz_errors: apiMetrics.musicbrainzErrors,
+          lastfm_calls: apiMetrics.lastfmCalls,
+          lastfm_errors: apiMetrics.lastfmErrors,
+          total_api_call_time_ms: apiMetrics.totalAPICallTime,
+        },
+        cases: cases.map((c) => ({
+          track: c.track, artist: c.artist, album: c.album, mbid: c.mbid,
+          baseline_pos: c.baselinePos >= 0 ? c.baselinePos + 1 : null,
+          improved_pos: c.improvedPos >= 0 ? c.improvedPos + 1 : null,
+          baseline_found: c.baselineFound, improved_found: c.improvedFound,
+          failure_mode: c.failureMode, hardness: c.hardness,
+          matchability: c.baselineFound || c.improvedFound ? "matchable"
+            : c.workEquivalentPos >= 0 ? "work_equivalent" : "unmatchable",
+          field_combination: c.fieldCombination, duplicate_count: c.duplicateCount,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`\nResults saved to: ${resultsFile}`);
+}

--- a/scripts/eval/search.ts
+++ b/scripts/eval/search.ts
@@ -1,0 +1,359 @@
+/**
+ * Search functions for the evaluation harness.
+ *
+ * Baseline: raw Lucene query (matches the old searchMusicbrainz in oldStamp.tsx).
+ * Improved: mirrors the production searchOrchestrator pipeline but wraps each
+ * search stage with a SQLite cache layer (cachedSearchStage) so that MB API
+ * responses persist across eval runs. The production code only has an in-memory
+ * 5-min cache, which is fine for interactive use but not for repeatable evaluation.
+ */
+
+import {
+  MUSICBRAINZ_BASE_URL,
+  USER_AGENT,
+  RATE_LIMIT_DELAY,
+  type SearchResult,
+  type SearchConfig,
+  type APIMetrics,
+} from "./types.js";
+import type { LastFMCache } from "./evaluate-lastfm-cache.js";
+import {
+  cleanTrackName,
+  cleanArtistName,
+  cleanReleaseName,
+  normalizeForComparison,
+} from "../../apps/amethyst/lib/musicbrainzCleaner.js";
+import {
+  escapeLucene,
+  searchStage,
+  hasCJK,
+  resolveArtistAlias,
+  PARTIAL_THRESHOLD,
+} from "../../apps/amethyst/lib/musicbrainzSearchUtils.js";
+import {
+  rankMultiStageResults,
+  type RankingQuery,
+} from "../../apps/amethyst/lib/musicbrainzRanking.js";
+
+/**
+ * Baseline search (original "funny search string").
+ *
+ * Uses escapeLucene() for safety (prevents query injection), making baseline
+ * slightly better than the true original, but this is a correctness fix.
+ */
+export async function baselineSearch(
+  track: string,
+  artist: string,
+  release: string | undefined,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<SearchResult[]> {
+  if (cache) {
+    const cached = cache.getSearchResults(track, artist, release, false, false, false);
+    if (cached !== null) return cached;
+  }
+
+  const queryParts: string[] = [];
+  if (track) queryParts.push(`title:"${escapeLucene(track)}"`);
+  if (artist) queryParts.push(`artist:"${escapeLucene(artist)}"`);
+  if (release) queryParts.push(`release:"${escapeLucene(release)}"`);
+
+  if (queryParts.length === 0) return [];
+
+  const query = queryParts.join(" AND ");
+  const url = `${MUSICBRAINZ_BASE_URL}/recording?query=${encodeURIComponent(query)}&fmt=json&limit=25`;
+
+  await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+
+  let retries = 3;
+  let delay = 1000;
+
+  while (retries > 0) {
+    try {
+      const apiCallStart = Date.now();
+      const res = await fetch(url, {
+        headers: { "User-Agent": USER_AGENT },
+      });
+      const apiCallTime = Date.now() - apiCallStart;
+
+      if (apiMetrics) {
+        apiMetrics.musicbrainzCalls++;
+        apiMetrics.totalAPICallTime += apiCallTime;
+      }
+
+      if (res.status === 503) {
+        if (apiMetrics) apiMetrics.musicbrainzRateLimits++;
+        retries--;
+        if (retries > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          delay *= 2;
+          continue;
+        }
+        const results: SearchResult[] = [];
+        if (cache) cache.setSearchResults(track, artist, release, results, false, false, false);
+        return results;
+      }
+
+      if (!res.ok) {
+        if (apiMetrics) apiMetrics.musicbrainzErrors++;
+        const results: SearchResult[] = [];
+        if (cache) cache.setSearchResults(track, artist, release, results, false, false, false);
+        return results;
+      }
+
+      const data = await res.json();
+      const rawResults = data.recordings || [];
+      const results = rawResults.filter(
+        (r: SearchResult): r is SearchResult & { id: string } => !!r.id,
+      );
+      if (cache) cache.setSearchResults(track, artist, release, results, false, false, false);
+      return results;
+    } catch (error) {
+      if (apiMetrics) apiMetrics.musicbrainzErrors++;
+      retries--;
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2;
+        continue;
+      }
+      const results: SearchResult[] = [];
+      if (cache) cache.setSearchResults(track, artist, release, results, false, false, false);
+      return results;
+    }
+  }
+
+  const results: SearchResult[] = [];
+  if (cache) cache.setSearchResults(track, artist, release, results, false, false, false);
+  return results;
+}
+
+/**
+ * Cache-aware search stage for the eval harness.
+ * Checks SQLite cache before calling the real searchStage (which only has
+ * an in-memory 5-min cache). Stores results back for cross-run reuse.
+ * The mb_search_cache is keyed by (track, artist, album, strategy) and
+ * never invalidated -- raw MB API responses don't change with our code.
+ */
+async function cachedSearchStage(
+  track: string | undefined,
+  artist: string | undefined,
+  release: string | undefined,
+  strategy: "exact" | "fuzzy" | "partial",
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<SearchResult[]> {
+  // Check SQLite cache first
+  if (cache) {
+    const cached = cache.getSearchResults(
+      track ?? "", artist ?? "", release, false, false, false, strategy,
+    );
+    if (cached !== null) return cached.filter(
+      (r: SearchResult): r is SearchResult & { id: string } => !!r.id,
+    );
+  }
+
+  const stageStart = Date.now();
+  const raw = (await searchStage(track, artist, release, strategy)) as SearchResult[];
+  if (apiMetrics && (track || artist || release)) {
+    apiMetrics.musicbrainzCalls++;
+    apiMetrics.totalAPICallTime += Date.now() - stageStart;
+  }
+  const results = raw.filter(
+    (r): r is SearchResult & { id: string } => !!r.id,
+  );
+
+  // Store in SQLite for cross-run reuse
+  if (cache) {
+    cache.setSearchResults(
+      track ?? "", artist ?? "", release, results, false, false, false, strategy,
+    );
+  }
+
+  return results;
+}
+
+/**
+ * Check if exact search results are "good enough" to skip later stages.
+ * Mirrors production exactResultsSufficient in searchOrchestrator.ts.
+ */
+function exactResultsSufficient(
+  results: SearchResult[],
+  cleanedTrack: string | undefined,
+  hasArtist: boolean,
+): boolean {
+  if (results.length === 0) return false;
+
+  const topScore = results[0]?.score ?? 100;
+
+  if (hasArtist) {
+    return topScore >= 70 || results.length >= 3;
+  }
+
+  if (results.length >= 2) return true;
+  const first = results[0];
+  if (first?.title && cleanedTrack) {
+    const norm = normalizeForComparison(first.title);
+    const trackNorm = normalizeForComparison(cleanedTrack);
+    return norm === trackNorm || norm.startsWith(trackNorm + " ");
+  }
+  return false;
+}
+
+/**
+ * Improved search matching production orchestrator (searchOrchestrator.ts).
+ *
+ * Pipeline: clean -> exact (fallback to original if 0) -> fuzzy -> track-only
+ * Expected API calls: 1 (best), 2 (typical miss), 3 (worst)
+ */
+export async function improvedSearchWithConfig(
+  track: string,
+  artist: string,
+  release: string | undefined,
+  config: SearchConfig,
+  cache?: LastFMCache,
+  apiMetrics?: APIMetrics,
+): Promise<SearchResult[]> {
+  let cleanedTrack: string | undefined;
+  let cleanedArtist: string | undefined;
+  let cleanedRelease: string | undefined;
+
+  if (config.enableCleaning) {
+    cleanedTrack = track ? cleanTrackName(track) || undefined : undefined;
+    cleanedArtist = artist ? cleanArtistName(artist) || undefined : undefined;
+    cleanedRelease = release ? cleanReleaseName(release) || undefined : undefined;
+  } else {
+    cleanedTrack = track || undefined;
+    cleanedArtist = artist || undefined;
+    cleanedRelease = release || undefined;
+  }
+
+  const cleaningChangedTrack = cleanedTrack !== undefined && cleanedTrack !== track;
+  const cleaningChangedArtist = cleanedArtist !== undefined && cleanedArtist !== artist;
+
+  // Stage 1a: Exact match WITH release (if available).
+  // Narrows to specific recording on that album -- critical for popular tracks.
+  let exactWithRelease: SearchResult[] = [];
+  if (cleanedRelease) {
+    exactWithRelease = await cachedSearchStage(
+      cleanedTrack, cleanedArtist, cleanedRelease, "exact", cache, apiMetrics,
+    );
+  }
+
+  // Stage 1b: Exact match WITHOUT release.
+  // Skip if 1a already got sufficient results (saves 1 API call in the common case).
+  // Still run if 1a got 0 results (release name might differ between scrobbler and MB).
+  let exactWithoutRelease: SearchResult[] = [];
+  if (!exactResultsSufficient(exactWithRelease, cleanedTrack, !!cleanedArtist)) {
+    exactWithoutRelease = await cachedSearchStage(
+      cleanedTrack, cleanedArtist, undefined, "exact", cache, apiMetrics,
+    );
+  }
+
+  // Stage 1c: If cleaning changed names and both stages got 0, retry with originals
+  let originalExactResults: SearchResult[] = [];
+  if (exactWithRelease.length === 0 && exactWithoutRelease.length === 0 &&
+      (cleaningChangedTrack || cleaningChangedArtist)) {
+    originalExactResults = await cachedSearchStage(
+      track || undefined, artist || undefined, undefined,
+      "exact", cache, apiMetrics,
+    );
+  }
+
+  // Stage 1d: CJK artist alias resolution (mirrors searchOrchestrator.ts)
+  let cjkAliasResults: SearchResult[] = [];
+  const artistForSearch = cleanedArtist || artist;
+  if (
+    exactWithRelease.length === 0 &&
+    exactWithoutRelease.length === 0 &&
+    originalExactResults.length === 0 &&
+    artistForSearch &&
+    hasCJK(artistForSearch)
+  ) {
+    const romanized = await resolveArtistAlias(artistForSearch);
+    if (romanized && romanized !== artistForSearch) {
+      cjkAliasResults = await cachedSearchStage(
+        cleanedTrack, romanized, cleanedRelease || undefined,
+        "exact", cache, apiMetrics,
+      );
+    }
+  }
+
+  const combinedExact = [
+    ...exactWithRelease, ...exactWithoutRelease,
+    ...originalExactResults, ...cjkAliasResults,
+  ];
+  const hasArtist = !!cleanedArtist;
+
+  // Early exit: good exact results -> rank (matches production behavior)
+  const sufficient = exactResultsSufficient(
+    combinedExact,
+    cleanedTrack,
+    hasArtist,
+  );
+  if (sufficient) {
+    // Rank even on early exit (matches production searchOrchestrator behavior).
+    // Ranking applies variant matching, release quality, and text-match boosts
+    // that can improve on MB's default Lucene ordering.
+    const rankingQuery: RankingQuery = {
+      track,
+      artist,
+      release,
+      cleanedTrack: config.enableCleaning ? cleanedTrack : undefined,
+      cleanedArtist: config.enableCleaning ? cleanedArtist : undefined,
+      cleanedRelease: config.enableCleaning ? cleanedRelease : undefined,
+    };
+    return rankMultiStageResults(
+      [{ results: combinedExact, strategy: "exact" as const }],
+      rankingQuery,
+    ).slice(0, 25);
+  }
+
+  const needsMoreStages =
+    combinedExact.length === 0 ||
+    (!hasArtist && combinedExact.length === 1);
+
+  // Stage 2: Fuzzy match (no release constraint)
+  let fuzzyResults: SearchResult[] = [];
+  if (needsMoreStages && config.enableMultiStage && config.enableFuzzy && (cleanedTrack || cleanedArtist)) {
+    fuzzyResults = await cachedSearchStage(
+      cleanedTrack, cleanedArtist, undefined, "fuzzy", cache, apiMetrics,
+    );
+  }
+
+  // Stage 3: Track-only fallback (drops artist constraint)
+  let trackOnlyResults: SearchResult[] = [];
+  const totalSoFar = combinedExact.length + fuzzyResults.length;
+  if (needsMoreStages && config.enableMultiStage && totalSoFar < PARTIAL_THRESHOLD && track && artist) {
+    trackOnlyResults = await cachedSearchStage(
+      cleanedTrack ?? (track || undefined), undefined,
+      undefined, "exact", cache, apiMetrics,
+    );
+  }
+
+  // Rank and combine all stages
+  const stageResultsForRanking = [
+    { results: exactWithRelease, strategy: "exact" as const },
+    { results: exactWithoutRelease, strategy: "exact" as const },
+    { results: originalExactResults, strategy: "exact" as const },
+    { results: cjkAliasResults, strategy: "exact" as const },
+    { results: fuzzyResults, strategy: "fuzzy" as const },
+    { results: trackOnlyResults, strategy: "exact" as const },
+  ].filter((stage) => stage.results.length > 0);
+
+  let finalResults: SearchResult[];
+  if (stageResultsForRanking.length > 0) {
+    const rankingQuery: RankingQuery = {
+      track,
+      artist,
+      release,
+      cleanedTrack: config.enableCleaning ? cleanedTrack : undefined,
+      cleanedArtist: config.enableCleaning ? cleanedArtist : undefined,
+      cleanedRelease: config.enableCleaning ? cleanedRelease : undefined,
+    };
+    finalResults = rankMultiStageResults(stageResultsForRanking, rankingQuery);
+  } else {
+    finalResults = [];
+  }
+
+  return finalResults.slice(0, 25);
+}

--- a/scripts/eval/statistics.ts
+++ b/scripts/eval/statistics.ts
@@ -1,0 +1,162 @@
+/**
+ * Statistical functions for evaluation metrics.
+ * Pure functions, no external dependencies.
+ */
+
+/**
+ * Complementary error function (erfc) via Horner approximation.
+ * Abramowitz & Stegun formula 7.1.26, max error ~1.5e-7.
+ * Used for chi-squared p-value with 1 df: p = erfc(sqrt(chi2/2)).
+ */
+export function erfc(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+  const t = 1.0 / (1.0 + p * absX);
+  const y =
+    1.0 -
+    ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) *
+      t *
+      Math.exp(-absX * absX);
+  return 1.0 - sign * y;
+}
+
+/**
+ * Bootstrap confidence intervals.
+ * Returns [point estimate, lower bound, upper bound].
+ */
+export function bootstrapCI(
+  values: boolean[],
+  metric: (vals: boolean[]) => number,
+  iterations: number = 10000,
+  confidence: number = 0.95,
+): [number, number, number] {
+  const n = values.length;
+
+  if (n < 30) {
+    const point = metric(values);
+    const successes = values.filter((v) => v).length;
+    const p = successes / n;
+    const se = Math.sqrt((p * (1 - p)) / n);
+    const tCrit = 2.045;
+    const margin = tCrit * se;
+    return [point, Math.max(0, point - margin), Math.min(100, point + margin)];
+  }
+
+  const allSame = values.every((v) => v === values[0]);
+  if (allSame) {
+    const point = metric(values);
+    return [point, point, point];
+  }
+
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const resample: boolean[] = [];
+    for (let j = 0; j < n; j++) {
+      resample.push(values[Math.floor(Math.random() * n)]);
+    }
+    samples.push(metric(resample));
+  }
+
+  samples.sort((a, b) => a - b);
+  const alpha = 1 - confidence;
+  const lowerIdx = Math.floor(iterations * (alpha / 2));
+  const upperIdx = Math.floor(iterations * (1 - alpha / 2));
+  const point = metric(values);
+
+  return [point, samples[lowerIdx], samples[upperIdx]];
+}
+
+/**
+ * McNemar's test for paired binary classification.
+ * Tests whether two classifiers have significantly different error rates.
+ */
+export function mcnemarTest(
+  baselineCorrect: boolean[],
+  improvedCorrect: boolean[],
+): { statistic: number; pValue: number; significant: boolean } {
+  if (baselineCorrect.length !== improvedCorrect.length) {
+    throw new Error("McNemar test requires arrays of equal length");
+  }
+
+  let b01 = 0; // Baseline wrong, improved correct
+  let b10 = 0; // Baseline correct, improved wrong
+
+  for (let i = 0; i < baselineCorrect.length; i++) {
+    const b = baselineCorrect[i];
+    const imp = improvedCorrect[i];
+    if (!b && imp) b01++;
+    else if (b && !imp) b10++;
+  }
+
+  const discordant = b01 + b10;
+
+  if (discordant === 0) {
+    return { statistic: 0, pValue: 1.0, significant: false };
+  }
+
+  // Exact binomial test for small samples
+  if (discordant < 25) {
+    const n = discordant;
+    const k = Math.max(b01, b10);
+    let pValue = 0;
+
+    for (let x = k; x <= n; x++) {
+      let logCoeff = 0;
+      for (let i = 0; i < x; i++) {
+        logCoeff += Math.log(n - i) - Math.log(i + 1);
+      }
+      pValue += Math.exp(logCoeff - n * Math.log(2));
+    }
+    pValue = Math.min(1.0, pValue * 2);
+
+    return { statistic: 0, pValue, significant: pValue < 0.05 };
+  }
+
+  // Chi-squared approximation with continuity correction
+  const chi2 = Math.pow(Math.abs(b01 - b10) - 1, 2) / discordant;
+  const pValue = erfc(Math.sqrt(chi2 / 2));
+
+  return { statistic: chi2, pValue, significant: pValue < 0.05 };
+}
+
+/** Cohen's h for effect size between two proportions (as percentages). */
+export function cohensH(p1: number, p2: number): number {
+  const h1 = 2 * Math.asin(Math.sqrt(p1 / 100));
+  const h2 = 2 * Math.asin(Math.sqrt(p2 / 100));
+  return h1 - h2;
+}
+
+/**
+ * Discounted Cumulative Gain at position p.
+ * DCG_p = sum(rel_i / log2(i + 1)) for i from 1 to p
+ */
+export function dcg(relevance: number[], p: number = Infinity): number {
+  const limit = Math.min(p, relevance.length);
+  return relevance
+    .slice(0, limit)
+    .reduce((sum, rel, i) => sum + rel / Math.log2(i + 2), 0);
+}
+
+/**
+ * Normalized Discounted Cumulative Gain at position p.
+ * NDCG_p = DCG_p / IDCG_p
+ */
+export function ndcg(
+  actualRelevance: number[],
+  p: number = Infinity,
+): number {
+  if (actualRelevance.length === 0) return 0;
+
+  const idealRelevance = [...actualRelevance].sort((a, b) => b - a);
+  const dcgActual = dcg(actualRelevance, p);
+  const idcg = dcg(idealRelevance, p);
+
+  if (idcg === 0) return 0;
+  return dcgActual / idcg;
+}

--- a/scripts/eval/types.ts
+++ b/scripts/eval/types.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared types, constants, and helpers for the evaluation harness.
+ */
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+export const MUSICBRAINZ_BASE_URL = "https://musicbrainz.org/ws/2";
+export const USER_AGENT = "tealtracker/0.0.1 (https://github.com/teal-fm/teal)";
+// 1 second between MusicBrainz API calls (default).
+// Honors MB_RATE_LIMIT_MS env var -- set to 0 when using a rotating proxy.
+export const RATE_LIMIT_DELAY = (() => {
+  if (typeof process !== "undefined" && process.env?.MB_RATE_LIMIT_MS != null) {
+    const v = parseInt(process.env.MB_RATE_LIMIT_MS, 10);
+    return Number.isFinite(v) && v >= 0 ? v : 1000;
+  }
+  return 1000;
+})();
+
+// ── Interfaces ─────────────────────────────────────────────────────────
+
+export interface CachedScrobble {
+  track: string;
+  artist: string;
+  album?: string;
+  mbid: string | null;
+  mbid_source: MBIDSource | null;
+  timestamp: string; // ISO timestamp from Last.fm
+}
+
+export interface ScrobbleCache {
+  timestamp: string;
+  username: string;
+  scrobbles: CachedScrobble[];
+}
+
+export interface LastFMTrack {
+  name: string;
+  artist: { "#text": string; mbid?: string };
+  album?: { "#text": string };
+  mbid?: string;
+  "@attr"?: { nowplaying?: string };
+  date?: { "#text": string; uts: string };
+}
+
+export interface LastFMResponse {
+  recenttracks: {
+    track: LastFMTrack | LastFMTrack[];
+    "@attr": {
+      total: string;
+      page: string;
+      perPage: string;
+      totalPages: string;
+    };
+  };
+}
+
+export interface SearchResult {
+  id: string;
+  title: string;
+  score?: number; // MB API relevance score (0-100)
+  disambiguation?: string;
+  "first-release-date"?: string;
+  "artist-credit"?: Array<{
+    artist: { id: string; name: string };
+    name: string;
+  }>;
+  releases?: Array<{
+    title: string;
+    id: string;
+    status?: string;
+    date?: string;
+  }>;
+}
+
+export interface SearchConfig {
+  enableCleaning: boolean;
+  enableFuzzy: boolean;
+  enableMultiStage: boolean;
+}
+
+export interface APIMetrics {
+  musicbrainzCalls: number;
+  musicbrainzRateLimits: number;
+  musicbrainzErrors: number;
+  lastfmCalls: number;
+  lastfmErrors: number;
+  totalAPICallTime: number; // milliseconds
+}
+
+export interface EvaluationCase {
+  track: string;
+  artist: string;
+  album?: string;
+  mbid: string;
+  baselinePos: number; // -1 if not found
+  improvedPos: number; // -1 if not found
+  baselineFound: boolean;
+  improvedFound: boolean;
+  baselineNDCG: number;
+  improvedNDCG: number;
+  failureMode?: string;
+  duplicateCount?: number;
+  fieldCombination?: string;
+  hardness?: "easy" | "medium" | "hard";
+  baselineCacheHit?: boolean;
+  improvedCacheHit?: boolean;
+  workEquivalentPos: number;
+  workEquivalentSource: "baseline" | "improved" | null;
+  apiCallsImproved: number;
+  improvedTopIds?: string[];
+  baselineTopIds?: string[];
+}
+
+/**
+ * Provenance of an MBID -- tracks how the MBID was obtained to prevent
+ * ground-truth circularity. Only "lastfm_track_info", "track_data", and
+ * "listenbrainz_acr" are safe to use as evaluation ground truth; the
+ * others are derived from the same MusicBrainz search we are evaluating.
+ */
+export type MBIDSource =
+  | "lastfm_track_info"     // From Last.fm track.getInfo API (independent ground truth)
+  | "lastfm_search"         // From Last.fm track.search API (semi-independent)
+  | "musicbrainz_search"    // From MusicBrainz recording search (CIRCULAR -- not ground truth)
+  | "listenbrainz_acr"      // From ListenBrainz ACR lookup (independent canonical mapping)
+  | "track_data";           // From Last.fm scrobble's own .mbid field (independent)
+
+/** Ground-truth-safe MBID sources (independent of MB search). */
+export const GROUND_TRUTH_SOURCES: ReadonlySet<MBIDSource> = new Set([
+  "lastfm_track_info",
+  "lastfm_search",
+  "listenbrainz_acr",
+  "track_data",
+]);
+
+export interface MBIDResult {
+  mbid: string | null;
+  source: MBIDSource | null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Format milliseconds as human-readable duration. */
+export function formatTime(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  if (hours > 0) return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}
+
+/** Estimate time remaining given elapsed time and progress. */
+export function calculateETA(
+  elapsed: number,
+  completed: number,
+  total: number,
+): string {
+  if (completed === 0 || completed >= total) return "0s";
+  const avgTimePerItem = elapsed / completed;
+  const remaining = total - completed;
+  return formatTime(avgTimePerItem * remaining);
+}
+
+/** Create a fresh APIMetrics object. */
+export function createAPIMetrics(): APIMetrics {
+  return {
+    musicbrainzCalls: 0,
+    musicbrainzRateLimits: 0,
+    musicbrainzErrors: 0,
+    lastfmCalls: 0,
+    lastfmErrors: 0,
+    totalAPICallTime: 0,
+  };
+}

--- a/services/cadet/Cargo.toml
+++ b/services/cadet/Cargo.toml
@@ -41,3 +41,4 @@ futures = "0.3"
 redis.workspace = true
 chrono.workspace = true
 uuid.workspace = true
+unicode-normalization = "0.1"

--- a/services/cadet/Cargo.toml
+++ b/services/cadet/Cargo.toml
@@ -24,17 +24,14 @@ async-trait.workspace = true
 sqlx = { workspace = true, features = ["time"] }
 time.workspace = true
 dotenvy.workspace = true
-multihash-codetable = { version = "0.1.4", features = ["sha2", "serde"] }
+multihash-codetable = { version = "0.2.2", features = ["sha2", "serde"] }
 multibase = "0.9.1"
 jacquard-common.workspace = true
 
 # CAR file processing
 iroh-car.workspace = true
-libipld.workspace = true
-cid.workspace = true
 base64.workspace = true
 atmst = "0.0.1"
-serde_ipld_dagcbor = "0.6"
 futures = "0.3"
 
 # Redis for job queues

--- a/services/cadet/Dockerfile
+++ b/services/cadet/Dockerfile
@@ -37,12 +37,12 @@ RUN ./scripts/setup-lexicons.sh
 
 # Install Node.js and pnpm for lexicon generation
 RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.15.0
 
 # Install dependencies and generate lexicons
 RUN pnpm install
 RUN cd tools/lexicon-cli && pnpm build
-RUN pnpm lex:gen
+RUN pnpm lex:gen --rust-only
 
 # Install cross-compilation toolchains
 RUN rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu

--- a/services/cadet/src/ingestors/car/car_import.rs
+++ b/services/cadet/src/ingestors/car/car_import.rs
@@ -37,7 +37,6 @@ use async_trait::async_trait;
 use atmst::{mst::Mst, Bytes, CarImporter};
 use base64::Engine;
 use futures::StreamExt;
-use jacquard_common::types::did::Did;
 use jacquard_common::types::value;
 use redis::AsyncCommands;
 use rocketman::{ingestion::LexiconIngestor, types::event::Event};
@@ -310,8 +309,8 @@ impl CarImportIngestor {
 
     /// Process a play record using the existing PlayIngestor
     async fn process_play_record(&self, data: &Value, did: &str, rkey: &str) -> Result<()> {
-        let data = value::Data::from_json(data)?;
-        let play_record = value::from_data::<types::fm_teal::alpha::feed::play::Play>(&data)?;
+        let play_record: types::fm_teal::alpha::feed::play::Play =
+            value::from_json_value::<types::fm_teal::alpha::feed::play::Play>(data.clone())?;
 
         let play_ingestor = super::super::teal::feed_play::PlayIngestor::new(self.sql.clone());
         let uri = super::super::teal::assemble_at_uri(did, "fm.teal.alpha.feed.play", rkey);
@@ -335,17 +334,14 @@ impl CarImportIngestor {
 
     /// Process a profile record using the existing ActorProfileIngestor
     async fn process_profile_record(&self, data: &Value, did: &str, _rkey: &str) -> Result<()> {
-        let data = value::Data::from_json(data).to_owned()?;
-        let profile_record =
-            value::from_data::<types::fm_teal::alpha::actor::profile::Profile>(&data)?;
+        let profile_record: types::fm_teal::alpha::actor::profile::Profile =
+            value::from_json_value::<types::fm_teal::alpha::actor::profile::Profile>(data.clone())?;
 
         let profile_ingestor =
             super::super::teal::actor_profile::ActorProfileIngestor::new(self.sql.clone());
-        let did_typed = jacquard_common::types::did::Did::new(did)
-            .map_err(|e| anyhow!("Failed to create Did: {}", e))?;
 
         profile_ingestor
-            .insert_profile(did_typed, &profile_record)
+            .insert_profile(did, &profile_record)
             .await?;
 
         info!(
@@ -357,17 +353,15 @@ impl CarImportIngestor {
 
     /// Process a status record using the existing ActorStatusIngestor
     async fn process_status_record(&self, data: &Value, did: &str, rkey: &str) -> Result<()> {
-        let data = value::Data::from_json(data).to_owned()?;
-        let status_record =
-            value::from_data::<types::fm_teal::alpha::actor::status::Status>(&data)?;
+        let status_record: types::fm_teal::alpha::actor::status::Status =
+            value::from_json_value::<types::fm_teal::alpha::actor::status::Status>(data.clone())?;
 
         let status_ingestor =
             super::super::teal::actor_status::ActorStatusIngestor::new(self.sql.clone());
-        let did_typed = Did::new(did).map_err(|e| anyhow!("Failed to create Did: {}", e))?;
 
         status_ingestor
             .insert_status(
-                did_typed,
+                did,
                 rkey,
                 &format!("car-import-{}", uuid::Uuid::new_v4()),
                 &status_record,

--- a/services/cadet/src/ingestors/teal/actor_profile.rs
+++ b/services/cadet/src/ingestors/teal/actor_profile.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use jacquard_common::types::{did::Did, value};
+use jacquard_common::types::{blob::BlobRef, value};
 use rocketman::{ingestion::LexiconIngestor, types::event::Event};
 use serde_json::Value;
 use sqlx::PgPool;
@@ -10,8 +10,8 @@ pub struct ActorProfileIngestor {
     sql: PgPool,
 }
 
-fn get_blob_ref(blob_ref: &jacquard_common::types::blob::Blob) -> String {
-    blob_ref.r#ref.as_ref().to_string()
+fn get_blob_ref(blob_ref: &BlobRef) -> String {
+    blob_ref.blob().r#ref.as_str().to_string()
 }
 
 impl ActorProfileIngestor {
@@ -19,14 +19,14 @@ impl ActorProfileIngestor {
         Self { sql }
     }
 
-    pub async fn insert_profile<'a>(
+    pub async fn insert_profile(
         &self,
-        provided_did: Did<'_>,
-        profile: &'a types::fm_teal::alpha::actor::profile::Profile<'a>,
+        provided_did: &str,
+        profile: &types::fm_teal::alpha::actor::profile::Profile,
     ) -> anyhow::Result<()> {
         dbg!(&profile);
         // TODO: cache the doc for like 8 hours or something
-        let did = resolve_identity(provided_did.as_str(), "https://public.api.bsky.app").await?;
+        let did = resolve_identity(provided_did, "https://public.api.bsky.app").await?;
 
         let handle = did.doc.also_known_as.first().to_owned();
 
@@ -39,8 +39,10 @@ impl ActorProfileIngestor {
                 .unwrap_or_else(|_| time::OffsetDateTime::now_utc());
 
         dbg!(&profile.avatar);
-        let avatar = profile.avatar.as_ref().map(|bref| get_blob_ref(bref));
-        let banner = profile.banner.as_ref().map(|bref| get_blob_ref(bref));
+        let avatar = profile.avatar.as_ref().map(get_blob_ref);
+        let banner = profile.banner.as_ref().map(get_blob_ref);
+        let display_name = profile.display_name.as_ref().map(ToString::to_string);
+        let description = profile.description.as_ref().map(ToString::to_string);
         sqlx::query!(
             r#"
                 INSERT INTO profiles (did, handle, display_name, description, description_facets, avatar, banner, created_at)
@@ -55,8 +57,8 @@ impl ActorProfileIngestor {
             "#,
             did.identity,
             handle,
-            profile.display_name.as_ref().map(|s| s.as_ref()),
-            profile.description.as_ref().map(|s| s.as_ref()),
+            display_name,
+            description,
             serde_json::to_value(profile.description_facets.clone())?,
             avatar,
             banner,
@@ -66,12 +68,12 @@ impl ActorProfileIngestor {
         .await?;
         Ok(())
     }
-    pub async fn remove_profile(&self, did: Did<'_>) -> anyhow::Result<()> {
+    pub async fn remove_profile(&self, did: &str) -> anyhow::Result<()> {
         sqlx::query!(
             r#"
                 DELETE FROM profiles WHERE did = $1
             "#,
-            did.as_str()
+            did
         )
         .execute(&self.sql)
         .await?;
@@ -84,27 +86,19 @@ impl LexiconIngestor for ActorProfileIngestor {
     async fn ingest(&self, message: Event<Value>) -> anyhow::Result<()> {
         if let Some(commit) = &message.commit {
             if let Some(ref record) = &commit.record {
-                let data = &value::Data::from_json(record).to_owned()?;
                 let record: types::fm_teal::alpha::actor::profile::Profile =
-                    value::from_data(data)?;
+                    value::from_json_value::<types::fm_teal::alpha::actor::profile::Profile>(
+                        record.clone(),
+                    )?;
                 if let Some(ref commit) = message.commit {
                     if let Some(ref _cid) = commit.cid {
                         // TODO: verify cid
-                        self.insert_profile(
-                            Did::new(&message.did)
-                                .map_err(|e| anyhow::anyhow!("Failed to create Did: {}", e))?,
-                            &record,
-                        )
-                        .await?;
+                        self.insert_profile(&message.did, &record).await?;
                     }
                 }
             } else {
                 println!("{}: Message {} deleted", message.did, commit.rkey);
-                self.remove_profile(
-                    Did::new(&message.did)
-                        .map_err(|e| anyhow::anyhow!("Failed to create Did: {}", e))?,
-                )
-                .await?;
+                self.remove_profile(&message.did).await?;
             }
         } else {
             return Err(anyhow::anyhow!("Message has no commit"));

--- a/services/cadet/src/ingestors/teal/actor_status.rs
+++ b/services/cadet/src/ingestors/teal/actor_status.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use jacquard_common::types::{did::Did, value};
+use jacquard_common::types::value;
 use rocketman::{ingestion::LexiconIngestor, types::event::Event};
 use serde_json::Value;
 use sqlx::PgPool;
@@ -15,28 +15,28 @@ impl ActorStatusIngestor {
         Self { sql }
     }
 
-    pub async fn insert_status<'a>(
+    pub async fn insert_status(
         &self,
-        did: Did<'_>,
+        did: &str,
         rkey: &str,
         cid: &str,
-        status: &types::fm_teal::alpha::actor::status::Status<'a>,
+        status: &types::fm_teal::alpha::actor::status::Status,
     ) -> anyhow::Result<()> {
-        let uri = assemble_at_uri(did.as_str(), "fm.teal.alpha.actor.status", rkey);
+        let uri = assemble_at_uri(did, "fm.teal.alpha.actor.status", rkey);
 
         let record_json = serde_json::to_value(status)?;
 
         sqlx::query!(
             r#"
-                        INSERT INTO statii (uri, did, rkey, cid, record)
-                        VALUES ($1, $2, $3, $4, $5)
-                        ON CONFLICT (uri) DO UPDATE SET
-                            cid = EXCLUDED.cid,
-                            record = EXCLUDED.record,
-                            indexed_at = NOW();
-                    "#,
+                INSERT INTO statii (uri, did, rkey, cid, record)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (uri) DO UPDATE SET
+                    cid = EXCLUDED.cid,
+                    record = EXCLUDED.record,
+                    indexed_at = NOW();
+            "#,
             uri,
-            did.as_str(),
+            did,
             rkey,
             cid,
             record_json
@@ -47,8 +47,8 @@ impl ActorStatusIngestor {
         Ok(())
     }
 
-    pub async fn remove_status(&self, did: Did<'_>, rkey: &str) -> anyhow::Result<()> {
-        let uri = assemble_at_uri(did.as_str(), "fm.teal.alpha.actor.status", rkey);
+    pub async fn remove_status(&self, did: &str, rkey: &str) -> anyhow::Result<()> {
+        let uri = assemble_at_uri(did, "fm.teal.alpha.actor.status", rkey);
 
         sqlx::query!(
             r#"
@@ -68,17 +68,18 @@ impl LexiconIngestor for ActorStatusIngestor {
     async fn ingest(&self, message: Event<Value>) -> anyhow::Result<()> {
         if let Some(commit) = &message.commit {
             if let Some(ref record) = &commit.record {
-                let data = &value::Data::from_json(record).to_owned()?;
-                let record: types::fm_teal::alpha::actor::status::Status = value::from_data(data)?;
+                let record: types::fm_teal::alpha::actor::status::Status =
+                    value::from_json_value::<types::fm_teal::alpha::actor::status::Status>(
+                        record.clone(),
+                    )?;
 
                 if let Some(ref cid) = commit.cid {
-                    self.insert_status(Did::from(message.did), &commit.rkey, cid, &record)
+                    self.insert_status(&message.did, &commit.rkey, cid, &record)
                         .await?;
                 }
             } else {
                 println!("{}: Status {} deleted", message.did, commit.rkey);
-                self.remove_status(Did::from(message.did), &commit.rkey)
-                    .await?;
+                self.remove_status(&message.did, &commit.rkey).await?;
             }
         } else {
             return Err(anyhow::anyhow!("Message has no commit"));

--- a/services/cadet/src/ingestors/teal/feed_play.rs
+++ b/services/cadet/src/ingestors/teal/feed_play.rs
@@ -4,6 +4,7 @@ use atrium_api::types::string::Datetime;
 use rocketman::{ingestion::LexiconIngestor, types::event::Event};
 use serde_json::Value;
 use sqlx::{types::Uuid, PgPool};
+use unicode_normalization::UnicodeNormalization;
 
 use super::assemble_at_uri;
 
@@ -17,10 +18,12 @@ struct FuzzyMatchCandidate {
 struct MusicBrainzCleaner;
 
 impl MusicBrainzCleaner {
-    /// List of common "guff" words found in parentheses that should be removed
+    /// Words commonly found in parenthetical/bracketed content that can be removed.
+    /// Kept in sync with apps/amethyst/lib/musicbrainzCleaner.ts GUFF_WORDS.
     const GUFF_WORDS: &'static [&'static str] = &[
         "a cappella",
         "acoustic",
+        "anniversary",
         "bonus",
         "censored",
         "clean",
@@ -29,16 +32,23 @@ impl MusicBrainzCleaner {
         "composition",
         "cut",
         "dance",
+        "deluxe",
         "demo",
         "dialogue",
         "dirty",
+        "dub",
         "edit",
+        "edition",
         "excerpt",
+        "expanded",
         "explicit",
         "extended",
         "feat",
         "featuring",
         "ft",
+        "hd",
+        "hifi",
+        "hi-fi",
         "instrumental",
         "interlude",
         "intro",
@@ -46,6 +56,7 @@ impl MusicBrainzCleaner {
         "live",
         "long",
         "main",
+        "master",
         "maxi",
         "megamix",
         "mix",
@@ -57,6 +68,10 @@ impl MusicBrainzCleaner {
         "outtake",
         "outtakes",
         "piano",
+        "preview",
+        "prod",
+        "produced",
+        "production",
         "quadraphonic",
         "radio",
         "rap",
@@ -65,12 +80,11 @@ impl MusicBrainzCleaner {
         "refix",
         "rehearsal",
         "reinterpreted",
-        "released",
         "release",
+        "released",
         "remake",
-        "remastered",
         "remaster",
-        "master",
+        "remastered",
         "remix",
         "remixed",
         "remode",
@@ -82,6 +96,7 @@ impl MusicBrainzCleaner {
         "short",
         "single",
         "skit",
+        "special",
         "stereo",
         "studio",
         "take",
@@ -93,8 +108,8 @@ impl MusicBrainzCleaner {
         "unknown",
         "unplugged",
         "untitled",
-        "version",
         "ver",
+        "version",
         "video",
         "vocal",
         "vs",
@@ -102,81 +117,223 @@ impl MusicBrainzCleaner {
         "without",
     ];
 
+    /// Generic track names that commonly need disambiguation info preserved.
+    const GENERIC_TRACK_NAMES: &'static [&'static str] = &[
+        "beat", "dream", "five", "four", "heart", "high", "home", "life", "love", "low", "music",
+        "one", "piece", "song", "sound", "three", "time", "track", "tune", "two",
+    ];
+
+    const SHORT_NAME_THRESHOLD: usize = 15;
+    const COMMON_PHRASE_LENGTH: usize = 20;
+    const MIN_ARTIST_NAME_LENGTH: usize = 4;
+
+    /// Find the byte range of the first matched-depth bracket pair.
+    /// Returns (open_byte, content_start_byte, content_end_byte, close_end_byte).
+    fn find_bracketed(s: &str, open: char, close: char) -> Option<(usize, usize, usize, usize)> {
+        let mut chars = s.char_indices();
+        // Find opening bracket
+        let (open_byte, _) = chars.find(|&(_, c)| c == open)?;
+        let content_start = open_byte + open.len_utf8();
+        let mut depth: usize = 1;
+        for (i, c) in chars {
+            if c == open {
+                depth += 1;
+            } else if c == close {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((open_byte, content_start, i, i + close.len_utf8()));
+                }
+            }
+        }
+        None // unbalanced
+    }
+
+    /// Check if parenthetical content should be kept for disambiguation.
+    /// Partially mirrors the TS shouldKeepForDisambiguation logic (remix/feat only, not version).
+    fn should_keep_for_disambiguation(content: &str, base_name: &str, kind: &str) -> bool {
+        let content_lower = content.to_lowercase();
+        let base_lower = base_name.to_lowercase();
+
+        let is_relevant = match kind {
+            "remix" => {
+                content_lower.contains("remix")
+                    || content_lower.contains("rmx")
+                    || content_lower.contains("rework")
+                    || content_lower.contains("refix")
+                    || content_lower.contains("remode")
+            }
+            "feat" => {
+                content_lower.contains("feat")
+                    || content_lower.contains("ft")
+                    || content_lower.contains("featuring")
+            }
+            _ => false,
+        };
+        if !is_relevant {
+            return false;
+        }
+
+        // Generic word check
+        let is_generic = Self::GENERIC_TRACK_NAMES
+            .iter()
+            .any(|&w| base_lower == w || base_lower.starts_with(&format!("{w} ")));
+        let char_count = base_name.chars().count();
+        let is_short = char_count < Self::SHORT_NAME_THRESHOLD;
+        let word_count = base_name.split_whitespace().count();
+        let is_common_phrase = word_count <= 3 && char_count < Self::COMMON_PHRASE_LENGTH;
+
+        // Check for artist name in content
+        let keyword_pattern: &[&str] = match kind {
+            "remix" => &["remix", "rmx", "rework", "refix", "remode"],
+            _ => &["feat", "ft", "featuring"],
+        };
+        let has_artist_name = content_lower.split_whitespace().any(|w| {
+            w.chars().count() >= Self::MIN_ARTIST_NAME_LENGTH
+                && !keyword_pattern.iter().any(|kw| w.contains(kw))
+        });
+
+        is_generic || (is_short && is_common_phrase) || has_artist_name
+    }
+
+    /// Remove a bracketed section from `s` if it is guff and not needed for disambiguation.
+    /// Works for both () and []. Returns the cleaned string.
+    fn strip_guff_bracket(s: &str, open: char, close: char, check_disambiguation: bool) -> String {
+        if let Some((open_byte, content_start, content_end, close_end)) =
+            Self::find_bracketed(s, open, close)
+        {
+            let content = &s[content_start..content_end];
+            let base_name = s[..open_byte].trim();
+
+            if Self::is_likely_guff(&content.to_lowercase()) {
+                if check_disambiguation {
+                    let keep_remix =
+                        Self::should_keep_for_disambiguation(content, base_name, "remix");
+                    let keep_feat =
+                        Self::should_keep_for_disambiguation(content, base_name, "feat");
+                    if keep_remix || keep_feat {
+                        return s.to_string();
+                    }
+                    // Don't remove if it would leave the name empty
+                    let after = s[close_end..].trim();
+                    if base_name.is_empty() && after.is_empty() {
+                        return s.to_string();
+                    }
+                }
+                let result = format!("{}{}", &s[..open_byte], &s[close_end..]);
+                return result.split_whitespace().collect::<Vec<_>>().join(" ");
+            }
+        }
+        s.to_string()
+    }
+
+    /// Case-insensitive find of `pattern` in `s`, returning the byte offset in `s`.
+    /// Safe for non-ASCII: searches char-by-char in the original string, avoiding
+    /// the to_lowercase() byte-length mismatch problem.
+    fn find_case_insensitive(s: &str, pattern: &str) -> Option<usize> {
+        let pat_lower = pattern.to_lowercase();
+        let pat_char_count = pat_lower.chars().count();
+        if pat_char_count == 0 {
+            return None;
+        }
+        for (byte_pos, _) in s.char_indices() {
+            let candidate: String = s[byte_pos..].chars().take(pat_char_count).collect();
+            if candidate.to_lowercase() == pat_lower {
+                return Some(byte_pos);
+            }
+        }
+        None
+    }
+
     /// Clean artist name by removing common variations and guff
     fn clean_artist_name(name: &str) -> String {
         let mut cleaned = name.trim().to_string();
 
-        // Remove common featuring patterns
-        if let Some(pos) = cleaned.to_lowercase().find(" feat") {
-            cleaned = cleaned[..pos].trim().to_string();
-        }
-        if let Some(pos) = cleaned.to_lowercase().find(" ft.") {
-            cleaned = cleaned[..pos].trim().to_string();
-        }
-        if let Some(pos) = cleaned.to_lowercase().find(" featuring") {
-            cleaned = cleaned[..pos].trim().to_string();
-        }
-
-        // Remove parenthetical content if it looks like guff
-        if let Some(start) = cleaned.find('(') {
-            if let Some(end) = cleaned.find(')') {
-                let paren_content = &cleaned[start + 1..end].to_lowercase();
-                if Self::is_likely_guff(paren_content) {
-                    cleaned = format!("{}{}", &cleaned[..start], &cleaned[end + 1..])
-                        .trim()
-                        .to_string();
-                }
+        // Remove common featuring patterns (take the first match)
+        for pat in &[" feat", " ft.", " featuring"] {
+            if let Some(byte_pos) = Self::find_case_insensitive(&cleaned, pat) {
+                cleaned = cleaned[..byte_pos].trim().to_string();
+                break;
             }
         }
 
-        // Remove brackets with guff
-        if let Some(start) = cleaned.find('[') {
-            if let Some(end) = cleaned.find(']') {
-                let bracket_content = &cleaned[start + 1..end].to_lowercase();
-                if Self::is_likely_guff(bracket_content) {
-                    cleaned = format!("{}{}", &cleaned[..start], &cleaned[end + 1..])
-                        .trim()
-                        .to_string();
-                }
-            }
-        }
+        // Remove parenthetical guff (no disambiguation check for artist names)
+        cleaned = Self::strip_guff_bracket(&cleaned, '(', ')', false);
+        cleaned = Self::strip_guff_bracket(&cleaned, '[', ']', false);
 
-        // Remove common prefixes/suffixes
-        if cleaned.to_lowercase().starts_with("the ") && cleaned.len() > 4 {
-            let without_the = &cleaned[4..];
-            if !without_the.trim().is_empty() {
-                return without_the.trim().to_string();
-            }
-        }
+        // Don't strip "The " prefix -- MusicBrainz indexes artists with "The"
+        // (e.g., "The Beatles", "The Rolling Stones") and stripping causes
+        // exact search misses in the matching pipeline.
 
-        cleaned.trim().to_string()
+        cleaned
     }
 
-    /// Clean track name by removing common variations and guff
+    /// Clean track name by removing common variations and guff.
+    /// Includes disambiguation-aware cleaning: preserves remix/feat info for
+    /// short or generic track names (matching TS frontend logic).
     fn clean_track_name(name: &str) -> String {
         let mut cleaned = name.trim().to_string();
 
-        // Remove parenthetical content if it looks like guff
-        if let Some(start) = cleaned.find('(') {
-            if let Some(end) = cleaned.find(')') {
-                let paren_content = &cleaned[start + 1..end].to_lowercase();
-                if Self::is_likely_guff(paren_content) {
-                    cleaned = format!("{}{}", &cleaned[..start], &cleaned[end + 1..])
-                        .trim()
-                        .to_string();
+        // Strip leading/trailing decorative characters (aligned with TS frontend)
+        let decorative: &[char] = &[
+            '*', '~', '\u{00b7}', '\u{2022}', '\u{2605}', '\u{2606}', '\u{266a}', '\u{266b}', '|',
+            '_', '>', '<',
+        ];
+        cleaned = cleaned
+            .trim_start_matches(|c: char| c.is_whitespace() || decorative.contains(&c))
+            .to_string();
+        cleaned = cleaned
+            .trim_end_matches(|c: char| c.is_whitespace() || decorative.contains(&c))
+            .to_string();
+        cleaned = cleaned.trim().to_string();
+
+        // Remove parenthetical guff (with disambiguation check) -- process all groups
+        loop {
+            let next = Self::strip_guff_bracket(&cleaned, '(', ')', true);
+            if next == cleaned {
+                break;
+            }
+            cleaned = next;
+        }
+        loop {
+            let next = Self::strip_guff_bracket(&cleaned, '[', ']', true);
+            if next == cleaned {
+                break;
+            }
+            cleaned = next;
+        }
+
+        // Remove dash-separated suffixes that look like guff or remix info
+        // Common in scrobbler data: "Song - Single Version", "Song - Artist Remix"
+        if let Some(dash_pos) = cleaned.find(" - ") {
+            let base_name = cleaned[..dash_pos].trim();
+            let suffix = cleaned[dash_pos + 3..].trim();
+            if !base_name.is_empty() && !suffix.is_empty() {
+                let should_keep_remix =
+                    Self::should_keep_for_disambiguation(suffix, base_name, "remix");
+                let should_keep_feat =
+                    Self::should_keep_for_disambiguation(suffix, base_name, "feat");
+                if Self::is_likely_guff(&suffix.to_lowercase())
+                    && !should_keep_remix
+                    && !should_keep_feat
+                {
+                    cleaned = base_name.to_string();
                 }
             }
         }
 
-        // Remove featuring artists from track titles
-        if let Some(pos) = cleaned.to_lowercase().find(" feat") {
-            cleaned = cleaned[..pos].trim().to_string();
-        }
-        if let Some(pos) = cleaned.to_lowercase().find(" ft.") {
-            cleaned = cleaned[..pos].trim().to_string();
+        // Remove featuring artists from track titles (with disambiguation check)
+        for pat in &[" feat", " ft.", " featuring"] {
+            if let Some(byte_pos) = Self::find_case_insensitive(&cleaned, pat) {
+                let base_name = cleaned[..byte_pos].trim();
+                let feat_content = cleaned[byte_pos..].trim();
+                if !Self::should_keep_for_disambiguation(feat_content, base_name, "feat") {
+                    cleaned = base_name.to_string();
+                }
+                break;
+            }
         }
 
-        cleaned.trim().to_string()
+        cleaned
     }
 
     /// Check if parenthetical content is likely "guff" that should be removed
@@ -184,17 +341,23 @@ impl MusicBrainzCleaner {
         let content_lower = content.to_lowercase();
         let words: Vec<&str> = content_lower.split_whitespace().collect();
 
-        // If most words are guff words, consider it guff
+        // Count guff words (strip trailing punctuation for matching)
         let guff_word_count = words
             .iter()
-            .filter(|word| Self::GUFF_WORDS.contains(word))
+            .filter(|word| {
+                let stripped = word.trim_end_matches(|c: char| c.is_ascii_punctuation());
+                Self::GUFF_WORDS.contains(word) || Self::GUFF_WORDS.contains(&stripped)
+            })
             .count();
 
-        // Also check for years (19XX or 20XX)
-        let has_year = content_lower.chars().collect::<String>().contains("19")
-            || content_lower.contains("20");
+        // Check for years (19XX or 20XX) -- match 4-digit years only, not "Part 19" etc.
+        let has_year = content_lower.as_bytes().windows(4).any(|w| {
+            (w[0] == b'1' && w[1] == b'9' || w[0] == b'2' && w[1] == b'0')
+                && w[2].is_ascii_digit()
+                && w[3].is_ascii_digit()
+        });
 
-        // Consider it guff if >50% are guff words, or if it contains years, or if it's short and common
+        // >50% guff words, or contains years, or short and contains a guff word
         guff_word_count > words.len() / 2
             || has_year
             || (words.len() <= 2
@@ -203,9 +366,21 @@ impl MusicBrainzCleaner {
                     .any(|&guff| content_lower.contains(guff)))
     }
 
-    /// Normalize text for comparison (remove special chars, lowercase, etc.)
+    /// Normalize text for comparison (remove special chars, lowercase).
+    /// Aligned with frontend normalizeForComparison in musicbrainzCleaner.ts:
+    /// 1. NFD decomposition to separate base characters from accents
+    /// 2. Strip combining diacritical marks (U+0300..U+036F)
+    /// 3. Keep all Unicode alphanumeric characters (CJK, Cyrillic, etc.)
+    /// 4. NFC recomposition, lowercase, whitespace collapse
     fn normalize_for_comparison(text: &str) -> String {
-        text.chars()
+        // Step 1+2: NFD decompose, strip combining marks (accents)
+        let stripped: String = text
+            .nfd()
+            .filter(|c| !('\u{0300}'..='\u{036f}').contains(c))
+            .collect();
+        // Step 3+4: keep alphanumeric + whitespace, NFC, lowercase, collapse whitespace
+        stripped
+            .nfc()
             .filter(|c| c.is_alphanumeric() || c.is_whitespace())
             .collect::<String>()
             .to_lowercase()

--- a/services/cadet/src/ingestors/teal/feed_play.rs
+++ b/services/cadet/src/ingestors/teal/feed_play.rs
@@ -398,8 +398,8 @@ pub struct PlayIngestor {
 }
 
 fn clean(
-    record: &types::fm_teal::alpha::feed::play::Play<'_>,
-) -> types::fm_teal::alpha::feed::play::Play<'static> {
+    record: &types::fm_teal::alpha::feed::play::Play,
+) -> types::fm_teal::alpha::feed::play::Play {
     let mut cleaned = record.clone();
 
     // Clean artist MBIDs inside artists vector, if present
@@ -1314,7 +1314,7 @@ impl PlayIngestor {
 
     pub async fn insert_play(
         &self,
-        play_record: &types::fm_teal::alpha::feed::play::Play<'_>,
+        play_record: &types::fm_teal::alpha::feed::play::Play,
         uri: &str,
         cid: &str,
         did: &str,
@@ -1446,51 +1446,56 @@ impl PlayIngestor {
         } else {
             None
         };
+        let isrc = play_record.isrc.as_ref().map(ToString::to_string);
+        let track_name = play_record.track_name.to_string();
+        let release_name = play_record.release_name.as_ref().map(ToString::to_string);
+        let submission_client_agent = play_record
+            .submission_client_agent
+            .as_ref()
+            .map(ToString::to_string);
+        let music_service_base_domain = play_record
+            .music_service_base_domain
+            .as_ref()
+            .map(ToString::to_string);
 
         sqlx::query!(
             r#"
-                    INSERT INTO plays (
-                        uri, cid, did, rkey, isrc, duration, track_name, played_time,
-                        processed_time, release_mbid, release_name, recording_mbid,
-                        submission_client_agent, music_service_base_domain, artist_names_raw,
-                        track_discriminant, release_discriminant
-                    ) VALUES (
-                        $1, $2, $3, $4, $5, $6, $7, $8,
-                        NOW(), $9, $10, $11, $12, $13, $14, $15, $16
-                    ) ON CONFLICT(uri) DO UPDATE SET
-                        isrc = EXCLUDED.isrc,
-                        duration = EXCLUDED.duration,
-                        track_name = EXCLUDED.track_name,
-                        played_time = EXCLUDED.played_time,
-                        processed_time = EXCLUDED.processed_time,
-                        release_mbid = EXCLUDED.release_mbid,
-                        release_name = EXCLUDED.release_name,
-                        recording_mbid = EXCLUDED.recording_mbid,
-                        submission_client_agent = EXCLUDED.submission_client_agent,
-                        music_service_base_domain = EXCLUDED.music_service_base_domain,
-                        artist_names_raw = EXCLUDED.artist_names_raw,
-                        track_discriminant = EXCLUDED.track_discriminant,
-                        release_discriminant = EXCLUDED.release_discriminant;
-                "#,
+                INSERT INTO plays (
+                    uri, cid, did, rkey, isrc, duration, track_name, played_time,
+                    processed_time, release_mbid, release_name, recording_mbid,
+                    submission_client_agent, music_service_base_domain, artist_names_raw,
+                    track_discriminant, release_discriminant
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8,
+                    NOW(), $9, $10, $11, $12, $13, $14, $15, $16
+                ) ON CONFLICT(uri) DO UPDATE SET
+                    isrc = EXCLUDED.isrc,
+                    duration = EXCLUDED.duration,
+                    track_name = EXCLUDED.track_name,
+                    played_time = EXCLUDED.played_time,
+                    processed_time = EXCLUDED.processed_time,
+                    release_mbid = EXCLUDED.release_mbid,
+                    release_name = EXCLUDED.release_name,
+                    recording_mbid = EXCLUDED.recording_mbid,
+                    submission_client_agent = EXCLUDED.submission_client_agent,
+                    music_service_base_domain = EXCLUDED.music_service_base_domain,
+                    artist_names_raw = EXCLUDED.artist_names_raw,
+                    track_discriminant = EXCLUDED.track_discriminant,
+                    release_discriminant = EXCLUDED.release_discriminant;
+            "#,
             uri,
             cid,
             did,
             rkey,
-            play_record.isrc.as_ref().map(|s| s.as_ref()),
+            isrc,
             play_record.duration.map(|d| d as i32),
-            play_record.track_name.as_ref(),
+            track_name,
             time_datetime,
             release_mbid_opt,
-            play_record.release_name.as_ref().map(|s| s.as_ref()),
+            release_name,
             recording_mbid_opt,
-            play_record
-                .submission_client_agent
-                .as_ref()
-                .map(|s| s.as_ref()),
-            play_record
-                .music_service_base_domain
-                .as_ref()
-                .map(|s| s.as_ref()),
+            submission_client_agent,
+            music_service_base_domain,
             artist_names_json,
             track_discriminant,
             release_discriminant
@@ -1501,17 +1506,17 @@ impl PlayIngestor {
         // Insert plays into the extended join table (supports all artists)
         for (artist_id, artist_name) in &parsed_artists {
             sqlx::query!(
-                    r#"
-                        INSERT INTO play_to_artists_extended (play_uri, artist_id, artist_name) VALUES
-                        ($1, $2, $3)
-                        ON CONFLICT (play_uri, artist_id) DO NOTHING;
-                    "#,
-                    uri,
-                    artist_id,
-                    artist_name
-                )
-                .execute(&self.sql)
-                .await?;
+                r#"
+                    INSERT INTO play_to_artists_extended (play_uri, artist_id, artist_name) VALUES
+                    ($1, $2, $3)
+                    ON CONFLICT (play_uri, artist_id) DO NOTHING;
+                "#,
+                uri,
+                artist_id,
+                artist_name
+            )
+            .execute(&self.sql)
+            .await?;
         }
 
         // Refresh materialized views concurrently (if needed, consider if this should be done less frequently)
@@ -1572,8 +1577,10 @@ impl LexiconIngestor for PlayIngestor {
     async fn ingest(&self, message: Event<Value>) -> anyhow::Result<()> {
         if let Some(commit) = &message.commit {
             if let Some(ref record) = &commit.record {
-                let data = &value::Data::from_json(record).to_owned()?;
-                let record: types::fm_teal::alpha::feed::play::Play = value::from_data(data)?;
+                let record: types::fm_teal::alpha::feed::play::Play =
+                    value::from_json_value::<types::fm_teal::alpha::feed::play::Play>(
+                        record.clone(),
+                    )?;
                 if let Some(ref commit) = message.commit {
                     if let Some(ref cid) = commit.cid {
                         // TODO: verify cid

--- a/services/types/Cargo.toml
+++ b/services/types/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 jacquard-common.workspace = true
 jacquard-derive.workspace = true
+jacquard-lexicon.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 miette = "7.6"
@@ -20,3 +21,18 @@ chat_bsky = []
 com_atproto = []
 fm_teal = []
 tools_ozone = []
+streaming = ["jacquard-common/websocket"]
+
+[lints.rust]
+unused_imports = "allow"
+non_snake_case = "allow"
+
+[lints.clippy]
+absurd_extreme_comparisons = "allow"
+manual_strip = "allow"
+needless_update = "allow"
+new_ret_no_self = "allow"
+new_without_default = "allow"
+should_implement_trait = "allow"
+type_complexity = "allow"
+unit_arg = "allow"

--- a/tools/lexicon-cli/src/commands/generate.ts
+++ b/tools/lexicon-cli/src/commands/generate.ts
@@ -94,19 +94,28 @@ async function generateRust(workspaceRoot: string, force?: boolean) {
         // Try cargo-binstall first for faster installation
         try {
           await execa("cargo", ["binstall", "--version"], { stdio: "pipe" });
-          await execa("cargo", ["binstall", "-y", "jacquard-lexicon"], {
-            stdio: "inherit",
-          });
+          await execa(
+            "cargo",
+            ["binstall", "-y", "jacquard-lexgen", "--version", "0.12.0-beta.2"],
+            {
+              stdio: "inherit",
+            },
+          );
         } catch {
           // Fallback to cargo install if binstall not available
-          await execa("cargo", ["install", "jacquard-lexicon"], {
+          await execa("cargo", [
+            "install",
+            "jacquard-lexgen",
+            "--version",
+            "0.12.0-beta.2",
+          ], {
             stdio: "inherit",
           });
         }
         console.log(pc.green("    ✓ jacquard-codegen installed successfully"));
       } catch (installError) {
         throw new Error(
-          "Failed to install jacquard-codegen. Please install manually: cargo install jacquard-lexicon",
+          "Failed to install jacquard-codegen. Please install manually: cargo install jacquard-lexgen --version 0.12.0-beta.2",
         );
       }
     }


### PR DESCRIPTION
Updates the Rust side of the Jacquard branch against current `main`, refreshing Jacquard dependencies to `0.12.0-beta.2` and regenerating Rust lexicon types for validation. Fixes Aqua and Cadet for the new generated type shapes, including response lifetimes, blob refs, DID/string handling, JSON decoding, SQLx params, and generated `extra_data`.

Also updates the lexicon CLI Rust generator install path to use `jacquard-lexgen`, refreshes `Cargo.lock`, removes stale/yanked Rust dependency paths, and keeps generated Rust output ignored. The Aqua and Cadet Dockerfiles now pin `pnpm@9.15.0` so Docker builds do not break on latest `pnpm` requiring newer Node; Cadet’s image build now runs Rust-only lexicon generation.

Files touched (files changed tab is gonna show the rebase stuff too):
```text
Cargo.lock
Cargo.toml
apps/aqua/Cargo.toml
apps/aqua/Dockerfile
apps/aqua/src/repos/actor_profile.rs
apps/aqua/src/repos/feed_play.rs
apps/aqua/src/repos/stats.rs
apps/aqua/src/xrpc/actor.rs
apps/aqua/src/xrpc/feed.rs
apps/aqua/src/xrpc/stats.rs
services/cadet/Cargo.toml
services/cadet/Dockerfile
services/cadet/src/ingestors/car/car_import.rs
services/cadet/src/ingestors/teal/actor_profile.rs
services/cadet/src/ingestors/teal/actor_status.rs
services/cadet/src/ingestors/teal/feed_play.rs
services/types/Cargo.toml
tools/lexicon-cli/src/commands/generate.ts
```

Verified with:
```bash
pnpm --filter @teal/lexicon-cli build
pnpm lex:gen --rust-only
cargo fmt --all
cargo check --workspace --all-features
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
docker build -f apps/aqua/Dockerfile -t teal-aqua:jacquard-work .
docker build -f services/cadet/Dockerfile -t teal-cadet:jacquard-work .
git merge-tree --write-tree natb/jacquard jacquard-work
```