### PR TITLE
feat(amethyst): keep profile badges on dedicated branch

### DIFF
--- a/apps/amethyst/app/(tabs)/notifications.tsx
+++ b/apps/amethyst/app/(tabs)/notifications.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/teal/api";
 import { timeAgo } from "@/lib/utils";
 import { useStore } from "@/stores/mainStore";
-import { Bell, Heart, MessageCircle, Repeat2 } from "lucide-react-native";
+import { BadgeCheck, Bell, Heart, MessageCircle, Repeat2 } from "lucide-react-native";
 
 function reasonLabel(reason: string) {
   switch (reason) {
@@ -28,6 +28,8 @@ function reasonLabel(reason: string) {
       return "reposted your post";
     case "reply":
       return "replied to your post";
+    case "badgeAssignment":
+      return "assigned you a badge";
     default:
       return reason;
   }
@@ -41,6 +43,8 @@ function reasonIcon(reason: string) {
       return Repeat2;
     case "reply":
       return MessageCircle;
+    case "badgeAssignment":
+      return BadgeCheck;
     default:
       return Bell;
   }
@@ -158,7 +162,7 @@ export default function Notifications() {
             Sign in to view notifications.
           </Text>
           <Text className="max-w-sm text-center text-sm leading-5 text-muted-foreground">
-            Likes, reposts, replies, and playlist collaboration
+            Likes, reposts, replies, badge assignments, and playlist collaboration
             activity will appear here.
           </Text>
           <Link href="/auth/login" asChild>

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -7,6 +7,7 @@ import {
 } from "react-native";
 import { Link, Stack, useLocalSearchParams } from "expo-router";
 import PlayFeedCard from "@/components/teal/PlayFeedCard";
+import BadgeManager from "@/components/teal/BadgeManager";
 import EditProfileModal from "@/components/teal/EditProfileModal";
 import { PlaylistCreator } from "@/components/teal/PlaylistControls";
 import { ProfileStatsSections } from "@/components/teal/ProfileStats";
@@ -32,6 +33,7 @@ import {
 } from "@/lib/teal/actors";
 import {
   getActorFeed,
+  getActorBadges,
   getActorPlaylists,
   getBlueskyProfile,
   getGraphFollowers,
@@ -44,6 +46,7 @@ import {
   displayArtists,
   getRecordingCoverArtUrl,
   type GraphSummaryView,
+  type SocialBadgeAssignmentView,
   type SocialPostView,
   type SocialPlaylistView,
   type StatsPeriod,
@@ -279,6 +282,7 @@ export default function ProfileScreen() {
   const actor = Array.isArray(handle) ? handle[0] : handle;
   const [did, setDid] = useState<string | null>(null);
   const [profile, setProfile] = useState<DisplayProfile | null>(null);
+  const [badges, setBadges] = useState<SocialBadgeAssignmentView[]>([]);
   const [playlists, setPlaylists] = useState<SocialPlaylistView[]>([]);
   const [topReleases, setTopReleases] = useState<ReleaseView[]>([]);
   const [graphSummary, setGraphSummary] = useState<GraphSummaryView>({
@@ -317,6 +321,7 @@ export default function ProfileScreen() {
         setError(null);
         setDid(null);
         setProfile(null);
+        setBadges([]);
         setPlaylists([]);
         setTopReleases([]);
         setGraphSummary({ followersCount: 0, followsCount: 0 });
@@ -341,6 +346,9 @@ export default function ProfileScreen() {
           pdsAgent?.did,
           resolved,
         ).catch(() => ({
+          items: [],
+        }));
+        const badgeRes = await getActorBadges(resolved, 12).catch(() => ({
           items: [],
         }));
         const playlistRes = await getActorPlaylists(resolved, 12).catch(() => ({
@@ -409,6 +417,7 @@ export default function ProfileScreen() {
         }));
         if (!mounted) return;
         setProfile(nextProfile);
+        setBadges(badgeRes.items);
         setPlaylists(playlistRes.items);
         setTopReleases(topReleaseRes.releases);
         setGraphSummary(graphSummaryRes);
@@ -747,6 +756,25 @@ export default function ProfileScreen() {
                   </View>
                 </View>
               )}
+              {badges.length > 0 && (
+                <View className="mt-5">
+                  <Text className="mb-2 font-mono text-[10px] uppercase text-muted-foreground">
+                    Badges
+                  </Text>
+                  <View className="flex-row flex-wrap gap-2">
+                    {badges.map((assignment) => (
+                      <View
+                        key={assignment.uri}
+                        className="rounded-full border border-border bg-muted px-3 py-1"
+                      >
+                        <Text className="text-xs font-bold">
+                          {assignment.badge.name}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                </View>
+              )}
               {isSelf && isBlueskyFallback && (
                 <Link href="/onboarding" asChild>
                   <Button className="mt-5 flex-row gap-2 self-start">
@@ -1007,6 +1035,16 @@ export default function ProfileScreen() {
               </View>
             )}
           </View>
+          {isSelf && (
+            <View className="mb-8">
+              <SectionHeading eyebrow="Admin" title="Badge tools" />
+              <BadgeManager
+                onAssigned={(assignment) =>
+                  setBadges((current) => [assignment, ...current])
+                }
+              />
+            </View>
+          )}
         </>
       )}
     </TealShell>

--- a/apps/amethyst/components/teal/BadgeManager.tsx
+++ b/apps/amethyst/components/teal/BadgeManager.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState } from "react";
+import { Image, Pressable, View } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { RichText as AtprotoRichText } from "@atproto/api";
+import RichText from "@/components/teal/RichText";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { Textarea } from "@/components/ui/textarea";
+import getImageCdnLink from "@/lib/atp/getImageCdnLink";
+import {
+  getBadgeCatalog,
+  type SocialBadgeAssignmentView,
+  type SocialBadgeView,
+} from "@/lib/teal/api";
+import { useStore } from "@/stores/mainStore";
+
+type BadgeManagerProps = {
+  onAssigned: (assignment: SocialBadgeAssignmentView) => void;
+};
+
+export default function BadgeManager({ onAssigned }: BadgeManagerProps) {
+  const pdsAgent = useStore((state) => state.pdsAgent);
+  const [badges, setBadges] = useState<SocialBadgeView[]>([]);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageUri, setImageUri] = useState<string>();
+  const [assignee, setAssignee] = useState("");
+  const [selectedBadge, setSelectedBadge] = useState<SocialBadgeView>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getBadgeCatalog(50)
+      .then((res) => setBadges(res.items))
+      .catch(() => setBadges([]));
+  }, []);
+
+  async function pickImage() {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.9,
+    });
+    if (!result.canceled) setImageUri(result.assets[0].uri);
+  }
+
+  async function createBadge() {
+    if (!pdsAgent?.did || !name.trim() || !description.trim() || !imageUri) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const data = await fetch(imageUri).then((response) => response.blob());
+      const fileType = data.type || "image/png";
+      const image = (await pdsAgent.uploadBlob(data, { encoding: fileType })).data
+        .blob;
+      const rt = new AtprotoRichText({ text: description.trim() });
+      await rt.detectFacets(pdsAgent);
+      const record = {
+        $type: "fm.teal.alpha.feed.social.badge",
+        name: name.trim(),
+        description: description.trim(),
+        descriptionFacets: rt.facets,
+        image,
+        creator: pdsAgent.did,
+        type: "achievement",
+        createdAt: new Date().toISOString(),
+      };
+      const res = await pdsAgent.call(
+        "com.atproto.repo.createRecord",
+        {},
+        {
+          repo: pdsAgent.did,
+          collection: "fm.teal.alpha.feed.social.badge",
+          record,
+        },
+      );
+      const created: SocialBadgeView = {
+        uri: (res.data as { uri?: string }).uri || "",
+        cid: (res.data as { cid?: string }).cid || "",
+        name: record.name,
+        description: record.description,
+        descriptionFacets: record.descriptionFacets,
+        imageCid: (image as any)?.ref?.$link || (image as any)?.ref?.toString?.() || "",
+        creator: record.creator,
+        badgeType: record.type,
+        createdAt: record.createdAt,
+      };
+      setBadges((current) => [created, ...current]);
+      setSelectedBadge(created);
+      setName("");
+      setDescription("");
+      setImageUri(undefined);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function assignBadge() {
+    if (!pdsAgent?.did || !selectedBadge || !assignee.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const record = {
+        $type: "fm.teal.alpha.feed.social.badgeAssignment",
+        badge: { uri: selectedBadge.uri, cid: selectedBadge.cid },
+        assignee: assignee.trim(),
+        assigner: pdsAgent.did,
+        createdAt: new Date().toISOString(),
+      };
+      const res = await pdsAgent.call(
+        "com.atproto.repo.createRecord",
+        {},
+        {
+          repo: pdsAgent.did,
+          collection: "fm.teal.alpha.feed.social.badgeAssignment",
+          record,
+        },
+      );
+      onAssigned({
+        uri: (res.data as { uri?: string }).uri || "",
+        cid: (res.data as { cid?: string }).cid || "",
+        badge: selectedBadge,
+        assignee: record.assignee,
+        assigner: record.assigner,
+        createdAt: record.createdAt,
+      });
+      setAssignee("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!pdsAgent?.did) return null;
+
+  return (
+    <View className="gap-4 rounded-lg border border-border bg-card p-4">
+      <View>
+        <Text className="font-mono text-[10px] uppercase text-primary">
+          Badge management
+        </Text>
+        <Text className="mt-1 text-sm text-muted-foreground">
+          Create badge definitions and assign them to Teal actors.
+        </Text>
+      </View>
+      <View className="gap-3">
+        <Input placeholder="Badge name" value={name} onChangeText={setName} />
+        <Textarea
+          className="min-h-20"
+          placeholder="Badge description"
+          value={description}
+          onChangeText={setDescription}
+        />
+        <Pressable
+          onPress={pickImage}
+          className="h-24 w-24 items-center justify-center overflow-hidden rounded-lg border border-border bg-muted"
+        >
+          {imageUri ? (
+            <Image source={{ uri: imageUri }} className="h-full w-full" />
+          ) : (
+            <Text className="text-center text-xs text-muted-foreground">
+              Pick image
+            </Text>
+          )}
+        </Pressable>
+        <Button disabled={busy} className="self-start" onPress={createBadge}>
+          <Text>{busy ? "Working..." : "Create badge"}</Text>
+        </Button>
+      </View>
+
+      {badges.length > 0 && (
+        <View className="gap-2">
+          <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+            Assign badge
+          </Text>
+          <View className="flex-row flex-wrap gap-2">
+            {badges.map((badge) => (
+              <Pressable
+                key={badge.uri}
+                onPress={() => setSelectedBadge(badge)}
+                className={`rounded-full border px-3 py-1 ${
+                  selectedBadge?.uri === badge.uri
+                    ? "border-primary bg-primary/10"
+                    : "border-border bg-muted"
+                }`}
+              >
+                <Text className="text-xs font-bold">{badge.name}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <Input
+            placeholder="Assignee DID"
+            value={assignee}
+            onChangeText={setAssignee}
+          />
+          {selectedBadge?.imageCid && (
+            <Image
+              source={{
+                uri: getImageCdnLink({
+                  did: selectedBadge.creator,
+                  hash: selectedBadge.imageCid,
+                }),
+              }}
+              className="h-12 w-12 rounded-lg"
+            />
+          )}
+          {selectedBadge && (
+            <RichText
+              text={selectedBadge.description}
+              facets={selectedBadge.descriptionFacets}
+              className="text-sm text-muted-foreground"
+            />
+          )}
+          <Button disabled={busy || !selectedBadge} className="self-start" onPress={assignBadge}>
+            <Text>Assign badge</Text>
+          </Button>
+        </View>
+      )}
+      {error && <Text className="text-sm text-destructive">{error}</Text>}
+    </View>
+  );
+}

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -70,6 +70,27 @@ export type SocialPostView = {
   viewerRepost?: string;
 };
 
+export type SocialBadgeView = {
+  uri: string;
+  cid: string;
+  name: string;
+  description: string;
+  descriptionFacets?: unknown;
+  imageCid: string;
+  creator: string;
+  badgeType: string;
+  createdAt: string;
+};
+
+export type SocialBadgeAssignmentView = {
+  uri: string;
+  cid: string;
+  badge: SocialBadgeView;
+  assignee: string;
+  assigner: string;
+  createdAt: string;
+};
+
 export type SocialPlaylistView = {
   uri: string;
   cid: string;
@@ -312,6 +333,20 @@ export function getNotifications(actor: string, limit = 30, cursor?: string) {
   return getXrpc<{ items: SocialNotificationView[]; cursor?: string }>(
     "fm.teal.alpha.feed.social.getNotifications",
     { actor, limit, cursor },
+  );
+}
+
+export function getActorBadges(actor: string, limit = 20, cursor?: string) {
+  return getXrpc<{ items: SocialBadgeAssignmentView[]; cursor?: string }>(
+    "fm.teal.alpha.feed.social.getActorBadges",
+    { actor, limit, cursor },
+  );
+}
+
+export function getBadgeCatalog(limit = 50, cursor?: string) {
+  return getXrpc<{ items: SocialBadgeView[]; cursor?: string }>(
+    "fm.teal.alpha.feed.social.getBadgeCatalog",
+    { limit, cursor },
   );
 }
 

--- a/lexicons/fm.teal.alpha/feed/social/badge.json
+++ b/lexicons/fm.teal.alpha/feed/social/badge.json
@@ -1,0 +1,64 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.feed.social.badge",
+  "description": "This lexicon is in a not officially released state. It is subject to change. | A teal.fm badge definition.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record containing badge metadata that can be assigned to actors.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "name",
+          "description",
+          "image",
+          "creator",
+          "type",
+          "createdAt"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the badge.",
+            "minLength": 1,
+            "maxLength": 100,
+            "maxGraphemes": 100
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of what the badge represents.",
+            "minLength": 1,
+            "maxLength": 5000,
+            "maxGraphemes": 500
+          },
+          "descriptionFacets": {
+            "type": "array",
+            "description": "Annotations of text in the badge description.",
+            "items": { "type": "ref", "ref": "fm.teal.alpha.richtext.facet" }
+          },
+          "image": {
+            "type": "blob",
+            "description": "Image displayed for the badge.",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000
+          },
+          "creator": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the actor who created this badge definition."
+          },
+          "type": {
+            "type": "ref",
+            "ref": "fm.teal.alpha.feed.social.defs#badgeType"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this badge was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/feed/social/badgeAssignment.json
+++ b/lexicons/fm.teal.alpha/feed/social/badgeAssignment.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.feed.social.badgeAssignment",
+  "description": "This lexicon is in a not officially released state. It is subject to change. | A teal.fm badge assignment.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record assigning a badge to an actor.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["badge", "assignee", "assigner", "createdAt"],
+        "properties": {
+          "badge": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the badge definition being assigned."
+          },
+          "assignee": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the actor receiving the badge."
+          },
+          "assigner": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the actor assigning the badge."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this badge assignment was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/feed/social/defs.json
+++ b/lexicons/fm.teal.alpha/feed/social/defs.json
@@ -82,6 +82,11 @@
           "description": "The URL associated with this track."
         }
       }
+    },
+    "badgeType": {
+      "type": "string",
+      "description": "The category of badge.",
+      "knownValues": ["verification", "listeningParty", "achievement"]
     }
   }
 }

--- a/lexicons/fm.teal.alpha/feed/social/like.json
+++ b/lexicons/fm.teal.alpha/feed/social/like.json
@@ -11,11 +11,15 @@
         "type": "object",
         "required": ["subject", "createdAt"],
         "properties": {
-          "subject": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the record being liked."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",
-            "description": "Client-declared timestamp when this post was originally created."
+            "description": "Client-declared timestamp when this like was originally created."
           }
         }
       }

--- a/lexicons/fm.teal.alpha/feed/social/playlist.json
+++ b/lexicons/fm.teal.alpha/feed/social/playlist.json
@@ -9,15 +9,39 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["name", "createdAt"],
+        "required": ["name", "authors", "createdAt"],
         "properties": {
           "name": {
             "type": "string",
             "description": "Display name for the playlist, required.",
             "minLength": 1,
-            "maxLength": 50
+            "maxLength": 100,
+            "maxGraphemes": 100
           },
-          "description": { "type": "string", "maxLength": 5000 },
+          "description": {
+            "type": "string",
+            "description": "Free-form playlist description text.",
+            "maxLength": 5000,
+            "maxGraphemes": 500
+          },
+          "descriptionFacets": {
+            "type": "array",
+            "description": "Annotations of text in the playlist description.",
+            "items": { "type": "ref", "ref": "fm.teal.alpha.richtext.facet" }
+          },
+          "authors": {
+            "type": "array",
+            "description": "DIDs of actors who can author playlist items for this playlist. Include the playlist record author. Appviews may attribute playlist items to this playlist when the item's repo author appears in this list.",
+            "minLength": 1,
+            "maxLength": 100,
+            "items": { "type": "string", "format": "did" }
+          },
+          "cover": {
+            "type": "blob",
+            "description": "Optional image displayed for the playlist.",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/fm.teal.alpha/feed/social/playlistItem.json
+++ b/lexicons/fm.teal.alpha/feed/social/playlistItem.json
@@ -9,21 +9,27 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "createdAt", "trackName"],
+        "required": ["subject", "track", "createdAt"],
         "properties": {
-          "subject": { "type": "record", "ref": "com.atproto.repo.strongRef" },
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the playlist this item belongs to."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",
-            "description": "Client-declared timestamp when this post was originally created."
+            "description": "Client-declared timestamp when this playlist item was originally created."
           },
           "track": {
             "type": "ref",
-            "ref": "fm.teal.alpha.feed.social.defs#trackView"
+            "ref": "fm.teal.alpha.feed.social.defs#trackView",
+            "description": "The track added to the playlist."
           },
           "order": {
             "type": "integer",
-            "description": "The order of the track in the playlist"
+            "minimum": 0,
+            "description": "The order of the track in the playlist."
           }
         }
       }

--- a/lexicons/fm.teal.alpha/feed/social/post.json
+++ b/lexicons/fm.teal.alpha/feed/social/post.json
@@ -9,7 +9,7 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["text", "createdAt"],
+        "required": ["text", "track", "createdAt"],
         "properties": {
           "text": {
             "type": "string",
@@ -17,54 +17,10 @@
             "maxGraphemes": 300,
             "description": "The primary post content. May be an empty string, if there are embeds."
           },
-
-          "trackName": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "maxGraphemes": 2560,
-            "description": "The name of the track"
-          },
-          "trackMbId": {
-            "type": "string",
-            "description": "The Musicbrainz ID of the track"
-          },
-          "recordingMbId": {
-            "type": "string",
-            "description": "The Musicbrainz recording ID of the track"
-          },
-          "duration": {
-            "type": "integer",
-            "description": "The duration of the track in seconds"
-          },
-          "artistNames": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256,
-              "maxGraphemes": 2560
-            },
-            "description": "The names of the artists"
-          },
-          "artistMbIds": {
-            "type": "array",
-            "items": { "type": "string" },
-            "description": "The Musicbrainz IDs of the artists"
-          },
-          "releaseName": {
-            "type": "string",
-            "maxLength": 256,
-            "maxGraphemes": 2560,
-            "description": "The name of the release/album"
-          },
-          "releaseMbId": {
-            "type": "string",
-            "description": "The Musicbrainz ID of the release/album"
-          },
-          "isrc": {
-            "type": "string",
-            "description": "The ISRC code associated with the recording"
+          "track": {
+            "type": "ref",
+            "ref": "fm.teal.alpha.feed.social.defs#trackView",
+            "description": "The track associated with this post."
           },
           "reply": { "type": "ref", "ref": "#replyRef" },
           "facets": {

--- a/lexicons/fm.teal.alpha/feed/social/repost.json
+++ b/lexicons/fm.teal.alpha/feed/social/repost.json
@@ -11,11 +11,15 @@
         "type": "object",
         "required": ["subject", "createdAt"],
         "properties": {
-          "subject": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the record being reposted."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",
-            "description": "Client-declared timestamp when this post was originally created."
+            "description": "Client-declared timestamp when this repost was originally created."
           }
         }
       }


### PR DESCRIPTION
## What changed

- Keep the profile badge display and admin badge management on a dedicated branch.
- Restore badge-specific client APIs, lexicon records, and notification behavior.

## Branching

This PR is stacked on `agent/remove-profile-badges`, which removes badges from `feature/teal-firehose-clone`. Merge the removal PR first, then this branch can be retargeted as needed.

## Validation

- `pnpm lex:validate` passed.
- `pnpm --filter @teal/amethyst exec tsc --noEmit` passed.
- `git diff --check` passed.
