### PR TITLE
Improve lexicon typing before publish

### DIFF
--- a/lexicons/fm.teal/actor/defs.json
+++ b/lexicons/fm.teal/actor/defs.json
@@ -73,12 +73,12 @@
         "time": {
           "type": "string",
           "format": "datetime",
-          "description": "The unix timestamp of when the item was recorded"
+          "description": "The datetime at which the status was recorded."
         },
         "expiry": {
           "type": "string",
           "format": "datetime",
-          "description": "The unix timestamp of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
+          "description": "The datetime after which the status is no longer current."
         },
         "item": {
           "type": "ref",

--- a/lexicons/fm.teal/actor/defs.json
+++ b/lexicons/fm.teal/actor/defs.json
@@ -7,6 +7,7 @@
       "properties": {
         "did": {
           "type": "string",
+          "format": "did",
           "description": "The decentralized identifier of the actor"
         },
         "displayName": {
@@ -46,6 +47,7 @@
       "properties": {
         "did": {
           "type": "string",
+          "format": "did",
           "description": "The decentralized identifier of the actor"
         },
         "displayName": {

--- a/lexicons/fm.teal/actor/defs.json
+++ b/lexicons/fm.teal/actor/defs.json
@@ -54,7 +54,8 @@
           "type": "string"
         },
         "handle": {
-          "type": "string"
+          "type": "string",
+          "format": "handle"
         },
         "avatar": {
           "type": "string",

--- a/lexicons/fm.teal/actor/defs.json
+++ b/lexicons/fm.teal/actor/defs.json
@@ -29,10 +29,12 @@
         },
         "avatar": {
           "type": "string",
+          "format": "cid",
           "description": "IPLD of the avatar"
         },
         "banner": {
           "type": "string",
+          "format": "cid",
           "description": "IPLD of the banner image"
         },
         "status": {
@@ -59,6 +61,7 @@
         },
         "avatar": {
           "type": "string",
+          "format": "cid",
           "description": "IPLD of the avatar"
         }
       }

--- a/lexicons/fm.teal/actor/getProfile.json
+++ b/lexicons/fm.teal/actor/getProfile.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "fm.teal.actor.getProfile",
-  "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves a play given an author DID and record key.",
+  "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves a profile for an actor DID or handle.",
   "defs": {
     "main": {
       "type": "query",
@@ -12,7 +12,7 @@
           "actor": {
             "type": "string",
             "format": "at-identifier",
-            "description": "The author's DID"
+            "description": "The actor's DID or handle"
           }
         }
       },

--- a/lexicons/fm.teal/actor/getProfiles.json
+++ b/lexicons/fm.teal/actor/getProfiles.json
@@ -15,7 +15,7 @@
               "type": "string",
               "format": "at-identifier"
             },
-            "description": "Array of actor DIDs"
+            "description": "Array of actor DIDs or handles"
           }
         }
       },

--- a/lexicons/fm.teal/actor/profile.json
+++ b/lexicons/fm.teal/actor/profile.json
@@ -57,7 +57,8 @@
         },
         "type": {
           "type": "string",
-          "description": "The type of the item. Must be a valid Musicbrainz type, e.g. album, track, recording, etc."
+          "knownValues": ["artist", "release", "recording"],
+          "description": "The MusicBrainz entity type of the item."
         }
       }
     }

--- a/lexicons/fm.teal/actor/status.json
+++ b/lexicons/fm.teal/actor/status.json
@@ -13,12 +13,12 @@
           "time": {
             "type": "string",
             "format": "datetime",
-            "description": "The RFC 3339 formatted time of when the item was recorded"
+            "description": "The datetime at which the status was recorded."
           },
           "expiry": {
             "type": "string",
             "format": "datetime",
-            "description": "The RFC 3339 formatted time of the expiry time of the item. If unavailable, default to 10 minutes past the start time."
+            "description": "The datetime after which the status is no longer current. If unavailable, default to 10 minutes after the start time."
           },
           "item": {
             "type": "ref",

--- a/lexicons/fm.teal/feed/defs.json
+++ b/lexicons/fm.teal/feed/defs.json
@@ -70,7 +70,7 @@
         "playedTime": {
           "type": "string",
           "format": "datetime",
-          "description": "The unix timestamp of when the track was played"
+          "description": "The datetime at which playback began."
         }
       }
     },

--- a/lexicons/fm.teal/feed/defs.json
+++ b/lexicons/fm.teal/feed/defs.json
@@ -51,13 +51,15 @@
           "type": "string",
           "description": "The ISRC code associated with the recording"
         },
-        "originUrl": {
+        "originUri": {
           "type": "string",
-          "description": "The URL associated with this track"
+          "format": "uri",
+          "description": "The exact URI where the listening event originated."
         },
-        "musicServiceBaseDomain": {
+        "musicServiceUri": {
           "type": "string",
-          "description": "The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if not provided."
+          "format": "uri",
+          "description": "The canonical URI identifying the listening surface or music service."
         },
         "submissionClientAgent": {
           "type": "string",

--- a/lexicons/fm.teal/feed/getActorFeed.json
+++ b/lexicons/fm.teal/feed/getActorFeed.json
@@ -11,7 +11,7 @@
         "properties": {
           "authorDID": {
             "type": "string",
-            "format": "at-identifier",
+            "format": "did",
             "description": "The author's DID for the play"
           },
           "cursor": {

--- a/lexicons/fm.teal/feed/getPlay.json
+++ b/lexicons/fm.teal/feed/getPlay.json
@@ -16,6 +16,7 @@
           },
           "rkey": {
             "type": "string",
+            "format": "record-key",
             "description": "The record key of the play"
           }
         }

--- a/lexicons/fm.teal/feed/getPlay.json
+++ b/lexicons/fm.teal/feed/getPlay.json
@@ -11,7 +11,7 @@
         "properties": {
           "authorDID": {
             "type": "string",
-            "format": "at-identifier",
+            "format": "did",
             "description": "The author's DID for the play"
           },
           "rkey": {

--- a/lexicons/fm.teal/feed/play.json
+++ b/lexicons/fm.teal/feed/play.json
@@ -90,7 +90,7 @@
           "playedTime": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of when the track was played"
+            "description": "The datetime at which playback began."
           },
           "trackDiscriminant": {
             "type": "string",

--- a/lexicons/fm.teal/feed/play.json
+++ b/lexicons/fm.teal/feed/play.json
@@ -71,13 +71,15 @@
             "type": "string",
             "description": "The ISRC code associated with the recording"
           },
-          "originUrl": {
+          "originUri": {
             "type": "string",
-            "description": "The URL associated with this track"
+            "format": "uri",
+            "description": "The exact URI where the listening event originated."
           },
-          "musicServiceBaseDomain": {
+          "musicServiceUri": {
             "type": "string",
-            "description": "The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if unavailable or not provided."
+            "format": "uri",
+            "description": "The canonical URI identifying the listening surface or music service."
           },
           "submissionClientAgent": {
             "type": "string",


### PR DESCRIPTION
Presenting a fairly sizable PR with a number of commits for improving the Lexicon, which we can hopefully land atop #110. Changes here should correspond to recommendations from https://atproto.com/specs/lexicon , and broadly should help assist with better typed fields, with format alignment such as improved `datetime` compatibility.

This improved type information in the lexicon would let services such as microcosm's constellation just do a ton of indexing for us, gratis, no personal app view needed for many users/apps. This would be a huge help to anyone building an app! These changes deeply enrich the data model, and allow actual linkage of the data in many cases.

I made an ID for each prospective improvement, to make it easier to talk about each.

## Format Fixes

| ID | What | Why |
| --- | --- | --- |
| URI1 | Replace `originUrl` and `musicServiceBaseDomain` with URI-typed `originUri` and `musicServiceUri`. | Makes listening origins and services discoverable as links by generic Atmosphere tooling instead of requiring Teal-specific interpretation of bare hostnames. |
| DID1 | Type actor identities in profile views as DIDs. | Gives clients a reliable decentralized identity primitive instead of opaque text and enables validation wherever these views are consumed. |
| HANDLE1 | Type profile handles with the dedicated `handle` format. | Prevents malformed handles from crossing the API boundary and communicates their identity semantics to generated clients. |
| DID2 | Require DIDs for feed query parameters explicitly named `authorDID`. | Aligns validation with the endpoint contract and avoids mutable handles where a stable repository identity is required. |
| RKEY1 | Type play lookup keys as AT Protocol record keys. | Rejects invalid record keys early and makes the lookup contract consistent with repository addressing rules. |
| CID1 | Type profile image references as CIDs. | Accurately represents the stored IPLD blob identities and lets clients distinguish content-addressed references from arbitrary strings or web URLs. |

## Other Fixes

| ID | What | Why |
| --- | --- | --- |
| KNOWN1 | Add open known values for featured MusicBrainz entity types. | Improves generated guidance and interoperability while preserving forward compatibility with future entity categories. |                                                                                                                                                              | TIME1 | Describe datetime-formatted values consistently as RFC 3339 datetimes. | Removes wire-format ambiguity and prevents implementers from sending numeric Unix timestamps to fields that require RFC 3339 strings. |                                                                                                                                        | IDENTDOC1 | Document actor lookup parameters as accepting either a DID or handle. | Aligns the public contract with the existing `at-identifier` format and implementation behavior. |

## Sidenote

Side-note, it's still in early stages, but I enhanced the very popular web-scrobbler extension for Teal.fm support. https://github.com/rektide/web-scrobbler/