### PR TITLE
[03/33] feat(feed): add explore discovery and infinite scrolling

### DIFF
--- a/.sqlx/query-1b1037b346ba7dc39ef6f133d6b9d60da8e2492383088cc50e88a0a29d88428b.json
+++ b/.sqlx/query-1b1037b346ba7dc39ef6f133d6b9d60da8e2492383088cc50e88a0a29d88428b.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH matched AS (\n                SELECT\n                    p.uri,\n                    p.track_name,\n                    p.release_name,\n                    p.release_mbid,\n                    p.processed_time,\n                    COALESCE(\n                        STRING_AGG(DISTINCT ptae.artist_name, ', ' ORDER BY ptae.artist_name),\n                        'Unknown artist'\n                    ) AS artist_name,\n                    COUNT(*) OVER (\n                        PARTITION BY LOWER(p.track_name), COALESCE(p.recording_mbid::text, '')\n                    ) AS play_count,\n                    ROW_NUMBER() OVER (\n                        PARTITION BY LOWER(p.track_name), COALESCE(p.recording_mbid::text, '')\n                        ORDER BY p.processed_time DESC, p.uri\n                    ) AS row_number\n                FROM plays p\n                LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri\n                WHERE p.track_name ILIKE $1\n                GROUP BY p.uri, p.track_name, p.release_name, p.release_mbid, p.processed_time,\n                         p.recording_mbid\n            )\n            SELECT uri, track_name, release_name, release_mbid, artist_name, play_count\n            FROM matched\n            WHERE row_number = 1\n            ORDER BY\n                CASE\n                    WHEN LOWER(track_name) = LOWER($2) THEN 0\n                    WHEN track_name ILIKE $3 THEN 1\n                    ELSE 2\n                END,\n                play_count DESC,\n                track_name\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "track_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "release_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "release_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "artist_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "play_count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "1b1037b346ba7dc39ef6f133d6b9d60da8e2492383088cc50e88a0a29d88428b"
+}

--- a/.sqlx/query-469181e5bef94d33e4275b012bc4cf8a82fb64449f15b5b512237bb63a15f38a.json
+++ b/.sqlx/query-469181e5bef94d33e4275b012bc4cf8a82fb64449f15b5b512237bb63a15f38a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                profile.did AS \"profile_did?\", profile.handle AS profile_handle,\n                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,\n                COALESCE(\n                  json_agg(\n                    json_build_object(\n                      'artistMbId', ae.mbid,\n                      'artistName', ptae.artist_name\n                    )\n                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),\n                  '[]'\n                ) AS artists\n            FROM plays p\n            LEFT JOIN profiles profile ON p.did = profile.did\n            LEFT JOIN play_to_artists_extended as ptae ON p.uri = ptae.play_uri\n            LEFT JOIN artists_extended as ae ON ptae.artist_id = ae.id\n            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                     profile.did, profile.handle, profile.display_name, profile.avatar\n            ORDER BY p.processed_time DESC\n            LIMIT $1\n            ",
+  "query": "\n            SELECT\n                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                profile.did AS \"profile_did?\", profile.handle AS profile_handle,\n                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,\n                COALESCE(\n                  json_agg(\n                    json_build_object(\n                      'artistMbId', ae.mbid,\n                      'artistName', ptae.artist_name\n                    )\n                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),\n                  '[]'\n                ) AS artists\n            FROM plays p\n            LEFT JOIN profiles profile ON p.did = profile.did\n            LEFT JOIN play_to_artists_extended as ptae ON p.uri = ptae.play_uri\n            LEFT JOIN artists_extended as ae ON ptae.artist_id = ae.id\n            WHERE ($1::timestamptz IS NULL OR (p.processed_time, p.uri) < ($1, $2))\n            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                     profile.did, profile.handle, profile.display_name, profile.avatar\n            ORDER BY p.processed_time DESC\n            LIMIT $3\n            ",
   "describe": {
     "columns": [
       {
@@ -106,6 +106,8 @@
     ],
     "parameters": {
       "Left": [
+        "Timestamptz",
+        "Text",
         "Int8"
       ]
     },
@@ -132,5 +134,5 @@
       null
     ]
   },
-  "hash": "79c5b71501e7d47ee397a17f73fe8ed0615fea2bfdf3c367b04b5a0353bfdb59"
+  "hash": "469181e5bef94d33e4275b012bc4cf8a82fb64449f15b5b512237bb63a15f38a"
 }

--- a/.sqlx/query-5e6b6ec603ed32de54da8236a54708f0c27e66cd04780fa3fd733efc329801f0.json
+++ b/.sqlx/query-5e6b6ec603ed32de54da8236a54708f0c27e66cd04780fa3fd733efc329801f0.json
@@ -1,0 +1,37 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT ae.mbid, ae.name, COUNT(ptae.play_uri) AS play_count\n            FROM artists_extended ae\n            LEFT JOIN play_to_artists_extended ptae ON ae.id = ptae.artist_id\n            WHERE ae.name ILIKE $1\n            GROUP BY ae.id, ae.mbid, ae.name\n            ORDER BY\n                CASE\n                    WHEN LOWER(ae.name) = LOWER($2) THEN 0\n                    WHEN ae.name ILIKE $3 THEN 1\n                    ELSE 2\n                END,\n                play_count DESC,\n                ae.name\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "play_count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "5e6b6ec603ed32de54da8236a54708f0c27e66cd04780fa3fd733efc329801f0"
+}

--- a/.sqlx/query-75d93f44f432f071ee5a829a68e3d4b1d04b1eb8af5a518a0a746de4c5ae4e67.json
+++ b/.sqlx/query-75d93f44f432f071ee5a829a68e3d4b1d04b1eb8af5a518a0a746de4c5ae4e67.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT did, handle, display_name, avatar\n            FROM profiles\n            WHERE display_name ILIKE $1 OR handle ILIKE $1\n            ORDER BY\n                CASE\n                    WHEN LOWER(handle) = LOWER($2) OR LOWER(display_name) = LOWER($2) THEN 0\n                    WHEN handle ILIKE $3 OR display_name ILIKE $3 THEN 1\n                    ELSE 2\n                END,\n                display_name NULLS LAST,\n                handle NULLS LAST\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "handle",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "avatar",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "75d93f44f432f071ee5a829a68e3d4b1d04b1eb8af5a518a0a746de4c5ae4e67"
+}

--- a/.sqlx/query-b920fc9e7b2c81158d6f2cdc9dbf618eda19f519102c0973ce8e71b382fcface.json
+++ b/.sqlx/query-b920fc9e7b2c81158d6f2cdc9dbf618eda19f519102c0973ce8e71b382fcface.json
@@ -1,0 +1,37 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT r.mbid, r.name, COUNT(p.uri) AS play_count\n            FROM releases r\n            LEFT JOIN plays p ON r.mbid = p.release_mbid\n            WHERE r.name ILIKE $1\n            GROUP BY r.mbid, r.name\n            ORDER BY\n                CASE\n                    WHEN LOWER(r.name) = LOWER($2) THEN 0\n                    WHEN r.name ILIKE $3 THEN 1\n                    ELSE 2\n                END,\n                play_count DESC,\n                r.name\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "play_count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "b920fc9e7b2c81158d6f2cdc9dbf618eda19f519102c0973ce8e71b382fcface"
+}

--- a/apps/amethyst/app/(tabs)/index.tsx
+++ b/apps/amethyst/app/(tabs)/index.tsx
@@ -1,22 +1,33 @@
-import { useEffect, useState } from "react";
-import { ActivityIndicator, View } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
 import { Stack } from "expo-router";
 import PlayFeedCard from "@/components/songish/PlayFeedCard";
 import RightRail from "@/components/songish/RightRail";
 import SongishShell from "@/components/songish/SongishShell";
 import { Text } from "@/components/ui/text";
 import { getLatestPlays } from "@/lib/teal/api";
+
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
 
 export default function HomeScreen() {
   const [plays, setPlays] = useState<PlayView[] | null>(null);
+  const [cursor, setCursor] = useState<string>();
   const [error, setError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
 
   useEffect(() => {
     let mounted = true;
-    getLatestPlays(50)
+    getLatestPlays(30)
       .then((res) => {
-        if (mounted) setPlays(res.plays);
+        if (!mounted) return;
+        setPlays(res.plays);
+        setCursor(res.cursor);
       })
       .catch((e) => {
         if (mounted) {
@@ -29,8 +40,45 @@ export default function HomeScreen() {
     };
   }, []);
 
+  const loadMore = useCallback(() => {
+    if (!cursor || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    getLatestPlays(30, cursor)
+      .then((res) => {
+        setPlays((current) => {
+          const knownUris = new Set(current?.map((play) => play.uri) || []);
+          return [
+            ...(current || []),
+            ...res.plays.filter(
+              (play) => !play.uri || !knownUris.has(play.uri),
+            ),
+          ];
+        });
+        setCursor(res.cursor);
+      })
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      });
+  }, [cursor]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const remaining =
+        contentSize.height - (contentOffset.y + layoutMeasurement.height);
+      if (remaining < 800) loadMore();
+    },
+    [loadMore],
+  );
+
   return (
-    <SongishShell rightRail={<RightRail />}>
+    <SongishShell rightRail={<RightRail />} onScroll={handleScroll}>
       <Stack.Screen options={{ title: "Teal", headerShown: false }} />
       {!plays && (
         <View className="min-h-[24rem] items-center justify-center">
@@ -46,7 +94,9 @@ export default function HomeScreen() {
       )}
       {plays?.length === 0 && !error && (
         <View className="min-h-[24rem] items-center justify-center rounded-2xl bg-background/70 p-8">
-          <Text className="text-center text-2xl font-black">No plays indexed yet.</Text>
+          <Text className="text-center text-2xl font-black">
+            No plays indexed yet.
+          </Text>
           <Text className="mt-2 text-center text-muted-foreground">
             Cadet will fill this feed as ATProto firehose records arrive.
           </Text>
@@ -58,6 +108,16 @@ export default function HomeScreen() {
           play={play}
         />
       ))}
+      {loadingMore && (
+        <View className="items-center justify-center py-5">
+          <ActivityIndicator />
+        </View>
+      )}
+      {plays && plays.length > 0 && !cursor && (
+        <Text className="pb-6 text-center font-mono text-xs text-muted-foreground">
+          You reached the beginning of the indexed feed.
+        </Text>
+      )}
     </SongishShell>
   );
 }

--- a/apps/amethyst/app/(tabs)/search/index.tsx
+++ b/apps/amethyst/app/(tabs)/search/index.tsx
@@ -1,16 +1,403 @@
-import { Stack } from "expo-router";
+import { useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, Image, Pressable, View } from "react-native";
+import { Link, Stack } from "expo-router";
 import RightRail from "@/components/songish/RightRail";
 import SongishShell from "@/components/songish/SongishShell";
+import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
+import getImageCdnLink from "@/lib/atp/getImageCdnLink";
+import { Icon } from "@/lib/icons/iconWithClassName";
+import {
+  coverArtUrl,
+  getSearchResults,
+  searchBlueskyUsers,
+  type SearchResults,
+} from "@/lib/teal/api";
+import type { AppBskyActorDefs } from "@atproto/api";
+import {
+  Disc3,
+  Mic2,
+  Music2,
+  Search,
+  UserRound,
+  UsersRound,
+  X,
+} from "lucide-react-native";
+
+import type { MiniProfileView } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
+import type { SongResult } from "@teal/lexicons/src/types/fm/teal/alpha/search/defs";
+import type {
+  ArtistView,
+  ReleaseView,
+} from "@teal/lexicons/src/types/fm/teal/alpha/stats/defs";
+
+type SearchTab = "users" | "songs" | "artists" | "albums";
+type UserResult = MiniProfileView & { avatarUrl?: string };
+
+const EMPTY_RESULTS: SearchResults = {
+  users: [],
+  songs: [],
+  artists: [],
+  albums: [],
+};
+
+function routePart(value?: string) {
+  return encodeURIComponent(
+    (value || "unknown")
+      .toLowerCase()
+      .replace(/^mbid:/, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") || "unknown",
+  );
+}
+
+function songHref(song: SongResult) {
+  return `/:o/music/${routePart(song.artistName)}/${routePart(song.releaseName)}/${routePart(song.trackName)}?uri=${encodeURIComponent(song.uri)}`;
+}
+
+function mergeUsers(
+  tealUsers: MiniProfileView[],
+  blueskyUsers: AppBskyActorDefs.ProfileViewBasic[],
+) {
+  const merged = new Map<string, UserResult>();
+  blueskyUsers.forEach((user) => {
+    merged.set(user.did, {
+      did: user.did,
+      displayName: user.displayName,
+      handle: user.handle,
+      avatarUrl: user.avatar,
+    });
+  });
+  tealUsers.forEach((user) => {
+    if (!user.did) return;
+    merged.set(user.did, {
+      ...merged.get(user.did),
+      ...user,
+      handle: user.handle?.replace(/^at:\/\//, ""),
+      avatarUrl:
+        user.avatar && user.did
+          ? getImageCdnLink({ did: user.did, hash: user.avatar })
+          : merged.get(user.did)?.avatarUrl,
+    });
+  });
+  return [...merged.values()];
+}
+
+function SearchTabButton({
+  active,
+  count,
+  icon,
+  label,
+  onPress,
+}: {
+  active: boolean;
+  count: number;
+  icon: typeof UserRound;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`min-w-0 flex-1 flex-row items-center justify-center gap-1 border-b-2 px-1 py-4 ${
+        active ? "border-foreground" : "border-transparent"
+      }`}
+    >
+      <Icon
+        icon={icon}
+        size={17}
+        className={active ? "text-foreground" : "text-muted-foreground"}
+      />
+      <Text
+        className={
+          active
+            ? "text-sm font-black"
+            : "text-sm font-bold text-muted-foreground"
+        }
+      >
+        {label}
+      </Text>
+      <Text className="font-mono text-xs text-muted-foreground">{count}</Text>
+    </Pressable>
+  );
+}
+
+function UserRow({ user }: { user: UserResult }) {
+  const handle = user.handle?.replace(/^at:\/\//, "");
+  return (
+    <Link href={`/profile/${handle || user.did}` as any} asChild>
+      <Pressable className="flex-row items-center gap-3 border-b border-border/70 px-1 py-4">
+        <View className="h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-primary/60">
+          {user.avatarUrl ? (
+            <Image source={{ uri: user.avatarUrl }} className="h-full w-full" />
+          ) : (
+            <Icon
+              icon={UserRound}
+              size={22}
+              className="text-primary-foreground"
+            />
+          )}
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="font-black" numberOfLines={1}>
+            {user.displayName || handle || user.did}
+          </Text>
+          <Text
+            className="font-mono text-xs text-muted-foreground"
+            numberOfLines={1}
+          >
+            {handle ? `@${handle}` : user.did}
+          </Text>
+        </View>
+      </Pressable>
+    </Link>
+  );
+}
+
+function SongRow({ song }: { song: SongResult }) {
+  const art = coverArtUrl(song.releaseMbId);
+  return (
+    <Link href={songHref(song) as any} asChild>
+      <Pressable className="flex-row items-center gap-3 border-b border-border/70 px-1 py-4">
+        <View className="h-14 w-14 items-center justify-center overflow-hidden rounded-lg bg-muted">
+          {art ? (
+            <Image source={{ uri: art }} className="h-full w-full" />
+          ) : (
+            <Icon icon={Music2} size={23} className="text-muted-foreground" />
+          )}
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="font-black" numberOfLines={1}>
+            {song.trackName}
+          </Text>
+          <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+            {song.artistName}
+          </Text>
+          {song.releaseName && (
+            <Text
+              className="font-mono text-xs text-muted-foreground"
+              numberOfLines={1}
+            >
+              {song.releaseName}
+            </Text>
+          )}
+        </View>
+        <Text className="font-mono text-xs text-muted-foreground">
+          {song.playCount}
+        </Text>
+      </Pressable>
+    </Link>
+  );
+}
+
+function MusicEntityRow({
+  icon,
+  name,
+  playCount,
+  onPress,
+}: {
+  icon: typeof Mic2;
+  name?: string;
+  playCount?: number;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center gap-3 border-b border-border/70 px-1 py-4"
+    >
+      <View className="h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <Icon icon={icon} size={22} className="text-muted-foreground" />
+      </View>
+      <Text className="min-w-0 flex-1 font-black" numberOfLines={1}>
+        {name || "Unknown"}
+      </Text>
+      <Text className="font-mono text-xs text-muted-foreground">
+        {playCount || 0} plays
+      </Text>
+    </Pressable>
+  );
+}
 
 export default function Explore() {
+  const [query, setQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<SearchTab>("songs");
+  const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS);
+  const [blueskyUsers, setBlueskyUsers] = useState<
+    AppBskyActorDefs.ProfileViewBasic[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const users = useMemo(
+    () => mergeUsers(results.users, blueskyUsers),
+    [blueskyUsers, results.users],
+  );
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults(EMPTY_RESULTS);
+      setBlueskyUsers([]);
+      setLoading(false);
+      setError(undefined);
+      return;
+    }
+
+    let mounted = true;
+    const timeout = setTimeout(() => {
+      setLoading(true);
+      setError(undefined);
+      Promise.all([
+        getSearchResults(trimmed, 12),
+        searchBlueskyUsers(trimmed, 12).catch(() => ({ actors: [] })),
+      ])
+        .then(([tealResults, blueskyResults]) => {
+          if (!mounted) return;
+          setResults(tealResults);
+          setBlueskyUsers(blueskyResults.actors);
+        })
+        .catch((searchError) => {
+          if (!mounted) return;
+          setResults(EMPTY_RESULTS);
+          setBlueskyUsers([]);
+          setError(
+            searchError instanceof Error
+              ? searchError.message
+              : String(searchError),
+          );
+        })
+        .finally(() => {
+          if (mounted) setLoading(false);
+        });
+    }, 250);
+
+    return () => {
+      mounted = false;
+      clearTimeout(timeout);
+    };
+  }, [query]);
+
+  const counts = {
+    users: users.length,
+    songs: results.songs.length,
+    artists: results.artists.length,
+    albums: results.albums.length,
+  };
+  const hasQuery = query.trim().length >= 2;
+  const hasResults = counts[activeTab] > 0;
+  const searchMusic = (name?: string) => {
+    if (!name) return;
+    setQuery(name);
+    setActiveTab("songs");
+  };
+
   return (
     <SongishShell title="Explore" rightRail={<RightRail />}>
       <Stack.Screen options={{ title: "Explore", headerShown: false }} />
-      <Text className="mb-6 text-2xl font-black">Events</Text>
-      <Text className="text-center text-lg text-muted-foreground">
-        No events at the moment.
-      </Text>
+      <View className="overflow-hidden rounded-2xl bg-background/75 shadow-sm backdrop-blur-xl">
+        <View className="flex-row items-center gap-3 px-4 py-4">
+          <Icon icon={Search} size={23} className="text-muted-foreground" />
+          <Input
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Search listeners, songs, artists, albums"
+            className="h-12 flex-1 border-0 bg-transparent px-0 text-lg web:focus-visible:ring-0"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          {loading ? (
+            <ActivityIndicator />
+          ) : (
+            query.length > 0 && (
+              <Pressable
+                onPress={() => setQuery("")}
+                className="h-9 w-9 items-center justify-center rounded-full bg-muted"
+              >
+                <Icon icon={X} size={18} className="text-muted-foreground" />
+              </Pressable>
+            )
+          )}
+        </View>
+        <View className="flex-row overflow-hidden border-t border-border/60">
+          <SearchTabButton
+            active={activeTab === "users"}
+            count={counts.users}
+            icon={UsersRound}
+            label="People"
+            onPress={() => setActiveTab("users")}
+          />
+          <SearchTabButton
+            active={activeTab === "songs"}
+            count={counts.songs}
+            icon={Music2}
+            label="Songs"
+            onPress={() => setActiveTab("songs")}
+          />
+          <SearchTabButton
+            active={activeTab === "artists"}
+            count={counts.artists}
+            icon={Mic2}
+            label="Artists"
+            onPress={() => setActiveTab("artists")}
+          />
+          <SearchTabButton
+            active={activeTab === "albums"}
+            count={counts.albums}
+            icon={Disc3}
+            label="Albums"
+            onPress={() => setActiveTab("albums")}
+          />
+        </View>
+      </View>
+
+      <View className="mt-5 rounded-2xl bg-background/75 px-4 py-2 backdrop-blur-xl">
+        {!hasQuery && (
+          <View className="min-h-[20rem] items-center justify-center gap-3 px-8">
+            <Icon icon={Search} size={38} className="text-muted-foreground" />
+            <Text className="text-center font-serif text-3xl font-black">
+              Find something playing
+            </Text>
+            <Text className="text-center text-muted-foreground">
+              Search live Teal plays and listeners across the ATProto network.
+            </Text>
+          </View>
+        )}
+        {error && (
+          <Text className="py-8 text-center font-bold text-destructive">
+            Search failed: {error}
+          </Text>
+        )}
+        {hasQuery && !loading && !error && !hasResults && (
+          <Text className="py-12 text-center text-muted-foreground">
+            No {activeTab} found for “{query.trim()}”.
+          </Text>
+        )}
+        {activeTab === "users" &&
+          users.map((user) => <UserRow key={user.did} user={user} />)}
+        {activeTab === "songs" &&
+          results.songs.map((song) => <SongRow key={song.uri} song={song} />)}
+        {activeTab === "artists" &&
+          results.artists.map((artist) => (
+            <MusicEntityRow
+              key={`${artist.mbid}-${artist.name}`}
+              icon={Mic2}
+              name={artist.name}
+              playCount={artist.playCount}
+              onPress={() => searchMusic(artist.name)}
+            />
+          ))}
+        {activeTab === "albums" &&
+          results.albums.map((album: ReleaseView) => (
+            <MusicEntityRow
+              key={`${album.mbid}-${album.name}`}
+              icon={Disc3}
+              name={album.name}
+              playCount={album.playCount}
+              onPress={() => searchMusic(album.name)}
+            />
+          ))}
+      </View>
     </SongishShell>
   );
 }

--- a/apps/amethyst/components/songish/SongishShell.tsx
+++ b/apps/amethyst/components/songish/SongishShell.tsx
@@ -1,9 +1,14 @@
 import { ReactNode } from "react";
-import { Pressable, ScrollView, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  View,
+  type ScrollViewProps,
+} from "react-native";
 import { Link, usePathname } from "expo-router";
 import useIsMobile from "@/hooks/useIsMobile";
-import { useStore } from "@/stores/mainStore";
 import { Icon } from "@/lib/icons/iconWithClassName";
+import { useStore } from "@/stores/mainStore";
 import { Bell, Home, LogIn, Search, UserCircle } from "lucide-react-native";
 
 import { Text } from "../ui/text";
@@ -12,6 +17,7 @@ type SongishShellProps = {
   children: ReactNode;
   rightRail?: ReactNode;
   title?: string;
+  onScroll?: ScrollViewProps["onScroll"];
 };
 
 function RecordLogo() {
@@ -122,7 +128,9 @@ function MobileNav() {
           <Icon
             icon={Home}
             size={34}
-            className={pathname === "/" ? "text-foreground" : "text-muted-foreground"}
+            className={
+              pathname === "/" ? "text-foreground" : "text-muted-foreground"
+            }
           />
         </Pressable>
       </Link>
@@ -144,7 +152,11 @@ function MobileNav() {
           <Icon
             icon={Search}
             size={38}
-            className={pathname.includes("search") ? "text-foreground" : "text-muted-foreground"}
+            className={
+              pathname.includes("search")
+                ? "text-foreground"
+                : "text-muted-foreground"
+            }
           />
         </Pressable>
       </Link>
@@ -161,6 +173,7 @@ export default function SongishShell({
   children,
   rightRail,
   title,
+  onScroll,
 }: SongishShellProps) {
   const isMobile = useIsMobile();
 
@@ -168,13 +181,16 @@ export default function SongishShell({
     <View className="min-h-screen flex-1 bg-background">
       <View className="absolute inset-0 bg-[linear-gradient(110deg,#ffffff_0%,#ffffff_34%,#8fb4ff_60%,#0a43ff_100%)] dark:bg-[linear-gradient(110deg,#08040b_0%,#13091a_38%,#26356f_68%,#0f49ff_100%)]" />
       <Text className="z-20 h-7 text-center text-sm font-black">
-        teal is in active development: expect bugs, missing features, and regular index rebuilds
+        teal is in active development: expect bugs, missing features, and
+        regular index rebuilds
       </Text>
       <View className="z-10 flex-1 flex-row">
         <LeftRail />
         <ScrollView
           className="flex-1"
           contentContainerClassName="items-center pb-28 lg:pb-10"
+          onScroll={onScroll}
+          scrollEventThrottle={onScroll ? 200 : undefined}
         >
           <View className="min-h-screen w-full max-w-[42rem] rounded-t-3xl bg-background/60 px-3 py-8 backdrop-blur-xl md:px-8">
             {title && (

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -50,10 +50,14 @@ async function getXrpc<T>(
   return response.json() as Promise<T>;
 }
 
-export function getLatestPlays(limit = 50) {
-  return getXrpc<{ plays: PlayView[] }>("fm.teal.alpha.stats.getLatest", {
-    limit,
-  });
+export function getLatestPlays(limit = 50, cursor?: string) {
+  return getXrpc<{ plays: PlayView[]; cursor?: string }>(
+    "fm.teal.alpha.stats.getLatest",
+    {
+      limit,
+      cursor,
+    },
+  );
 }
 
 export function getActorFeed(authorDID: string, limit = 50) {

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -1,15 +1,24 @@
-import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
-import type { ProfileView } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
-import type { ArtistView, ReleaseView } from "@teal/lexicons/src/types/fm/teal/alpha/stats/defs";
 import type { AppBskyActorDefs } from "@atproto/api";
 
+import type {
+  MiniProfileView,
+  ProfileView,
+} from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
+import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+import type { SongResult } from "@teal/lexicons/src/types/fm/teal/alpha/search/defs";
+import type {
+  ArtistView,
+  ReleaseView,
+} from "@teal/lexicons/src/types/fm/teal/alpha/stats/defs";
+
 const rawBase =
-  process.env.EXPO_PUBLIC_AQUA_URL ||
-  process.env.EXPO_PUBLIC_APPVIEW_URL ||
-  "";
+  process.env.EXPO_PUBLIC_AQUA_URL || process.env.EXPO_PUBLIC_APPVIEW_URL || "";
 
 const requestBase =
-  rawBase || (typeof window === "undefined" ? "http://localhost:3000" : window.location.origin);
+  rawBase ||
+  (typeof window === "undefined"
+    ? "http://localhost:3000"
+    : window.location.origin);
 const xrpcBase = requestBase.endsWith("/xrpc")
   ? requestBase
   : `${requestBase.replace(/\/$/, "")}/xrpc`;
@@ -79,9 +88,12 @@ export async function getBlueskyProfile(actor: string) {
 }
 
 export function getTopArtists(limit = 5) {
-  return getXrpc<{ artists: ArtistView[] }>("fm.teal.alpha.stats.getTopArtists", {
-    limit,
-  });
+  return getXrpc<{ artists: ArtistView[] }>(
+    "fm.teal.alpha.stats.getTopArtists",
+    {
+      limit,
+    },
+  );
 }
 
 export function getTopReleases(limit = 5) {
@@ -91,9 +103,42 @@ export function getTopReleases(limit = 5) {
   );
 }
 
+export type SearchResults = {
+  users: MiniProfileView[];
+  songs: SongResult[];
+  artists: ArtistView[];
+  albums: ReleaseView[];
+};
+
+export function getSearchResults(q: string, limit = 8) {
+  return getXrpc<SearchResults>("fm.teal.alpha.search.getResults", {
+    q,
+    limit,
+  });
+}
+
+export async function searchBlueskyUsers(q: string, limit = 8) {
+  const url = new URL(
+    "https://public.api.bsky.app/xrpc/app.bsky.actor.searchActors",
+  );
+  url.searchParams.set("q", q);
+  url.searchParams.set("limit", String(limit));
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new XrpcError("app.bsky.actor.searchActors", response.status);
+  }
+
+  return response.json() as Promise<{
+    actors: AppBskyActorDefs.ProfileViewBasic[];
+  }>;
+}
+
 export function coverArtUrl(releaseMbId?: string, size = 250) {
   const mbid = releaseMbId?.replace(/^mbid:/, "");
-  return mbid ? `https://coverartarchive.org/release/${mbid}/front-${size}` : undefined;
+  return mbid
+    ? `https://coverartarchive.org/release/${mbid}/front-${size}`
+    : undefined;
 }
 
 export function displayArtists(play: PlayView) {

--- a/apps/aqua/src/main.rs
+++ b/apps/aqua/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), String> {
         )
         .nest("/xrpc/", xrpc::actor::actor_routes())
         .nest("/xrpc/", xrpc::feed::feed_routes())
+        .nest("/xrpc/", xrpc::search::search_routes())
         .nest("/xrpc/", xrpc::stats::stats_routes())
         .layer(Extension(ctx))
         .layer(cors);

--- a/apps/aqua/src/repos/mod.rs
+++ b/apps/aqua/src/repos/mod.rs
@@ -4,15 +4,19 @@ use types::fm_teal::alpha::actor::MiniProfileView;
 use uuid::Uuid;
 
 use crate::repos::feed_play::FeedPlayRepo;
+use crate::repos::search::SearchRepo;
 use crate::repos::stats::StatsRepo;
 
 pub mod actor_profile;
 pub mod feed_play;
 pub mod pg;
+pub mod search;
 pub mod stats;
 
 #[async_trait::async_trait]
-pub trait DataSource: ActorProfileRepo + FeedPlayRepo + StatsRepo + Send + Sync {
+pub trait DataSource:
+    ActorProfileRepo + FeedPlayRepo + SearchRepo + StatsRepo + Send + Sync
+{
     fn boxed(self) -> Box<dyn DataSource>
     where
         Self: Sized + Send + Sync + 'static,

--- a/apps/aqua/src/repos/search.rs
+++ b/apps/aqua/src/repos/search.rs
@@ -1,0 +1,197 @@
+use async_trait::async_trait;
+use jacquard_common::types::string::AtUri;
+use types::fm_teal::alpha::{
+    actor::MiniProfileView,
+    search::SongResult,
+    stats::{ArtistView, ReleaseView},
+};
+
+use super::{mbid_uri, mini_profile, pg::PgDataSource};
+
+pub struct SearchResults {
+    pub users: Vec<MiniProfileView>,
+    pub songs: Vec<SongResult>,
+    pub artists: Vec<ArtistView>,
+    pub albums: Vec<ReleaseView>,
+}
+
+#[async_trait]
+pub trait SearchRepo: Send + Sync {
+    async fn search(&self, query: &str, limit: Option<i32>) -> anyhow::Result<SearchResults>;
+}
+
+#[async_trait]
+impl SearchRepo for PgDataSource {
+    async fn search(&self, query: &str, limit: Option<i32>) -> anyhow::Result<SearchResults> {
+        let limit = limit.unwrap_or(8).clamp(1, 25) as i64;
+        let pattern = format!("%{query}%");
+        let prefix = format!("{query}%");
+
+        let user_rows = sqlx::query!(
+            r#"
+            SELECT did, handle, display_name, avatar
+            FROM profiles
+            WHERE display_name ILIKE $1 OR handle ILIKE $1
+            ORDER BY
+                CASE
+                    WHEN LOWER(handle) = LOWER($2) OR LOWER(display_name) = LOWER($2) THEN 0
+                    WHEN handle ILIKE $3 OR display_name ILIKE $3 THEN 1
+                    ELSE 2
+                END,
+                display_name NULLS LAST,
+                handle NULLS LAST
+            LIMIT $4
+            "#,
+            pattern,
+            query,
+            prefix,
+            limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let users = user_rows
+            .into_iter()
+            .filter_map(|row| mini_profile(Some(row.did), row.handle, row.display_name, row.avatar))
+            .collect();
+
+        let song_rows = sqlx::query!(
+            r#"
+            WITH matched AS (
+                SELECT
+                    p.uri,
+                    p.track_name,
+                    p.release_name,
+                    p.release_mbid,
+                    p.processed_time,
+                    COALESCE(
+                        STRING_AGG(DISTINCT ptae.artist_name, ', ' ORDER BY ptae.artist_name),
+                        'Unknown artist'
+                    ) AS artist_name,
+                    COUNT(*) OVER (
+                        PARTITION BY LOWER(p.track_name), COALESCE(p.recording_mbid::text, '')
+                    ) AS play_count,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY LOWER(p.track_name), COALESCE(p.recording_mbid::text, '')
+                        ORDER BY p.processed_time DESC, p.uri
+                    ) AS row_number
+                FROM plays p
+                LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri
+                WHERE p.track_name ILIKE $1
+                GROUP BY p.uri, p.track_name, p.release_name, p.release_mbid, p.processed_time,
+                         p.recording_mbid
+            )
+            SELECT uri, track_name, release_name, release_mbid, artist_name, play_count
+            FROM matched
+            WHERE row_number = 1
+            ORDER BY
+                CASE
+                    WHEN LOWER(track_name) = LOWER($2) THEN 0
+                    WHEN track_name ILIKE $3 THEN 1
+                    ELSE 2
+                END,
+                play_count DESC,
+                track_name
+            LIMIT $4
+            "#,
+            pattern,
+            query,
+            prefix,
+            limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let songs = song_rows
+            .into_iter()
+            .filter_map(|row| {
+                Some(SongResult {
+                    uri: AtUri::try_from(row.uri).ok()?,
+                    track_name: row.track_name.into(),
+                    artist_name: row.artist_name?.into(),
+                    release_name: row.release_name.map(Into::into),
+                    release_mb_id: row.release_mbid.map(mbid_uri),
+                    play_count: row.play_count?,
+                    extra_data: Default::default(),
+                })
+            })
+            .collect();
+
+        let artist_rows = sqlx::query!(
+            r#"
+            SELECT ae.mbid, ae.name, COUNT(ptae.play_uri) AS play_count
+            FROM artists_extended ae
+            LEFT JOIN play_to_artists_extended ptae ON ae.id = ptae.artist_id
+            WHERE ae.name ILIKE $1
+            GROUP BY ae.id, ae.mbid, ae.name
+            ORDER BY
+                CASE
+                    WHEN LOWER(ae.name) = LOWER($2) THEN 0
+                    WHEN ae.name ILIKE $3 THEN 1
+                    ELSE 2
+                END,
+                play_count DESC,
+                ae.name
+            LIMIT $4
+            "#,
+            pattern,
+            query,
+            prefix,
+            limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let artists = artist_rows
+            .into_iter()
+            .map(|row| ArtistView {
+                mbid: row.mbid.map(mbid_uri),
+                name: Some(row.name.into()),
+                play_count: Some(row.play_count.unwrap_or(0)),
+                extra_data: Default::default(),
+            })
+            .collect();
+
+        let album_rows = sqlx::query!(
+            r#"
+            SELECT r.mbid, r.name, COUNT(p.uri) AS play_count
+            FROM releases r
+            LEFT JOIN plays p ON r.mbid = p.release_mbid
+            WHERE r.name ILIKE $1
+            GROUP BY r.mbid, r.name
+            ORDER BY
+                CASE
+                    WHEN LOWER(r.name) = LOWER($2) THEN 0
+                    WHEN r.name ILIKE $3 THEN 1
+                    ELSE 2
+                END,
+                play_count DESC,
+                r.name
+            LIMIT $4
+            "#,
+            pattern,
+            query,
+            prefix,
+            limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let albums = album_rows
+            .into_iter()
+            .map(|row| ReleaseView {
+                mbid: Some(mbid_uri(row.mbid)),
+                name: Some(row.name.into()),
+                play_count: Some(row.play_count.unwrap_or(0)),
+                extra_data: Default::default(),
+            })
+            .collect();
+
+        Ok(SearchResults {
+            users,
+            songs,
+            artists,
+            albums,
+        })
+    }
+}

--- a/apps/aqua/src/repos/stats.rs
+++ b/apps/aqua/src/repos/stats.rs
@@ -1,10 +1,39 @@
 use async_trait::async_trait;
 use jacquard_common::from_json_value;
 use jacquard_common::types::string::{AtUri, Did};
+use serde::{Deserialize, Serialize};
 use types::fm_teal::alpha::feed::PlayView;
 use types::fm_teal::alpha::stats::{ArtistView, ReleaseView};
 
 use super::{mbid_uri, mini_profile, pg::PgDataSource, utc_to_atrium_datetime};
+
+pub struct LatestPlaysPage {
+    pub plays: Vec<PlayView>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LatestPlaysCursor {
+    processed_time: String,
+    uri: String,
+}
+
+fn decode_latest_cursor(cursor: Option<&str>) -> anyhow::Result<Option<LatestPlaysCursor>> {
+    cursor
+        .map(|cursor| {
+            let bytes =
+                base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, cursor)?;
+            Ok(serde_json::from_slice(&bytes)?)
+        })
+        .transpose()
+}
+
+fn encode_latest_cursor(cursor: &LatestPlaysCursor) -> anyhow::Result<String> {
+    Ok(base64::Engine::encode(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+        serde_json::to_vec(cursor)?,
+    ))
+}
 
 #[async_trait]
 pub trait StatsRepo: Send + Sync {
@@ -20,7 +49,11 @@ pub trait StatsRepo: Send + Sync {
         did: &str,
         limit: Option<i32>,
     ) -> anyhow::Result<Vec<ReleaseView>>;
-    async fn get_latest(&self, limit: Option<i32>) -> anyhow::Result<Vec<PlayView>>;
+    async fn get_latest(
+        &self,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<LatestPlaysPage>;
 }
 
 #[async_trait]
@@ -179,8 +212,23 @@ impl StatsRepo for PgDataSource {
         Ok(result)
     }
 
-    async fn get_latest(&self, limit: Option<i32>) -> anyhow::Result<Vec<PlayView>> {
+    async fn get_latest(
+        &self,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<LatestPlaysPage> {
         let limit = limit.unwrap_or(50).min(100) as i64;
+        let query_limit = limit + 1;
+        let cursor = decode_latest_cursor(cursor)?;
+        let cursor_time = cursor
+            .as_ref()
+            .map(|cursor| {
+                time::OffsetDateTime::parse(
+                    &cursor.processed_time,
+                    &time::format_description::well_known::Rfc3339,
+                )
+            })
+            .transpose()?;
 
         let rows = sqlx::query!(
             r#"
@@ -203,27 +251,39 @@ impl StatsRepo for PgDataSource {
             LEFT JOIN profiles profile ON p.did = profile.did
             LEFT JOIN play_to_artists_extended as ptae ON p.uri = ptae.play_uri
             LEFT JOIN artists_extended as ae ON ptae.artist_id = ae.id
+            WHERE ($1::timestamptz IS NULL OR (p.processed_time, p.uri) < ($1, $2))
             GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,
                      p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,
                      p.submission_client_agent, p.music_service_base_domain, p.origin_url,
                      profile.did, profile.handle, profile.display_name, profile.avatar
             ORDER BY p.processed_time DESC
-            LIMIT $1
+            LIMIT $3
             "#,
-            limit
+            cursor_time,
+            cursor.as_ref().map(|cursor| cursor.uri.as_str()),
+            query_limit
         )
         .fetch_all(&self.db)
         .await?;
 
-        let mut result = Vec::with_capacity(rows.len());
-        for row in rows {
+        let has_more = rows.len() > limit as usize;
+        let mut plays = Vec::with_capacity(rows.len().min(limit as usize));
+        let mut next_cursor = None;
+        for row in rows.into_iter().take(limit as usize) {
+            next_cursor = Some(LatestPlaysCursor {
+                processed_time: row
+                    .processed_time
+                    .unwrap_or_else(time::OffsetDateTime::now_utc)
+                    .format(&time::format_description::well_known::Rfc3339)?,
+                uri: row.uri.clone(),
+            });
             let artists = match row.artists {
                 Some(value) => from_json_value::<Vec<types::fm_teal::alpha::feed::Artist>>(value)
                     .unwrap_or_default(),
                 None => vec![],
             };
 
-            result.push(PlayView {
+            plays.push(PlayView {
                 track_name: row.track_name.into(),
                 author: mini_profile(
                     row.profile_did,
@@ -252,6 +312,37 @@ impl StatsRepo for PgDataSource {
             });
         }
 
-        Ok(result)
+        Ok(LatestPlaysPage {
+            plays,
+            cursor: if has_more {
+                next_cursor.as_ref().map(encode_latest_cursor).transpose()?
+            } else {
+                None
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LatestPlaysCursor, decode_latest_cursor, encode_latest_cursor};
+
+    #[test]
+    fn latest_cursor_round_trips() -> anyhow::Result<()> {
+        let cursor = LatestPlaysCursor {
+            processed_time: "2026-05-31T22:53:52Z".to_string(),
+            uri: "at://did:plc:listener/fm.teal.alpha.feed.play/3example".to_string(),
+        };
+        let encoded = encode_latest_cursor(&cursor)?;
+        let decoded = decode_latest_cursor(Some(&encoded))?.expect("cursor should decode");
+
+        assert_eq!(decoded.processed_time, cursor.processed_time);
+        assert_eq!(decoded.uri, cursor.uri);
+        Ok(())
+    }
+
+    #[test]
+    fn latest_cursor_rejects_invalid_values() {
+        assert!(decode_latest_cursor(Some("not-a-cursor")).is_err());
     }
 }

--- a/apps/aqua/src/xrpc/mod.rs
+++ b/apps/aqua/src/xrpc/mod.rs
@@ -1,3 +1,4 @@
 pub mod actor;
 pub mod feed;
+pub mod search;
 pub mod stats;

--- a/apps/aqua/src/xrpc/search.rs
+++ b/apps/aqua/src/xrpc/search.rs
@@ -1,0 +1,40 @@
+use axum::{Extension, http::StatusCode, response::IntoResponse, routing::get};
+use jacquard_common::IntoStatic;
+use serde::Deserialize;
+use types::fm_teal::alpha::search::get_results::GetResultsOutput;
+
+use crate::ctx::Context;
+
+pub fn search_routes() -> axum::Router {
+    axum::Router::new().route("/fm.teal.alpha.search.getResults", get(get_results))
+}
+
+#[derive(Deserialize)]
+pub struct GetResultsQuery {
+    pub q: String,
+    pub limit: Option<i32>,
+}
+
+pub async fn get_results(
+    Extension(ctx): Extension<Context>,
+    axum::extract::Query(query): axum::extract::Query<GetResultsQuery>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let query_text = query.q.trim();
+    if query_text.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "q is required".to_string()));
+    }
+
+    match ctx.db.search(query_text, query.limit).await {
+        Ok(results) => Ok(axum::Json(
+            GetResultsOutput {
+                users: results.users,
+                songs: results.songs,
+                artists: results.artists,
+                albums: results.albums,
+                extra_data: Default::default(),
+            }
+            .into_static(),
+        )),
+        Err(error) => Err((StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
+    }
+}

--- a/apps/aqua/src/xrpc/stats.rs
+++ b/apps/aqua/src/xrpc/stats.rs
@@ -130,11 +130,13 @@ pub async fn get_user_top_releases(
 #[derive(Deserialize)]
 pub struct GetLatestQuery {
     pub limit: Option<i32>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct GetLatestResponse {
     plays: Vec<PlayView>,
+    cursor: Option<String>,
 }
 
 pub async fn get_latest(
@@ -143,9 +145,10 @@ pub async fn get_latest(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let repo = &ctx.db;
 
-    match repo.get_latest(query.limit).await {
-        Ok(plays) => Ok(axum::Json(GetLatestResponse {
-            plays: plays.into_static(),
+    match repo.get_latest(query.limit, query.cursor.as_deref()).await {
+        Ok(page) => Ok(axum::Json(GetLatestResponse {
+            plays: page.plays.into_static(),
+            cursor: page.cursor,
         })),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }

--- a/lexicons/fm.teal.alpha/search/defs.json
+++ b/lexicons/fm.teal.alpha/search/defs.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.search.defs",
+  "defs": {
+    "songResult": {
+      "type": "object",
+      "required": ["uri", "trackName", "artistName", "playCount"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "Representative indexed play URI for this song"
+        },
+        "trackName": {
+          "type": "string",
+          "description": "Track name"
+        },
+        "artistName": {
+          "type": "string",
+          "description": "Display-ready artist credit"
+        },
+        "releaseName": {
+          "type": "string",
+          "description": "Release or album name"
+        },
+        "releaseMbId": {
+          "type": "string",
+          "format": "uri",
+          "description": "MusicBrainz release ID URI, formatted as mbid:<uuid>"
+        },
+        "playCount": {
+          "type": "integer",
+          "description": "Number of indexed plays for this song"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/search/getResults.json
+++ b/lexicons/fm.teal.alpha/search/getResults.json
@@ -1,0 +1,66 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.search.getResults",
+  "description": "Search indexed Teal listeners and music metadata.",
+  "defs": {
+    "main": {
+      "type": "query",
+      "parameters": {
+        "type": "params",
+        "required": ["q"],
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query",
+            "maxGraphemes": 128,
+            "maxLength": 640
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum results per category",
+            "minimum": 1,
+            "maximum": 25,
+            "default": 8
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["users", "songs", "artists", "albums"],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "fm.teal.alpha.actor.defs#miniProfileView"
+              }
+            },
+            "songs": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "fm.teal.alpha.search.defs#songResult"
+              }
+            },
+            "artists": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "fm.teal.alpha.stats.defs#artistView"
+              }
+            },
+            "albums": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "fm.teal.alpha.stats.defs#releaseView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/stats/getLatest.json
+++ b/lexicons/fm.teal.alpha/stats/getLatest.json
@@ -14,6 +14,10 @@
             "maximum": 100,
             "default": 50,
             "description": "Number of latest plays to return"
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque cursor for the next page of plays"
           }
         }
       },
@@ -29,6 +33,10 @@
                 "type": "ref",
                 "ref": "fm.teal.alpha.feed.defs#playView"
               }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Opaque cursor for the next page of plays"
             }
           }
         }

--- a/todo.md
+++ b/todo.md
@@ -4,8 +4,8 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 
 ## Current State
 
-- Amethyst has a Teal-branded Songish-style shell with desktop navigation, mobile navigation, Home, Explore, Notifications, Profile, and music detail views.
-- Aqua exposes Teal XRPC routes for latest plays, individual plays, actor feeds, profiles, and stats.
+- Amethyst has a Teal-branded Songish-style shell with desktop navigation, mobile navigation, Home, searchable Explore, Notifications, Profile, and music detail views.
+- Aqua exposes Teal XRPC routes for latest plays, individual plays, actor feeds, profiles, stats, and indexed search across listeners, songs, artists, and albums.
 - Cadet consumes Teal records from Jetstream, stores a durable cursor in Redis with file fallback, and ingests create, update, and delete events for profiles and plays.
 - The public Amethyst feed uses only live Aqua XRPC data. There is no seeded, mocked, demo, or backup play feed.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
@@ -47,6 +47,7 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 
 ## Next: Amethyst UI
 
+- [x] Add Explore search for users, songs, artists, and albums.
 - [ ] Finish profile avatar and banner blob URL rendering.
 - [ ] Add artist and release detail routes in addition to track detail.
 - [ ] Render real Cover Art Archive images for recordings with MusicBrainz IDs and polished fallbacks for missing art.

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,7 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 ## Current State
 
 - Amethyst has a Teal-branded Songish-style shell with desktop navigation, mobile navigation, Home, searchable Explore, Notifications, Profile, and music detail views.
-- Aqua exposes Teal XRPC routes for latest plays, individual plays, actor feeds, profiles, stats, and indexed search across listeners, songs, artists, and albums.
+- Aqua exposes Teal XRPC routes for cursor-paginated latest plays, individual plays, actor feeds, profiles, stats, and indexed search across listeners, songs, artists, and albums.
 - Cadet consumes Teal records from Jetstream, stores a durable cursor in Redis with file fallback, and ingests create, update, and delete events for profiles and plays.
 - The public Amethyst feed uses only live Aqua XRPC data. There is no seeded, mocked, demo, or backup play feed.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
@@ -40,6 +40,7 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 ## Next: Aqua And Lexicons
 
 - [ ] Add pagination support for `fm.teal.alpha.feed.getActorFeed` cursor and limit parameters.
+- [x] Add keyset pagination and infinite scrolling for the global latest-play feed.
 - [x] Run SQLx prepare against the development Postgres instance and commit refreshed query cache data.
 - [ ] Resolve the existing Satellite SQLx offline-cache gap so `pnpm turbo run test:rust` passes without a live Docker hostname.
 - [ ] Decide whether the legacy `play_to_artists` join table can be removed after Aqua reads move fully to `play_to_artists_extended`.


### PR DESCRIPTION
Add explore discovery and infinite scrolling. This groups the existing commits by chronology and the area they change.

Part 3 of 33 replacing #113. Review this PR against `feature/obbpr-02-profile-identity`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 45f494c feat(search): add live explore discovery
- 41130e3 feat(feed): add infinite scroll pagination

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/196
- Next: https://github.com/teal-fm/teal/pull/198
- Full stack index: https://github.com/teal-fm/teal/pull/113
