### PR TITLE
[04/33] feat(music): add artist and album pages

### DIFF
--- a/.sqlx/query-08f2f4778882d946cc1d82f9ca7dd3bfe1bff6cab962a119d0a721e332d98d51.json
+++ b/.sqlx/query-08f2f4778882d946cc1d82f9ca7dd3bfe1bff6cab962a119d0a721e332d98d51.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT ae.id, ae.mbid, ae.name, COUNT(DISTINCT ptae.play_uri) AS play_count\n            FROM artists_extended ae\n            LEFT JOIN play_to_artists_extended ptae ON ae.id = ptae.artist_id\n            WHERE ($1::uuid IS NOT NULL AND ae.mbid = $1)\n               OR ($1::uuid IS NULL AND LOWER(ae.name) = LOWER($2))\n            GROUP BY ae.id, ae.mbid, ae.name\n            ORDER BY play_count DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "play_count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "08f2f4778882d946cc1d82f9ca7dd3bfe1bff6cab962a119d0a721e332d98d51"
+}

--- a/.sqlx/query-50705a996b6048f8d9d145e27b34c62d8ead70b840deb29957ec60d2988b4ac9.json
+++ b/.sqlx/query-50705a996b6048f8d9d145e27b34c62d8ead70b840deb29957ec60d2988b4ac9.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH track_plays AS (\n                SELECT\n                    p.uri,\n                    p.recording_mbid,\n                    p.track_name,\n                    p.processed_time,\n                    COALESCE(\n                        STRING_AGG(DISTINCT ptae.artist_name, ', ' ORDER BY ptae.artist_name),\n                        'Unknown artist'\n                    ) AS artist_name\n                FROM plays p\n                LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri\n                WHERE p.release_mbid = $1\n                GROUP BY p.uri, p.recording_mbid, p.track_name, p.processed_time\n            )\n            SELECT DISTINCT ON (COALESCE(recording_mbid::text, LOWER(track_name)))\n                uri,\n                recording_mbid,\n                track_name,\n                artist_name,\n                COUNT(*) OVER (\n                    PARTITION BY COALESCE(recording_mbid::text, LOWER(track_name))\n                ) AS \"play_count!\"\n            FROM track_plays\n            ORDER BY COALESCE(recording_mbid::text, LOWER(track_name)), processed_time DESC, uri\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "recording_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "track_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "artist_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "play_count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "50705a996b6048f8d9d145e27b34c62d8ead70b840deb29957ec60d2988b4ac9"
+}

--- a/.sqlx/query-7b59e08731ba68a06d740c7715258bce8f914f9a705f61c79e7d8f9fb0edce54.json
+++ b/.sqlx/query-7b59e08731ba68a06d740c7715258bce8f914f9a705f61c79e7d8f9fb0edce54.json
@@ -1,0 +1,139 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                profile.did AS \"profile_did?\", profile.handle AS profile_handle,\n                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,\n                COALESCE(\n                  json_agg(\n                    json_build_object(\n                      'artistMbId', ae.mbid,\n                      'artistName', ptae.artist_name\n                    )\n                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),\n                  '[]'\n                ) AS artists\n            FROM plays p\n            LEFT JOIN profiles profile ON p.did = profile.did\n            LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri\n            LEFT JOIN artists_extended ae ON ptae.artist_id = ae.id\n            WHERE p.release_mbid = $1\n              AND ($2::timestamptz IS NULL OR (p.processed_time, p.uri) < ($2, $3))\n            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                     profile.did, profile.handle, profile.display_name, profile.avatar\n            ORDER BY p.processed_time DESC, p.uri DESC\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "rkey",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "isrc",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "duration",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "track_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "played_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "processed_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "release_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 10,
+        "name": "release_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "recording_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 12,
+        "name": "submission_client_agent",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "music_service_base_domain",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "origin_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "profile_did?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "profile_handle",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "profile_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "profile_avatar",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "artists",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "7b59e08731ba68a06d740c7715258bce8f914f9a705f61c79e7d8f9fb0edce54"
+}

--- a/.sqlx/query-abe60b617d4cd5861a4a8f80755adb8946f3df1bf85b8a7dc3b7c6f2b5733e6d.json
+++ b/.sqlx/query-abe60b617d4cd5861a4a8f80755adb8946f3df1bf85b8a7dc3b7c6f2b5733e6d.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                p.release_mbid AS \"mbid!\",\n                MAX(p.release_name) AS \"name!\",\n                COUNT(DISTINCT p.uri) AS \"play_count!\"\n            FROM plays p\n            INNER JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri\n            WHERE ptae.artist_id = $1\n              AND p.release_mbid IS NOT NULL\n              AND p.release_name IS NOT NULL\n            GROUP BY p.release_mbid\n            ORDER BY MAX(p.played_time) DESC NULLS LAST, MAX(p.release_name)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "mbid!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "play_count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "abe60b617d4cd5861a4a8f80755adb8946f3df1bf85b8a7dc3b7c6f2b5733e6d"
+}

--- a/.sqlx/query-c06c1576352568580ef9a4284b4607311fe73a06606146de92f109d2ce5dedb6.json
+++ b/.sqlx/query-c06c1576352568580ef9a4284b4607311fe73a06606146de92f109d2ce5dedb6.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                p.release_mbid AS \"mbid!\",\n                COALESCE(MAX(p.release_name), 'Unknown release') AS \"name!\",\n                COUNT(DISTINCT p.uri) AS \"play_count!\",\n                COALESCE(\n                    (ARRAY_AGG(ptae.artist_name ORDER BY ptae.artist_name)\n                        FILTER (WHERE ptae.artist_name IS NOT NULL))[1],\n                    'Unknown artist'\n                ) AS \"artist_name!\",\n                (ARRAY_AGG(ae.mbid ORDER BY ptae.artist_name)\n                    FILTER (WHERE ae.mbid IS NOT NULL))[1] AS artist_mbid\n            FROM plays p\n            LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri\n            LEFT JOIN artists_extended ae ON ptae.artist_id = ae.id\n            WHERE p.release_mbid = $1\n            GROUP BY p.release_mbid\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "mbid!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "play_count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "artist_name!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "artist_mbid",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "c06c1576352568580ef9a4284b4607311fe73a06606146de92f109d2ce5dedb6"
+}

--- a/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
+++ b/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState } from "react";
-import { ActivityIndicator, Image, View } from "react-native";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, Image, Pressable, View } from "react-native";
+import { Link, Stack, useLocalSearchParams } from "expo-router";
 import PlayFeedCard from "@/components/songish/PlayFeedCard";
 import RightRail from "@/components/songish/RightRail";
 import SongishShell from "@/components/songish/SongishShell";
 import { Text } from "@/components/ui/text";
-import { coverArtUrl, displayArtists, getLatestPlays, getPlayByUri } from "@/lib/teal/api";
+import {
+  coverArtUrl,
+  displayArtists,
+  getLatestPlays,
+  getPlayByUri,
+} from "@/lib/teal/api";
+import { musicAlbumHref, musicArtistHref } from "@/lib/teal/routes";
+
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
 
 export default function MusicDetail() {
@@ -45,7 +52,9 @@ export default function MusicDetail() {
 
   return (
     <SongishShell rightRail={<RightRail />}>
-      <Stack.Screen options={{ title: play?.trackName || "Music", headerShown: false }} />
+      <Stack.Screen
+        options={{ title: play?.trackName || "Music", headerShown: false }}
+      />
       {!play && !error && (
         <View className="min-h-[24rem] items-center justify-center">
           <ActivityIndicator size="large" />
@@ -53,7 +62,9 @@ export default function MusicDetail() {
       )}
       {error && (
         <View className="rounded-2xl bg-destructive/15 p-4">
-          <Text className="font-bold text-destructive">Could not load music detail: {error}</Text>
+          <Text className="font-bold text-destructive">
+            Could not load music detail: {error}
+          </Text>
         </View>
       )}
       {play && (
@@ -71,27 +82,71 @@ export default function MusicDetail() {
               {coverArtUrl(play.releaseMbId) ? (
                 <Image
                   source={{ uri: coverArtUrl(play.releaseMbId) }}
-                  className="h-36 w-36 rounded-2xl bg-muted"
+                  className="h-24 w-24 rounded-2xl bg-muted md:h-28 md:w-28"
                 />
               ) : (
-                <View className="h-36 w-36 rounded-2xl bg-muted" />
+                <View className="h-24 w-24 rounded-2xl bg-muted md:h-28 md:w-28" />
               )}
               <View className="min-w-0 flex-1 justify-end pb-2">
-                <Text className="font-serif text-3xl font-black" numberOfLines={2}>
+                <Text
+                  className="font-serif text-2xl font-black"
+                  numberOfLines={3}
+                >
                   {play.trackName}
                 </Text>
-                <Text className="text-lg font-bold text-muted-foreground">
-                  {displayArtists(play) || "Unknown artist"}
-                </Text>
-                {play.releaseName && (
-                  <Text className="text-muted-foreground">{play.releaseName}</Text>
+                {play.artists[0]?.artistMbId ? (
+                  <Link
+                    href={
+                      musicArtistHref(
+                        displayArtists(play),
+                        play.artists[0].artistMbId,
+                      ) as any
+                    }
+                    asChild
+                  >
+                    <Pressable>
+                      <Text className="font-bold text-muted-foreground">
+                        {displayArtists(play) || "Unknown artist"}
+                      </Text>
+                    </Pressable>
+                  </Link>
+                ) : (
+                  <Text className="font-bold text-muted-foreground">
+                    {displayArtists(play) || "Unknown artist"}
+                  </Text>
                 )}
+                {play.releaseName &&
+                  (play.releaseMbId ? (
+                    <Link
+                      href={
+                        musicAlbumHref(
+                          displayArtists(play),
+                          play.releaseName,
+                          play.releaseMbId,
+                        ) as any
+                      }
+                      asChild
+                    >
+                      <Pressable>
+                        <Text className="text-muted-foreground">
+                          {play.releaseName}
+                        </Text>
+                      </Pressable>
+                    </Link>
+                  ) : (
+                    <Text className="text-muted-foreground">
+                      {play.releaseName}
+                    </Text>
+                  ))}
               </View>
             </View>
           </View>
           <Text className="mb-4 text-2xl font-black">Plays</Text>
           {(related.length ? related : [play]).map((item, index) => (
-            <PlayFeedCard key={item.uri || `${item.trackName}-${index}`} play={item} />
+            <PlayFeedCard
+              key={item.uri || `${item.trackName}-${index}`}
+              play={item}
+            />
           ))}
         </>
       )}

--- a/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/index.tsx
+++ b/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/index.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
+import { Link, Stack, useLocalSearchParams } from "expo-router";
+import PlayFeedCard from "@/components/songish/PlayFeedCard";
+import RightRail from "@/components/songish/RightRail";
+import SongishShell from "@/components/songish/SongishShell";
+import { Text } from "@/components/ui/text";
+import { Icon } from "@/lib/icons/iconWithClassName";
+import { coverArtUrl, getAlbum } from "@/lib/teal/api";
+import { musicArtistHref, musicTrackHref } from "@/lib/teal/routes";
+import { ChevronRight, Disc3, Music2 } from "lucide-react-native";
+
+import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+import type { AlbumView } from "@teal/lexicons/src/types/fm/teal/alpha/music/defs";
+
+export default function AlbumDetail() {
+  const params = useLocalSearchParams();
+  const mbid = Array.isArray(params.mbid) ? params.mbid[0] : params.mbid;
+  const [album, setAlbum] = useState<AlbumView | null>(null);
+  const [plays, setPlays] = useState<PlayView[]>([]);
+  const [cursor, setCursor] = useState<string>();
+  const [error, setError] = useState<string>();
+  const [artFailed, setArtFailed] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!mbid) {
+      setError("Missing MusicBrainz release ID");
+      return;
+    }
+    getAlbum(mbid, 30)
+      .then((page) => {
+        if (!mounted) return;
+        setAlbum(page.album);
+        setPlays(page.plays);
+        setCursor(page.cursor);
+      })
+      .catch((loadError) => {
+        if (mounted) {
+          setError(
+            loadError instanceof Error ? loadError.message : String(loadError),
+          );
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [mbid]);
+
+  const loadMore = useCallback(() => {
+    if (!mbid || !cursor || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    getAlbum(mbid, 30, cursor)
+      .then((page) => {
+        setPlays((current) => {
+          const knownUris = new Set(current.map((play) => play.uri));
+          return [
+            ...current,
+            ...page.plays.filter(
+              (play) => !play.uri || !knownUris.has(play.uri),
+            ),
+          ];
+        });
+        setCursor(page.cursor);
+      })
+      .catch((loadError) => {
+        setError(
+          loadError instanceof Error ? loadError.message : String(loadError),
+        );
+      })
+      .finally(() => {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      });
+  }, [cursor, mbid]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      if (
+        contentSize.height - (contentOffset.y + layoutMeasurement.height) <
+        800
+      ) {
+        loadMore();
+      }
+    },
+    [loadMore],
+  );
+
+  const art = artFailed ? undefined : coverArtUrl(album?.mbid, 500);
+
+  return (
+    <SongishShell rightRail={<RightRail />} onScroll={handleScroll}>
+      <Stack.Screen
+        options={{ title: album?.name || "Album", headerShown: false }}
+      />
+      {!album && !error && (
+        <View className="min-h-[24rem] items-center justify-center">
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+      {error && (
+        <View className="mb-6 rounded-2xl bg-destructive/15 p-4">
+          <Text className="font-bold text-destructive">
+            Could not load album: {error}
+          </Text>
+        </View>
+      )}
+      {album && (
+        <>
+          <View className="mb-10 overflow-hidden rounded-2xl bg-background/75">
+            <View className="h-40 bg-muted">
+              {art && (
+                <Image
+                  source={{ uri: art }}
+                  className="h-full w-full opacity-40"
+                  onError={() => setArtFailed(true)}
+                />
+              )}
+            </View>
+            <View className="-mt-10 flex-row items-end gap-4 px-5 pb-7">
+              <View className="h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-muted md:h-28 md:w-28">
+                {art ? (
+                  <Image
+                    source={{ uri: art }}
+                    className="h-full w-full"
+                    onError={() => setArtFailed(true)}
+                  />
+                ) : (
+                  <Icon
+                    icon={Disc3}
+                    size={42}
+                    className="text-muted-foreground"
+                  />
+                )}
+              </View>
+              <View className="min-w-0 flex-1 pb-1">
+                <Text className="font-mono text-xs font-bold uppercase text-muted-foreground">
+                  Album
+                </Text>
+                <Text
+                  className="font-serif text-2xl font-black md:text-3xl"
+                  numberOfLines={3}
+                >
+                  {album.name}
+                </Text>
+                {album.artistMbid ? (
+                  <Link
+                    href={
+                      musicArtistHref(album.artistName, album.artistMbid) as any
+                    }
+                    asChild
+                  >
+                    <Pressable>
+                      <Text className="font-bold text-muted-foreground">
+                        {album.artistName}
+                      </Text>
+                    </Pressable>
+                  </Link>
+                ) : (
+                  <Text className="font-bold text-muted-foreground">
+                    {album.artistName}
+                  </Text>
+                )}
+                <Text className="font-mono text-xs text-muted-foreground">
+                  {album.playCount} indexed listens
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <Text className="mb-4 text-2xl font-black">Track list</Text>
+          <View className="mb-10 overflow-hidden rounded-2xl bg-background/75 px-4">
+            {album.tracks.map((track) => (
+              <Link
+                key={`${track.recordingMbid}-${track.uri}`}
+                href={
+                  musicTrackHref(
+                    track.artistName,
+                    album.name,
+                    track.name,
+                    track.uri,
+                  ) as any
+                }
+                asChild
+              >
+                <Pressable className="flex-row items-center gap-3 border-b border-border/70 py-4">
+                  <View className="h-10 w-10 items-center justify-center rounded-full bg-muted">
+                    <Icon
+                      icon={Music2}
+                      size={18}
+                      className="text-muted-foreground"
+                    />
+                  </View>
+                  <View className="min-w-0 flex-1">
+                    <Text className="font-black" numberOfLines={2}>
+                      {track.name}
+                    </Text>
+                    <Text
+                      className="text-sm text-muted-foreground"
+                      numberOfLines={1}
+                    >
+                      {track.artistName}
+                    </Text>
+                  </View>
+                  <Text className="font-mono text-xs text-muted-foreground">
+                    {track.playCount}
+                  </Text>
+                  <Icon
+                    icon={ChevronRight}
+                    size={18}
+                    className="text-muted-foreground"
+                  />
+                </Pressable>
+              </Link>
+            ))}
+          </View>
+
+          <Text className="mb-4 text-2xl font-black">Listens</Text>
+          {plays.map((play, index) => (
+            <PlayFeedCard
+              key={play.uri || `${play.trackName}-${index}`}
+              play={play}
+            />
+          ))}
+          {loadingMore && (
+            <View className="items-center justify-center py-5">
+              <ActivityIndicator />
+            </View>
+          )}
+          {plays.length > 0 && !cursor && (
+            <Text className="pb-6 text-center font-mono text-xs text-muted-foreground">
+              You reached the beginning of this album's indexed listens.
+            </Text>
+          )}
+        </>
+      )}
+    </SongishShell>
+  );
+}

--- a/apps/amethyst/app/(tabs)/:o/music/[artist]/index.tsx
+++ b/apps/amethyst/app/(tabs)/:o/music/[artist]/index.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { ActivityIndicator, Image, Pressable, View } from "react-native";
+import { Link, Stack, useLocalSearchParams } from "expo-router";
+import RightRail from "@/components/songish/RightRail";
+import SongishShell from "@/components/songish/SongishShell";
+import { Text } from "@/components/ui/text";
+import { Icon } from "@/lib/icons/iconWithClassName";
+import { coverArtUrl, getArtist } from "@/lib/teal/api";
+import { musicAlbumHref } from "@/lib/teal/routes";
+import { ChevronRight, Disc3, Mic2 } from "lucide-react-native";
+
+import type { ArtistView } from "@teal/lexicons/src/types/fm/teal/alpha/music/defs";
+
+export default function ArtistDetail() {
+  const params = useLocalSearchParams();
+  const mbid = Array.isArray(params.mbid) ? params.mbid[0] : params.mbid;
+  const name = Array.isArray(params.name) ? params.name[0] : params.name;
+  const [artist, setArtist] = useState<ArtistView | null>(null);
+  const [error, setError] = useState<string>();
+  const [artFailed, setArtFailed] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    getArtist(mbid, name)
+      .then(({ artist }) => {
+        if (mounted) setArtist(artist);
+      })
+      .catch((loadError) => {
+        if (mounted) {
+          setError(
+            loadError instanceof Error ? loadError.message : String(loadError),
+          );
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [mbid, name]);
+
+  const representativeArt = artFailed
+    ? undefined
+    : coverArtUrl(artist?.albums[0]?.mbid, 500);
+
+  return (
+    <SongishShell rightRail={<RightRail />}>
+      <Stack.Screen
+        options={{ title: artist?.name || "Artist", headerShown: false }}
+      />
+      {!artist && !error && (
+        <View className="min-h-[24rem] items-center justify-center">
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+      {error && (
+        <View className="rounded-2xl bg-destructive/15 p-4">
+          <Text className="font-bold text-destructive">
+            Could not load artist: {error}
+          </Text>
+        </View>
+      )}
+      {artist && (
+        <>
+          <View className="mb-10 overflow-hidden rounded-2xl bg-background/75">
+            <View className="h-40 bg-muted">
+              {representativeArt && (
+                <Image
+                  source={{ uri: representativeArt }}
+                  className="h-full w-full opacity-40"
+                  onError={() => setArtFailed(true)}
+                />
+              )}
+            </View>
+            <View className="-mt-10 flex-row items-end gap-4 px-5 pb-7">
+              <View className="h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-muted md:h-28 md:w-28">
+                {representativeArt ? (
+                  <Image
+                    source={{ uri: representativeArt }}
+                    className="h-full w-full"
+                    onError={() => setArtFailed(true)}
+                  />
+                ) : (
+                  <Icon
+                    icon={Mic2}
+                    size={42}
+                    className="text-muted-foreground"
+                  />
+                )}
+              </View>
+              <View className="min-w-0 flex-1 pb-1">
+                <Text className="font-mono text-xs font-bold uppercase text-muted-foreground">
+                  Artist
+                </Text>
+                <Text
+                  className="font-serif text-2xl font-black"
+                  numberOfLines={3}
+                >
+                  {artist.name}
+                </Text>
+                <Text className="font-mono text-xs text-muted-foreground">
+                  {artist.playCount} indexed listens
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <Text className="mb-4 text-2xl font-black">Discography</Text>
+          <View className="overflow-hidden rounded-2xl bg-background/75 px-4">
+            {artist.albums.map((album) => {
+              const art = coverArtUrl(album.mbid);
+              return (
+                <Link
+                  key={album.mbid}
+                  href={
+                    musicAlbumHref(
+                      album.artistName,
+                      album.name,
+                      album.mbid,
+                    ) as any
+                  }
+                  asChild
+                >
+                  <Pressable className="flex-row items-center gap-3 border-b border-border/70 py-4">
+                    <View className="h-16 w-16 items-center justify-center overflow-hidden rounded-lg bg-muted">
+                      {art ? (
+                        <Image
+                          source={{ uri: art }}
+                          className="h-full w-full"
+                        />
+                      ) : (
+                        <Icon
+                          icon={Disc3}
+                          size={26}
+                          className="text-muted-foreground"
+                        />
+                      )}
+                    </View>
+                    <View className="min-w-0 flex-1">
+                      <Text className="font-black" numberOfLines={2}>
+                        {album.name}
+                      </Text>
+                      <Text className="font-mono text-xs text-muted-foreground">
+                        {album.playCount} listens
+                      </Text>
+                    </View>
+                    <Icon
+                      icon={ChevronRight}
+                      size={18}
+                      className="text-muted-foreground"
+                    />
+                  </Pressable>
+                </Link>
+              );
+            })}
+          </View>
+        </>
+      )}
+    </SongishShell>
+  );
+}

--- a/apps/amethyst/app/(tabs)/search/index.tsx
+++ b/apps/amethyst/app/(tabs)/search/index.tsx
@@ -13,6 +13,11 @@ import {
   searchBlueskyUsers,
   type SearchResults,
 } from "@/lib/teal/api";
+import {
+  musicAlbumHref,
+  musicArtistHref,
+  musicTrackHref,
+} from "@/lib/teal/routes";
 import type { AppBskyActorDefs } from "@atproto/api";
 import {
   Disc3,
@@ -41,18 +46,13 @@ const EMPTY_RESULTS: SearchResults = {
   albums: [],
 };
 
-function routePart(value?: string) {
-  return encodeURIComponent(
-    (value || "unknown")
-      .toLowerCase()
-      .replace(/^mbid:/, "")
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") || "unknown",
-  );
-}
-
 function songHref(song: SongResult) {
-  return `/:o/music/${routePart(song.artistName)}/${routePart(song.releaseName)}/${routePart(song.trackName)}?uri=${encodeURIComponent(song.uri)}`;
+  return musicTrackHref(
+    song.artistName,
+    song.releaseName,
+    song.trackName,
+    song.uri,
+  );
 }
 
 function mergeUsers(
@@ -194,28 +194,27 @@ function MusicEntityRow({
   icon,
   name,
   playCount,
-  onPress,
+  href,
 }: {
   icon: typeof Mic2;
   name?: string;
   playCount?: number;
-  onPress: () => void;
+  href: string;
 }) {
   return (
-    <Pressable
-      onPress={onPress}
-      className="flex-row items-center gap-3 border-b border-border/70 px-1 py-4"
-    >
-      <View className="h-12 w-12 items-center justify-center rounded-full bg-muted">
-        <Icon icon={icon} size={22} className="text-muted-foreground" />
-      </View>
-      <Text className="min-w-0 flex-1 font-black" numberOfLines={1}>
-        {name || "Unknown"}
-      </Text>
-      <Text className="font-mono text-xs text-muted-foreground">
-        {playCount || 0} plays
-      </Text>
-    </Pressable>
+    <Link href={href as any} asChild>
+      <Pressable className="flex-row items-center gap-3 border-b border-border/70 px-1 py-4">
+        <View className="h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <Icon icon={icon} size={22} className="text-muted-foreground" />
+        </View>
+        <Text className="min-w-0 flex-1 font-black" numberOfLines={1}>
+          {name || "Unknown"}
+        </Text>
+        <Text className="font-mono text-xs text-muted-foreground">
+          {playCount || 0} plays
+        </Text>
+      </Pressable>
+    </Link>
   );
 }
 
@@ -286,12 +285,6 @@ export default function Explore() {
   };
   const hasQuery = query.trim().length >= 2;
   const hasResults = counts[activeTab] > 0;
-  const searchMusic = (name?: string) => {
-    if (!name) return;
-    setQuery(name);
-    setActiveTab("songs");
-  };
-
   return (
     <SongishShell title="Explore" rightRail={<RightRail />}>
       <Stack.Screen options={{ title: "Explore", headerShown: false }} />
@@ -384,7 +377,7 @@ export default function Explore() {
               icon={Mic2}
               name={artist.name}
               playCount={artist.playCount}
-              onPress={() => searchMusic(artist.name)}
+              href={musicArtistHref(artist.name || "Unknown", artist.mbid)}
             />
           ))}
         {activeTab === "albums" &&
@@ -394,7 +387,11 @@ export default function Explore() {
               icon={Disc3}
               name={album.name}
               playCount={album.playCount}
-              onPress={() => searchMusic(album.name)}
+              href={musicAlbumHref(
+                "album",
+                album.name || "Unknown",
+                album.mbid!,
+              )}
             />
           ))}
       </View>

--- a/apps/amethyst/components/songish/PlayFeedCard.tsx
+++ b/apps/amethyst/components/songish/PlayFeedCard.tsx
@@ -4,6 +4,7 @@ import { Link } from "expo-router";
 import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import { coverArtUrl, displayArtists, getBlueskyProfile } from "@/lib/teal/api";
+import { musicTrackHref } from "@/lib/teal/routes";
 import { cn, timeAgo } from "@/lib/utils";
 import { Disc3, MoreVertical, Play } from "lucide-react-native";
 
@@ -41,18 +42,13 @@ function getCachedBlueskyProfile(did: string) {
   return profile;
 }
 
-function routePart(value?: string) {
-  return encodeURIComponent(
-    (value || "unknown")
-      .toLowerCase()
-      .replace(/^mbid:/, "")
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") || "unknown",
-  );
-}
-
 export function musicHref(play: PlayView) {
-  return `/:o/music/${routePart(displayArtists(play))}/${routePart(play.releaseName)}/${routePart(play.trackName)}?uri=${encodeURIComponent(play.uri || "")}`;
+  return musicTrackHref(
+    displayArtists(play),
+    play.releaseName,
+    play.trackName,
+    play.uri || "",
+  );
 }
 
 export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -5,6 +5,10 @@ import type {
   ProfileView,
 } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+import type {
+  AlbumView,
+  ArtistView as MusicArtistView,
+} from "@teal/lexicons/src/types/fm/teal/alpha/music/defs";
 import type { SongResult } from "@teal/lexicons/src/types/fm/teal/alpha/search/defs";
 import type {
   ArtistView,
@@ -69,6 +73,20 @@ export function getActorFeed(authorDID: string, limit = 50) {
 
 export function getPlayByUri(uri: string) {
   return getXrpc<{ play: PlayView }>("fm.teal.alpha.feed.getPlay", { uri });
+}
+
+export function getArtist(mbid?: string, name?: string) {
+  return getXrpc<{ artist: MusicArtistView }>("fm.teal.alpha.music.getArtist", {
+    mbid,
+    name,
+  });
+}
+
+export function getAlbum(mbid: string, limit = 30, cursor?: string) {
+  return getXrpc<{ album: AlbumView; plays: PlayView[]; cursor?: string }>(
+    "fm.teal.alpha.music.getAlbum",
+    { mbid, limit, cursor },
+  );
 }
 
 export function getProfile(actor: string) {

--- a/apps/amethyst/lib/teal/routes.ts
+++ b/apps/amethyst/lib/teal/routes.ts
@@ -1,0 +1,32 @@
+export function routePart(value?: string) {
+  return encodeURIComponent(
+    (value || "unknown")
+      .toLowerCase()
+      .replace(/^mbid:/, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") || "unknown",
+  );
+}
+
+export function musicArtistHref(name: string, mbid?: string) {
+  const query = new URLSearchParams({ name });
+  if (mbid) query.set("mbid", mbid);
+  return `/:o/music/${routePart(name)}?${query.toString()}`;
+}
+
+export function musicAlbumHref(
+  artistName: string,
+  releaseName: string,
+  releaseMbId: string,
+) {
+  return `/:o/music/${routePart(artistName)}/${routePart(releaseName)}?mbid=${encodeURIComponent(releaseMbId)}`;
+}
+
+export function musicTrackHref(
+  artistName: string,
+  releaseName: string | undefined,
+  trackName: string,
+  uri: string,
+) {
+  return `/:o/music/${routePart(artistName)}/${routePart(releaseName)}/${routePart(trackName)}?uri=${encodeURIComponent(uri)}`;
+}

--- a/apps/aqua/src/main.rs
+++ b/apps/aqua/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), String> {
         )
         .nest("/xrpc/", xrpc::actor::actor_routes())
         .nest("/xrpc/", xrpc::feed::feed_routes())
+        .nest("/xrpc/", xrpc::music::music_routes())
         .nest("/xrpc/", xrpc::search::search_routes())
         .nest("/xrpc/", xrpc::stats::stats_routes())
         .layer(Extension(ctx))

--- a/apps/aqua/src/repos/mod.rs
+++ b/apps/aqua/src/repos/mod.rs
@@ -4,18 +4,20 @@ use types::fm_teal::alpha::actor::MiniProfileView;
 use uuid::Uuid;
 
 use crate::repos::feed_play::FeedPlayRepo;
+use crate::repos::music::MusicRepo;
 use crate::repos::search::SearchRepo;
 use crate::repos::stats::StatsRepo;
 
 pub mod actor_profile;
 pub mod feed_play;
+pub mod music;
 pub mod pg;
 pub mod search;
 pub mod stats;
 
 #[async_trait::async_trait]
 pub trait DataSource:
-    ActorProfileRepo + FeedPlayRepo + SearchRepo + StatsRepo + Send + Sync
+    ActorProfileRepo + FeedPlayRepo + MusicRepo + SearchRepo + StatsRepo + Send + Sync
 {
     fn boxed(self) -> Box<dyn DataSource>
     where

--- a/apps/aqua/src/repos/music.rs
+++ b/apps/aqua/src/repos/music.rs
@@ -1,0 +1,307 @@
+use async_trait::async_trait;
+use jacquard_common::from_json_value;
+use jacquard_common::types::string::{AtUri, Did};
+use types::fm_teal::alpha::feed::PlayView;
+use types::fm_teal::alpha::music::{AlbumSummary, AlbumView, ArtistView, TrackSummary};
+use uuid::Uuid;
+
+use super::stats::{LatestPlaysCursor, decode_latest_cursor, encode_latest_cursor};
+use super::{mbid_uri, mini_profile, pg::PgDataSource, utc_to_atrium_datetime};
+
+pub struct AlbumPage {
+    pub album: AlbumView,
+    pub plays: Vec<PlayView>,
+    pub cursor: Option<String>,
+}
+
+#[async_trait]
+pub trait MusicRepo: Send + Sync {
+    async fn get_artist(
+        &self,
+        mbid: Option<&str>,
+        name: Option<&str>,
+    ) -> anyhow::Result<ArtistView>;
+    async fn get_album(
+        &self,
+        mbid: &str,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<AlbumPage>;
+}
+
+fn parse_mbid(mbid: &str) -> anyhow::Result<Uuid> {
+    Ok(Uuid::parse_str(mbid.strip_prefix("mbid:").unwrap_or(mbid))?)
+}
+
+#[async_trait]
+impl MusicRepo for PgDataSource {
+    async fn get_artist(
+        &self,
+        mbid: Option<&str>,
+        name: Option<&str>,
+    ) -> anyhow::Result<ArtistView> {
+        let mbid = mbid.map(parse_mbid).transpose()?;
+        if mbid.is_none() && name.is_none_or(str::is_empty) {
+            anyhow::bail!("mbid or name is required");
+        }
+
+        let artist = sqlx::query!(
+            r#"
+            SELECT ae.id, ae.mbid, ae.name, COUNT(DISTINCT ptae.play_uri) AS play_count
+            FROM artists_extended ae
+            LEFT JOIN play_to_artists_extended ptae ON ae.id = ptae.artist_id
+            WHERE ($1::uuid IS NOT NULL AND ae.mbid = $1)
+               OR ($1::uuid IS NULL AND LOWER(ae.name) = LOWER($2))
+            GROUP BY ae.id, ae.mbid, ae.name
+            ORDER BY play_count DESC
+            LIMIT 1
+            "#,
+            mbid,
+            name
+        )
+        .fetch_optional(&self.db)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("artist not found"))?;
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                p.release_mbid AS "mbid!",
+                MAX(p.release_name) AS "name!",
+                COUNT(DISTINCT p.uri) AS "play_count!"
+            FROM plays p
+            INNER JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri
+            WHERE ptae.artist_id = $1
+              AND p.release_mbid IS NOT NULL
+              AND p.release_name IS NOT NULL
+            GROUP BY p.release_mbid
+            ORDER BY MAX(p.played_time) DESC NULLS LAST, MAX(p.release_name)
+            "#,
+            artist.id
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let artist_name = artist.name;
+        let artist_mbid = artist.mbid.map(mbid_uri);
+        let albums = rows
+            .into_iter()
+            .map(|row| AlbumSummary {
+                artist_mbid: artist_mbid.clone(),
+                artist_name: artist_name.clone().into(),
+                mbid: mbid_uri(row.mbid),
+                name: row.name.into(),
+                play_count: row.play_count,
+                extra_data: Default::default(),
+            })
+            .collect();
+
+        Ok(ArtistView {
+            albums,
+            mbid: artist_mbid,
+            name: artist_name.into(),
+            play_count: artist.play_count.unwrap_or(0),
+            extra_data: Default::default(),
+        })
+    }
+
+    async fn get_album(
+        &self,
+        mbid: &str,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<AlbumPage> {
+        let mbid = parse_mbid(mbid)?;
+        let limit = limit.unwrap_or(30).clamp(1, 100) as i64;
+        let query_limit = limit + 1;
+        let cursor = decode_latest_cursor(cursor)?;
+        let cursor_time = cursor
+            .as_ref()
+            .map(|cursor| {
+                time::OffsetDateTime::parse(
+                    &cursor.processed_time,
+                    &time::format_description::well_known::Rfc3339,
+                )
+            })
+            .transpose()?;
+
+        let album_row = sqlx::query!(
+            r#"
+            SELECT
+                p.release_mbid AS "mbid!",
+                COALESCE(MAX(p.release_name), 'Unknown release') AS "name!",
+                COUNT(DISTINCT p.uri) AS "play_count!",
+                COALESCE(
+                    (ARRAY_AGG(ptae.artist_name ORDER BY ptae.artist_name)
+                        FILTER (WHERE ptae.artist_name IS NOT NULL))[1],
+                    'Unknown artist'
+                ) AS "artist_name!",
+                (ARRAY_AGG(ae.mbid ORDER BY ptae.artist_name)
+                    FILTER (WHERE ae.mbid IS NOT NULL))[1] AS artist_mbid
+            FROM plays p
+            LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri
+            LEFT JOIN artists_extended ae ON ptae.artist_id = ae.id
+            WHERE p.release_mbid = $1
+            GROUP BY p.release_mbid
+            "#,
+            mbid
+        )
+        .fetch_optional(&self.db)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("album not found"))?;
+
+        let track_rows = sqlx::query!(
+            r#"
+            WITH track_plays AS (
+                SELECT
+                    p.uri,
+                    p.recording_mbid,
+                    p.track_name,
+                    p.processed_time,
+                    COALESCE(
+                        STRING_AGG(DISTINCT ptae.artist_name, ', ' ORDER BY ptae.artist_name),
+                        'Unknown artist'
+                    ) AS artist_name
+                FROM plays p
+                LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri
+                WHERE p.release_mbid = $1
+                GROUP BY p.uri, p.recording_mbid, p.track_name, p.processed_time
+            )
+            SELECT DISTINCT ON (COALESCE(recording_mbid::text, LOWER(track_name)))
+                uri,
+                recording_mbid,
+                track_name,
+                artist_name,
+                COUNT(*) OVER (
+                    PARTITION BY COALESCE(recording_mbid::text, LOWER(track_name))
+                ) AS "play_count!"
+            FROM track_plays
+            ORDER BY COALESCE(recording_mbid::text, LOWER(track_name)), processed_time DESC, uri
+            "#,
+            mbid
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let mut tracks = track_rows
+            .into_iter()
+            .filter_map(|row| {
+                Some(TrackSummary {
+                    uri: AtUri::try_from(row.uri).ok()?,
+                    recording_mbid: row.recording_mbid.map(mbid_uri),
+                    name: row.track_name.into(),
+                    artist_name: row.artist_name?.into(),
+                    play_count: row.play_count,
+                    extra_data: Default::default(),
+                })
+            })
+            .collect::<Vec<_>>();
+        tracks.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,
+                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,
+                p.submission_client_agent, p.music_service_base_domain, p.origin_url,
+                profile.did AS "profile_did?", profile.handle AS profile_handle,
+                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,
+                COALESCE(
+                  json_agg(
+                    json_build_object(
+                      'artistMbId', ae.mbid,
+                      'artistName', ptae.artist_name
+                    )
+                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),
+                  '[]'
+                ) AS artists
+            FROM plays p
+            LEFT JOIN profiles profile ON p.did = profile.did
+            LEFT JOIN play_to_artists_extended ptae ON p.uri = ptae.play_uri
+            LEFT JOIN artists_extended ae ON ptae.artist_id = ae.id
+            WHERE p.release_mbid = $1
+              AND ($2::timestamptz IS NULL OR (p.processed_time, p.uri) < ($2, $3))
+            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,
+                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,
+                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,
+                     profile.did, profile.handle, profile.display_name, profile.avatar
+            ORDER BY p.processed_time DESC, p.uri DESC
+            LIMIT $4
+            "#,
+            mbid,
+            cursor_time,
+            cursor.as_ref().map(|cursor| cursor.uri.as_str()),
+            query_limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let has_more = rows.len() > limit as usize;
+        let mut plays = Vec::with_capacity(rows.len().min(limit as usize));
+        let mut next_cursor = None;
+        for row in rows.into_iter().take(limit as usize) {
+            next_cursor = Some(LatestPlaysCursor {
+                processed_time: row
+                    .processed_time
+                    .unwrap_or_else(time::OffsetDateTime::now_utc)
+                    .format(&time::format_description::well_known::Rfc3339)?,
+                uri: row.uri.clone(),
+            });
+            let artists = row
+                .artists
+                .and_then(|value| {
+                    from_json_value::<Vec<types::fm_teal::alpha::feed::Artist>>(value).ok()
+                })
+                .unwrap_or_default();
+
+            plays.push(PlayView {
+                track_name: row.track_name.into(),
+                author: mini_profile(
+                    row.profile_did,
+                    row.profile_handle,
+                    row.profile_display_name,
+                    row.profile_avatar,
+                ),
+                uri: AtUri::try_from(row.uri).ok(),
+                cid: Some(row.cid.into()),
+                author_did: Did::new_owned(&row.did).ok(),
+                rkey: Some(row.rkey.into()),
+                track_mb_id: row.recording_mbid.map(mbid_uri),
+                recording_mb_id: row.recording_mbid.map(mbid_uri),
+                duration: row.duration.map(i64::from),
+                artists: artists
+                    .into_iter()
+                    .map(|artist| artist.to_owned())
+                    .collect(),
+                release_name: row.release_name.map(Into::into),
+                release_mb_id: row.release_mbid.map(mbid_uri),
+                isrc: row.isrc.map(Into::into),
+                origin_url: row.origin_url.map(Into::into),
+                music_service_base_domain: row.music_service_base_domain.map(Into::into),
+                submission_client_agent: row.submission_client_agent.map(Into::into),
+                played_time: row
+                    .played_time
+                    .map(|dt| utc_to_atrium_datetime(crate::repos::time_to_chrono_utc(dt))),
+                extra_data: Default::default(),
+            });
+        }
+
+        Ok(AlbumPage {
+            album: AlbumView {
+                artist_mbid: album_row.artist_mbid.map(mbid_uri),
+                artist_name: album_row.artist_name.into(),
+                mbid: mbid_uri(album_row.mbid),
+                name: album_row.name.into(),
+                play_count: album_row.play_count,
+                tracks,
+                extra_data: Default::default(),
+            },
+            plays,
+            cursor: if has_more {
+                next_cursor.as_ref().map(encode_latest_cursor).transpose()?
+            } else {
+                None
+            },
+        })
+    }
+}

--- a/apps/aqua/src/repos/stats.rs
+++ b/apps/aqua/src/repos/stats.rs
@@ -13,12 +13,14 @@ pub struct LatestPlaysPage {
 }
 
 #[derive(Deserialize, Serialize)]
-struct LatestPlaysCursor {
-    processed_time: String,
-    uri: String,
+pub(crate) struct LatestPlaysCursor {
+    pub processed_time: String,
+    pub uri: String,
 }
 
-fn decode_latest_cursor(cursor: Option<&str>) -> anyhow::Result<Option<LatestPlaysCursor>> {
+pub(crate) fn decode_latest_cursor(
+    cursor: Option<&str>,
+) -> anyhow::Result<Option<LatestPlaysCursor>> {
     cursor
         .map(|cursor| {
             let bytes =
@@ -28,7 +30,7 @@ fn decode_latest_cursor(cursor: Option<&str>) -> anyhow::Result<Option<LatestPla
         .transpose()
 }
 
-fn encode_latest_cursor(cursor: &LatestPlaysCursor) -> anyhow::Result<String> {
+pub(crate) fn encode_latest_cursor(cursor: &LatestPlaysCursor) -> anyhow::Result<String> {
     Ok(base64::Engine::encode(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD,
         serde_json::to_vec(cursor)?,

--- a/apps/aqua/src/xrpc/mod.rs
+++ b/apps/aqua/src/xrpc/mod.rs
@@ -1,4 +1,5 @@
 pub mod actor;
 pub mod feed;
+pub mod music;
 pub mod search;
 pub mod stats;

--- a/apps/aqua/src/xrpc/music.rs
+++ b/apps/aqua/src/xrpc/music.rs
@@ -1,0 +1,89 @@
+use axum::{Extension, http::StatusCode, response::IntoResponse, routing::get};
+use jacquard_common::IntoStatic;
+use serde::{Deserialize, Serialize};
+use types::fm_teal::alpha::feed::PlayView;
+use types::fm_teal::alpha::music::{AlbumView, ArtistView};
+
+use crate::ctx::Context;
+
+pub fn music_routes() -> axum::Router {
+    axum::Router::new()
+        .route("/fm.teal.alpha.music.getArtist", get(get_artist))
+        .route("/fm.teal.alpha.music.getAlbum", get(get_album))
+}
+
+#[derive(Deserialize)]
+pub struct GetArtistQuery {
+    pub mbid: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct GetArtistResponse {
+    artist: ArtistView,
+}
+
+pub async fn get_artist(
+    Extension(ctx): Extension<Context>,
+    axum::extract::Query(query): axum::extract::Query<GetArtistQuery>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if query.mbid.is_none() && query.name.as_deref().is_none_or(str::is_empty) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "mbid or name is required".to_string(),
+        ));
+    }
+
+    match ctx
+        .db
+        .get_artist(query.mbid.as_deref(), query.name.as_deref())
+        .await
+    {
+        Ok(artist) => Ok(axum::Json(GetArtistResponse {
+            artist: artist.into_static(),
+        })),
+        Err(error) if error.to_string() == "artist not found" => {
+            Err((StatusCode::NOT_FOUND, error.to_string()))
+        }
+        Err(error) => Err((StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct GetAlbumQuery {
+    pub mbid: String,
+    pub limit: Option<i32>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct GetAlbumResponse {
+    album: AlbumView,
+    plays: Vec<PlayView>,
+    cursor: Option<String>,
+}
+
+pub async fn get_album(
+    Extension(ctx): Extension<Context>,
+    axum::extract::Query(query): axum::extract::Query<GetAlbumQuery>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if query.mbid.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "mbid is required".to_string()));
+    }
+
+    match ctx
+        .db
+        .get_album(&query.mbid, query.limit, query.cursor.as_deref())
+        .await
+    {
+        Ok(page) => Ok(axum::Json(GetAlbumResponse {
+            album: page.album.into_static(),
+            plays: page.plays.into_static(),
+            cursor: page.cursor,
+        })),
+        Err(error) if error.to_string() == "album not found" => {
+            Err((StatusCode::NOT_FOUND, error.to_string()))
+        }
+        Err(error) => Err((StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
+    }
+}

--- a/lexicons/fm.teal.alpha/music/defs.json
+++ b/lexicons/fm.teal.alpha/music/defs.json
@@ -1,0 +1,114 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.music.defs",
+  "defs": {
+    "artistView": {
+      "type": "object",
+      "required": ["name", "playCount", "albums"],
+      "properties": {
+        "mbid": {
+          "type": "string",
+          "format": "uri",
+          "description": "MusicBrainz artist ID URI, formatted as mbid:<uuid>"
+        },
+        "name": {
+          "type": "string",
+          "description": "Artist name"
+        },
+        "playCount": {
+          "type": "integer",
+          "description": "Total indexed listens for this artist"
+        },
+        "albums": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#albumSummary"
+          }
+        }
+      }
+    },
+    "albumView": {
+      "type": "object",
+      "required": ["mbid", "name", "artistName", "playCount", "tracks"],
+      "properties": {
+        "mbid": {
+          "type": "string",
+          "format": "uri",
+          "description": "MusicBrainz release ID URI, formatted as mbid:<uuid>"
+        },
+        "name": {
+          "type": "string",
+          "description": "Release title"
+        },
+        "artistMbid": {
+          "type": "string",
+          "format": "uri",
+          "description": "MusicBrainz ID URI for a representative release artist"
+        },
+        "artistName": {
+          "type": "string",
+          "description": "Display name for the release artist"
+        },
+        "playCount": {
+          "type": "integer",
+          "description": "Total indexed listens for tracks on this release"
+        },
+        "tracks": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#trackSummary"
+          }
+        }
+      }
+    },
+    "albumSummary": {
+      "type": "object",
+      "required": ["mbid", "name", "artistName", "playCount"],
+      "properties": {
+        "mbid": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string"
+        },
+        "artistMbid": {
+          "type": "string",
+          "format": "uri"
+        },
+        "artistName": {
+          "type": "string"
+        },
+        "playCount": {
+          "type": "integer"
+        }
+      }
+    },
+    "trackSummary": {
+      "type": "object",
+      "required": ["uri", "name", "artistName", "playCount"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "Representative listen URI for opening the track page"
+        },
+        "recordingMbid": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string"
+        },
+        "artistName": {
+          "type": "string"
+        },
+        "playCount": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/music/getAlbum.json
+++ b/lexicons/fm.teal.alpha/music/getAlbum.json
@@ -1,0 +1,54 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.music.getAlbum",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get an indexed release, its tracks, and a page of listens",
+      "parameters": {
+        "type": "params",
+        "required": ["mbid"],
+        "properties": {
+          "mbid": {
+            "type": "string",
+            "description": "MusicBrainz release ID URI or UUID"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 30
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque cursor for the next page of listens"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["album", "plays"],
+          "properties": {
+            "album": {
+              "type": "ref",
+              "ref": "fm.teal.alpha.music.defs#albumView"
+            },
+            "plays": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "fm.teal.alpha.feed.defs#playView"
+              }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Opaque cursor for the next page of listens"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fm.teal.alpha/music/getArtist.json
+++ b/lexicons/fm.teal.alpha/music/getArtist.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "fm.teal.alpha.music.getArtist",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get an indexed artist and their release discography",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "mbid": {
+            "type": "string",
+            "description": "MusicBrainz artist ID URI or UUID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Artist name fallback when no MusicBrainz ID is available"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["artist"],
+          "properties": {
+            "artist": {
+              "type": "ref",
+              "ref": "fm.teal.alpha.music.defs#artistView"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,7 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 ## Current State
 
 - Amethyst has a Teal-branded Songish-style shell with desktop navigation, mobile navigation, Home, searchable Explore, Notifications, Profile, and music detail views.
-- Aqua exposes Teal XRPC routes for cursor-paginated latest plays, individual plays, actor feeds, profiles, stats, and indexed search across listeners, songs, artists, and albums.
+- Aqua exposes Teal XRPC routes for cursor-paginated latest plays, individual plays, actor feeds, profiles, stats, indexed search, artist discographies, and albums with track lists plus cursor-paginated listens.
 - Cadet consumes Teal records from Jetstream, stores a durable cursor in Redis with file fallback, and ingests create, update, and delete events for profiles and plays.
 - The public Amethyst feed uses only live Aqua XRPC data. There is no seeded, mocked, demo, or backup play feed.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
@@ -50,7 +50,9 @@ This file is the working handoff for the Songish-style Teal clone. Keep it updat
 
 - [x] Add Explore search for users, songs, artists, and albums.
 - [ ] Finish profile avatar and banner blob URL rendering.
-- [ ] Add artist and release detail routes in addition to track detail.
+- [x] Add artist and release detail routes in addition to track detail.
+- [ ] Select a dedicated artist-image source. Artist pages currently use representative Cover Art Archive release artwork.
+- [ ] Enrich album track ordering from MusicBrainz release media. Teal currently lists the tracks observed in indexed plays alphabetically.
 - [ ] Render real Cover Art Archive images for recordings with MusicBrainz IDs and polished fallbacks for missing art.
 - [ ] Exercise empty, loading, error, signed-out, and populated feed states at desktop and mobile widths.
 - [ ] Fix populated desktop feed-card text collisions for long DIDs, track titles, and artist names.


### PR DESCRIPTION
Add artist and album pages. This groups the existing commits by chronology and the area they change.

Part 4 of 33 replacing #113. Review this PR against `feature/obbpr-03-explore-feed`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 258385f feat(music): add artist and album pages

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/197
- Next: https://github.com/teal-fm/teal/pull/199
- Full stack index: https://github.com/teal-fm/teal/pull/113
