### PR TITLE
[06/33] fix(feed): paginate actor plays and repair profile and cover rendering

### DIFF
--- a/.sqlx/query-098c1e752ec1e822d32a76fdfbae5d8bfae01c8e4942518a15bc16f7fa5e025b.json
+++ b/.sqlx/query-098c1e752ec1e822d32a76fdfbae5d8bfae01c8e4942518a15bc16f7fa5e025b.json
@@ -1,0 +1,139 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                profile.did AS \"profile_did?\", profile.handle AS profile_handle,\n                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,\n                COALESCE(\n                  json_agg(\n                    json_build_object(\n                      'artistMbId', ae.mbid,\n                      'artistName', ptae.artist_name\n                    )\n                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),\n                  '[]'\n                ) AS artists\n            FROM plays p\n            LEFT JOIN profiles profile ON p.did = profile.did\n            LEFT JOIN play_to_artists_extended as ptae ON p.uri = ptae.play_uri\n            LEFT JOIN artists_extended as ae ON ptae.artist_id = ae.id\n            WHERE p.did = $1\n              AND ($2::timestamptz IS NULL OR (p.processed_time, p.uri) < ($2, $3))\n            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,\n                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,\n                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,\n                     profile.did, profile.handle, profile.display_name, profile.avatar\n            ORDER BY p.processed_time DESC, p.uri DESC\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "rkey",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "isrc",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "duration",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "track_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "played_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "processed_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "release_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 10,
+        "name": "release_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "recording_mbid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 12,
+        "name": "submission_client_agent",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "music_service_base_domain",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "origin_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "profile_did?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "profile_handle",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "profile_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "profile_avatar",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "artists",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "098c1e752ec1e822d32a76fdfbae5d8bfae01c8e4942518a15bc16f7fa5e025b"
+}

--- a/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
+++ b/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
@@ -7,13 +7,16 @@ import TealShell, {
   SectionHeading,
 } from "@/components/teal/TealShell";
 import { Text } from "@/components/ui/text";
+import { Icon } from "@/lib/icons/iconWithClassName";
 import {
   coverArtUrl,
   displayArtists,
   getLatestPlays,
   getPlayByUri,
+  getRecordingCoverArtUrl,
 } from "@/lib/teal/api";
 import { musicAlbumHref, musicArtistHref } from "@/lib/teal/routes";
+import { Disc3 } from "lucide-react-native";
 
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
 
@@ -24,6 +27,7 @@ export default function MusicDetail() {
   const [related, setRelated] = useState<PlayView[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [artFailed, setArtFailed] = useState(false);
+  const [recordingArt, setRecordingArt] = useState<string>();
 
   useEffect(() => {
     let mounted = true;
@@ -53,6 +57,24 @@ export default function MusicDetail() {
     };
   }, [uri]);
 
+  const releaseArt = coverArtUrl(play?.releaseMbId, 500);
+  const art = artFailed ? undefined : releaseArt || recordingArt;
+
+  useEffect(() => {
+    let mounted = true;
+    setArtFailed(false);
+    if (releaseArt || !play?.recordingMbId) {
+      setRecordingArt(undefined);
+      return;
+    }
+    getRecordingCoverArtUrl(play.recordingMbId, 500).then((url) => {
+      if (mounted) setRecordingArt(url);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [play?.recordingMbId, releaseArt]);
+
   return (
     <TealShell rightRail={<RightRail />}>
       <Stack.Screen
@@ -74,23 +96,29 @@ export default function MusicDetail() {
         <>
           <View className="mb-8 overflow-hidden rounded-lg border border-border bg-card">
             <View className="h-44 bg-muted">
-              {!artFailed && coverArtUrl(play.releaseMbId, 500) && (
+              {art && (
                 <Image
-                  source={{ uri: coverArtUrl(play.releaseMbId, 500) }}
+                  source={{ uri: art }}
                   className="h-full w-full opacity-40"
                   onError={() => setArtFailed(true)}
                 />
               )}
             </View>
             <View className="-mt-8 flex-row gap-4 px-5 pb-8">
-              {!artFailed && coverArtUrl(play.releaseMbId) ? (
+              {art ? (
                 <Image
-                  source={{ uri: coverArtUrl(play.releaseMbId) }}
+                  source={{ uri: art }}
                   className="h-24 w-24 rounded-lg bg-muted md:h-28 md:w-28"
                   onError={() => setArtFailed(true)}
                 />
               ) : (
-                <View className="h-24 w-24 rounded-lg bg-muted md:h-28 md:w-28" />
+                <View className="h-24 w-24 items-center justify-center rounded-lg bg-muted md:h-28 md:w-28">
+                  <Icon
+                    icon={Disc3}
+                    size={42}
+                    className="text-muted-foreground"
+                  />
+                </View>
               )}
               <View className="min-w-0 flex-1 justify-end pb-2">
                 <Text

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -1,5 +1,11 @@
-import { useEffect, useState } from "react";
-import { ActivityIndicator, Image, View } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
 import { Link, Stack, useLocalSearchParams } from "expo-router";
 import PlayFeedCard from "@/components/teal/PlayFeedCard";
 import RightRail from "@/components/teal/RightRail";
@@ -40,8 +46,11 @@ export default function ProfileScreen() {
   const [did, setDid] = useState<string | null>(null);
   const [profile, setProfile] = useState<DisplayProfile | null>(null);
   const [plays, setPlays] = useState<PlayView[]>([]);
+  const [cursor, setCursor] = useState<string>();
+  const [loadingMore, setLoadingMore] = useState(false);
   const [isBlueskyFallback, setIsBlueskyFallback] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const loadingMoreRef = useRef(false);
   const pdsAgent = useStore((state) => state.pdsAgent);
 
   useEffect(() => {
@@ -49,12 +58,17 @@ export default function ProfileScreen() {
     async function load() {
       if (!actor) return;
       try {
+        setError(null);
+        setDid(null);
+        setProfile(null);
+        setPlays([]);
+        setCursor(undefined);
         const resolved = actor.startsWith("did:")
           ? actor
           : await resolveHandle(actor);
         if (!mounted) return;
         setDid(resolved);
-        const feedRes = await getActorFeed(resolved, 50);
+        const feedRes = await getActorFeed(resolved, 30);
         let nextProfile: DisplayProfile | null = null;
         let nextIsBlueskyFallback = false;
 
@@ -78,6 +92,7 @@ export default function ProfileScreen() {
         setProfile(nextProfile);
         setIsBlueskyFallback(nextIsBlueskyFallback);
         setPlays(feedRes.plays);
+        setCursor(feedRes.cursor);
       } catch (e) {
         if (mounted) setError(e instanceof Error ? e.message : String(e));
       }
@@ -88,10 +103,47 @@ export default function ProfileScreen() {
     };
   }, [actor]);
 
+  const loadMore = useCallback(() => {
+    if (!did || !cursor || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    getActorFeed(did, 30, cursor)
+      .then((feedRes) => {
+        setPlays((current) => {
+          const knownUris = new Set(current.map((play) => play.uri));
+          return [
+            ...current,
+            ...feedRes.plays.filter(
+              (play) => !play.uri || !knownUris.has(play.uri),
+            ),
+          ];
+        });
+        setCursor(feedRes.cursor);
+      })
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      });
+  }, [cursor, did]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const remaining =
+        contentSize.height - (contentOffset.y + layoutMeasurement.height);
+      if (remaining < 800) loadMore();
+    },
+    [loadMore],
+  );
+
   const isSelf = did === pdsAgent?.did;
 
   return (
-    <TealShell rightRail={<RightRail />}>
+    <TealShell rightRail={<RightRail />} onScroll={handleScroll}>
       <Stack.Screen
         options={{ title: actor || "Profile", headerShown: false }}
       />
@@ -177,6 +229,16 @@ export default function ProfileScreen() {
                 play={play}
               />
             ))
+          )}
+          {loadingMore && (
+            <View className="items-center justify-center py-5">
+              <ActivityIndicator />
+            </View>
+          )}
+          {plays.length > 0 && !cursor && (
+            <Text className="pb-6 text-center font-mono text-xs text-muted-foreground">
+              You reached the beginning of this listener's indexed plays.
+            </Text>
           )}
         </>
       )}

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -14,6 +14,7 @@ import TealShell, {
 } from "@/components/teal/TealShell";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
+import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { resolveHandle } from "@/lib/atp/pid";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import {
@@ -38,6 +39,12 @@ type DisplayProfile = Pick<
 
 function isHttpUrl(value?: string) {
   return value?.startsWith("http://") || value?.startsWith("https://");
+}
+
+function profileImageUrl(did: string, value?: string) {
+  if (!value) return undefined;
+  if (isHttpUrl(value) || value.startsWith("data:")) return value;
+  return getImageCdnLink({ did, hash: value });
 }
 
 export default function ProfileScreen() {
@@ -141,6 +148,8 @@ export default function ProfileScreen() {
   );
 
   const isSelf = did === pdsAgent?.did;
+  const avatarUrl = did ? profileImageUrl(did, profile?.avatar) : undefined;
+  const bannerUrl = did ? profileImageUrl(did, profile?.banner) : undefined;
 
   return (
     <TealShell rightRail={<RightRail />} onScroll={handleScroll}>
@@ -163,17 +172,17 @@ export default function ProfileScreen() {
         <>
           <View className="mb-8 overflow-hidden rounded-lg border border-border bg-card">
             <View className="h-40 bg-primary/30">
-              {profile?.banner && isHttpUrl(profile.banner) && (
+              {bannerUrl && (
                 <Image
-                  source={{ uri: profile.banner }}
+                  source={{ uri: bannerUrl }}
                   className="h-full w-full"
                 />
               )}
             </View>
             <View className="-mt-12 px-6 pb-6">
-              {profile?.avatar && isHttpUrl(profile.avatar) ? (
+              {avatarUrl ? (
                 <Image
-                  source={{ uri: profile.avatar }}
+                  source={{ uri: avatarUrl }}
                   className="h-24 w-24 rounded-lg border-4 border-background bg-primary"
                 />
               ) : (

--- a/apps/amethyst/components/teal/PlayFeedCard.tsx
+++ b/apps/amethyst/components/teal/PlayFeedCard.tsx
@@ -132,12 +132,12 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
           </Pressable>
         </Link>
         <View className="min-w-0 flex-1 justify-center">
-          <Text className="font-black" numberOfLines={1}>
+          <Text className="max-w-full font-black" numberOfLines={1}>
             {authorName}
           </Text>
           {authorHandle && (
             <Text
-              className="font-mono text-xs text-muted-foreground"
+              className="max-w-full font-mono text-xs text-muted-foreground"
               numberOfLines={1}
             >
               @{authorHandle}
@@ -152,18 +152,21 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
       <View className="mt-4 border-t border-border pt-4">
         <Link href={musicHref(play) as any} asChild>
           <Pressable className="flex-row items-center justify-between gap-3">
-            <View className="min-w-0 flex-1">
-              <Text className="font-sans text-xl font-black" numberOfLines={2}>
+            <View className="min-w-0 flex-1 pr-1">
+              <Text
+                className="max-w-full font-sans text-xl font-black leading-tight"
+                numberOfLines={2}
+              >
                 {play.trackName}
               </Text>
               <Text
-                className="text-sm font-bold text-muted-foreground"
+                className="max-w-full text-sm font-bold text-muted-foreground"
                 numberOfLines={1}
               >
                 {displayArtists(play) || "Unknown artist"}
               </Text>
             </View>
-            <View>
+            <View className="shrink-0">
               {art ? (
                 <Image
                   source={{ uri: art }}
@@ -185,7 +188,10 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
       </View>
 
       {play.releaseName && (
-        <Text className="mt-3 font-mono text-[10px] uppercase text-muted-foreground">
+        <Text
+          className="mt-3 max-w-full font-mono text-[10px] uppercase text-muted-foreground"
+          numberOfLines={2}
+        >
           from {play.releaseName}
         </Text>
       )}

--- a/apps/amethyst/components/teal/PlayFeedCard.tsx
+++ b/apps/amethyst/components/teal/PlayFeedCard.tsx
@@ -3,7 +3,12 @@ import { Image, Pressable, View } from "react-native";
 import { Link } from "expo-router";
 import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { Icon } from "@/lib/icons/iconWithClassName";
-import { coverArtUrl, displayArtists, getBlueskyProfile } from "@/lib/teal/api";
+import {
+  coverArtUrl,
+  displayArtists,
+  getBlueskyProfile,
+  getRecordingCoverArtUrl,
+} from "@/lib/teal/api";
 import { musicTrackHref } from "@/lib/teal/routes";
 import { cn, timeAgo } from "@/lib/utils";
 import { Disc3 } from "lucide-react-native";
@@ -54,9 +59,12 @@ export function musicHref(play: PlayView) {
 export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
   const [blueskyAuthor, setBlueskyAuthor] = useState<FeedAuthor>();
   const [artFailed, setArtFailed] = useState(false);
+  const [recordingArt, setRecordingArt] = useState<string>();
   const indexedAuthor = play.author as FeedAuthor | undefined;
   const authorProfile = indexedAuthor || blueskyAuthor;
   const authorDid = authorProfile?.did || play.authorDid;
+  const releaseArt = coverArtUrl(play.releaseMbId);
+  const art = artFailed ? undefined : releaseArt || recordingArt;
 
   useEffect(() => {
     let mounted = true;
@@ -72,7 +80,21 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
     };
   }, [authorDid, indexedAuthor]);
 
-  const art = artFailed ? undefined : coverArtUrl(play.releaseMbId);
+  useEffect(() => {
+    let mounted = true;
+    setArtFailed(false);
+    if (releaseArt || !play.recordingMbId) {
+      setRecordingArt(undefined);
+      return;
+    }
+    getRecordingCoverArtUrl(play.recordingMbId).then((url) => {
+      if (mounted) setRecordingArt(url);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [play.recordingMbId, releaseArt]);
+
   const authorHandle = authorProfile?.handle?.replace(/^at:\/\//, "");
   const authorName =
     authorProfile?.displayName ||

--- a/apps/amethyst/components/teal/PlayFeedCard.tsx
+++ b/apps/amethyst/components/teal/PlayFeedCard.tsx
@@ -54,7 +54,7 @@ export function musicHref(play: PlayView) {
 export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
   const [blueskyAuthor, setBlueskyAuthor] = useState<FeedAuthor>();
   const [artFailed, setArtFailed] = useState(false);
-  const indexedAuthor = play.author;
+  const indexedAuthor = play.author as FeedAuthor | undefined;
   const authorProfile = indexedAuthor || blueskyAuthor;
   const authorDid = authorProfile?.did || play.authorDid;
 

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -64,11 +64,15 @@ export function getLatestPlays(limit = 50, cursor?: string) {
   );
 }
 
-export function getActorFeed(authorDID: string, limit = 50) {
-  return getXrpc<{ plays: PlayView[] }>("fm.teal.alpha.feed.getActorFeed", {
-    authorDID,
-    limit,
-  });
+export function getActorFeed(authorDID: string, limit = 30, cursor?: string) {
+  return getXrpc<{ plays: PlayView[]; cursor?: string }>(
+    "fm.teal.alpha.feed.getActorFeed",
+    {
+      authorDID,
+      limit,
+      cursor,
+    },
+  );
 }
 
 export function getPlayByUri(uri: string) {

--- a/apps/amethyst/lib/teal/api.ts
+++ b/apps/amethyst/lib/teal/api.ts
@@ -167,6 +167,29 @@ export function coverArtUrl(releaseMbId?: string, size = 250) {
     : undefined;
 }
 
+const recordingCoverArtCache = new Map<string, Promise<string | undefined>>();
+
+export function getRecordingCoverArtUrl(recordingMbId?: string, size = 250) {
+  const mbid = recordingMbId?.replace(/^mbid:/, "");
+  if (!mbid) return Promise.resolve(undefined);
+
+  const cacheKey = `${mbid}:${size}`;
+  let cached = recordingCoverArtCache.get(cacheKey);
+  if (!cached) {
+    cached = fetch(
+      `https://musicbrainz.org/ws/2/recording/${encodeURIComponent(mbid)}?inc=releases&fmt=json`,
+    )
+      .then((response) => (response.ok ? response.json() : undefined))
+      .then((recording?: { releases?: Array<{ id?: string }> }) => {
+        const releaseId = recording?.releases?.find((release) => release.id)?.id;
+        return releaseId ? coverArtUrl(releaseId, size) : undefined;
+      })
+      .catch(() => undefined);
+    recordingCoverArtCache.set(cacheKey, cached);
+  }
+  return cached;
+}
+
 export function displayArtists(play: PlayView) {
   return play.artists.map((artist) => artist.artistName).join(", ");
 }

--- a/apps/aqua/src/repos/feed_play.rs
+++ b/apps/aqua/src/repos/feed_play.rs
@@ -3,11 +3,27 @@ use jacquard_common::from_json_value;
 use jacquard_common::types::string::{AtUri, Did};
 use types::fm_teal::alpha::feed::{Artist, PlayView};
 
-use super::{mbid_uri, mini_profile, pg::PgDataSource, utc_to_atrium_datetime};
+use super::{
+    mbid_uri, mini_profile,
+    pg::PgDataSource,
+    stats::{LatestPlaysCursor, decode_latest_cursor, encode_latest_cursor},
+    utc_to_atrium_datetime,
+};
+
+pub struct ActorFeedPage {
+    pub plays: Vec<PlayView>,
+    pub cursor: Option<String>,
+}
 
 #[async_trait]
 pub trait FeedPlayRepo: Send + Sync {
     async fn get_feed_play(&self, identity: &str) -> anyhow::Result<Option<PlayView>>;
+    async fn get_actor_feed(
+        &self,
+        author_did: &str,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<ActorFeedPage>;
     async fn get_feed_plays_for_profile(
         &self,
         identities: &[String],
@@ -82,6 +98,119 @@ impl FeedPlayRepo for PgDataSource {
                 .map(|dt| utc_to_atrium_datetime(crate::repos::time_to_chrono_utc(dt))),
             extra_data: Default::default(),
         }))
+    }
+
+    async fn get_actor_feed(
+        &self,
+        author_did: &str,
+        limit: Option<i32>,
+        cursor: Option<&str>,
+    ) -> anyhow::Result<ActorFeedPage> {
+        let limit = limit.unwrap_or(20).clamp(1, 50) as i64;
+        let query_limit = limit + 1;
+        let cursor = decode_latest_cursor(cursor)?;
+        let cursor_time = cursor
+            .as_ref()
+            .map(|cursor| {
+                time::OffsetDateTime::parse(
+                    &cursor.processed_time,
+                    &time::format_description::well_known::Rfc3339,
+                )
+            })
+            .transpose()?;
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,
+                p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,
+                p.submission_client_agent, p.music_service_base_domain, p.origin_url,
+                profile.did AS "profile_did?", profile.handle AS profile_handle,
+                profile.display_name AS profile_display_name, profile.avatar AS profile_avatar,
+                COALESCE(
+                  json_agg(
+                    json_build_object(
+                      'artistMbId', ae.mbid,
+                      'artistName', ptae.artist_name
+                    )
+                  ) FILTER (WHERE ptae.artist_name IS NOT NULL),
+                  '[]'
+                ) AS artists
+            FROM plays p
+            LEFT JOIN profiles profile ON p.did = profile.did
+            LEFT JOIN play_to_artists_extended as ptae ON p.uri = ptae.play_uri
+            LEFT JOIN artists_extended as ae ON ptae.artist_id = ae.id
+            WHERE p.did = $1
+              AND ($2::timestamptz IS NULL OR (p.processed_time, p.uri) < ($2, $3))
+            GROUP BY p.uri, p.did, p.rkey, p.cid, p.isrc, p.duration, p.track_name, p.played_time,
+                     p.processed_time, p.release_mbid, p.release_name, p.recording_mbid,
+                     p.submission_client_agent, p.music_service_base_domain, p.origin_url,
+                     profile.did, profile.handle, profile.display_name, profile.avatar
+            ORDER BY p.processed_time DESC, p.uri DESC
+            LIMIT $4
+            "#,
+            author_did,
+            cursor_time,
+            cursor.as_ref().map(|cursor| cursor.uri.as_str()),
+            query_limit
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let has_more = rows.len() > limit as usize;
+        let mut plays = Vec::with_capacity(rows.len().min(limit as usize));
+        let mut next_cursor = None;
+        for row in rows.into_iter().take(limit as usize) {
+            next_cursor = Some(LatestPlaysCursor {
+                processed_time: row
+                    .processed_time
+                    .unwrap_or_else(time::OffsetDateTime::now_utc)
+                    .format(&time::format_description::well_known::Rfc3339)?,
+                uri: row.uri.clone(),
+            });
+
+            let artists: Vec<Artist> = match row.artists {
+                Some(value) => from_json_value::<Vec<Artist>>(value).unwrap_or_default(),
+                None => vec![],
+            };
+
+            plays.push(PlayView {
+                track_name: row.track_name.clone().into(),
+                author: mini_profile(
+                    row.profile_did,
+                    row.profile_handle,
+                    row.profile_display_name,
+                    row.profile_avatar,
+                ),
+                uri: AtUri::try_from(row.uri.clone()).ok(),
+                cid: Some(row.cid.clone().into()),
+                author_did: Did::new_owned(&row.did).ok(),
+                rkey: Some(row.rkey.clone().into()),
+                track_mb_id: row.recording_mbid.map(mbid_uri),
+                recording_mb_id: row.recording_mbid.map(mbid_uri),
+                duration: row.duration.map(|d| d as i64),
+                artists,
+                release_name: row.release_name.clone().map(|s| s.into()),
+                release_mb_id: row.release_mbid.map(mbid_uri),
+                isrc: row.isrc.map(|s| s.into()),
+                origin_url: row.origin_url.map(|s| s.into()),
+                music_service_base_domain: row.music_service_base_domain.map(|s| s.into()),
+                submission_client_agent: row.submission_client_agent.map(|s| s.into()),
+                played_time: row
+                    .played_time
+                    .map(|dt| utc_to_atrium_datetime(crate::repos::time_to_chrono_utc(dt))),
+                extra_data: Default::default(),
+            });
+        }
+
+        Ok(ActorFeedPage {
+            plays,
+            cursor: if has_more {
+                next_cursor.as_ref().map(encode_latest_cursor).transpose()?
+            } else {
+                None
+            },
+        })
     }
 
     async fn get_feed_plays_for_profile(

--- a/apps/aqua/src/xrpc/feed.rs
+++ b/apps/aqua/src/xrpc/feed.rs
@@ -63,6 +63,7 @@ pub struct GetActorFeedQuery {
 #[derive(Serialize)]
 pub struct GetActorFeedResponse {
     plays: Vec<PlayView>,
+    cursor: Option<String>,
 }
 
 pub async fn get_actor_feed(
@@ -75,12 +76,13 @@ pub async fn get_actor_feed(
         return Err((StatusCode::BAD_REQUEST, "authorDID is required".to_string()));
     }
 
-    // Cursor and limit are accepted for lexicon compatibility; repository pagination is deferred.
-    let _ = (query.limit, query.cursor);
-
-    match repo.get_feed_plays_for_profile(&[query.author_did]).await {
-        Ok(plays) => Ok(axum::Json(GetActorFeedResponse {
-            plays: plays.into_static(),
+    match repo
+        .get_actor_feed(&query.author_did, query.limit, query.cursor.as_deref())
+        .await
+    {
+        Ok(page) => Ok(axum::Json(GetActorFeedResponse {
+            cursor: page.cursor,
+            plays: page.plays.into_static(),
         })),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -77,6 +77,16 @@ services:
     depends_on:
       - amethyst
 
+  cloudflared-named:
+    image: cloudflare/cloudflared:latest
+    profiles:
+      - named-tunnel
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TUNNEL_TOKEN:-}
+    networks:
+      - app_network
+    depends_on:
+      - amethyst
+
   garnet:
     image: ghcr.io/microsoft/garnet:latest
     container_name: garnet

--- a/docs/development-oauth-tunnel.md
+++ b/docs/development-oauth-tunnel.md
@@ -1,0 +1,56 @@
+# Stable Development OAuth Tunnel
+
+Use this when ATProto OAuth callback testing needs a stable public HTTPS hostname. Do not commit Cloudflare tunnel tokens or credentials.
+
+## One-Time Cloudflare Setup
+
+1. Create a named Cloudflare Tunnel in the Cloudflare Zero Trust dashboard.
+2. Add a public hostname for the tunnel, for example `teal-dev.example.com`.
+3. Route that hostname to the service URL `http://amethyst:80`.
+4. Copy the generated tunnel token into a local shell or an uncommitted `.env` file as `CLOUDFLARED_TUNNEL_TOKEN`.
+
+## Local Environment
+
+Set the public host values before building Amethyst:
+
+```bash
+export TUNNEL_HOST=teal-dev.example.com
+export CLIENT_ADDRESS=:80
+export EXPO_PUBLIC_BASE_URL=https://$TUNNEL_HOST
+export EXPO_PUBLIC_AQUA_URL=https://$TUNNEL_HOST
+export CLOUDFLARED_TUNNEL_TOKEN=<cloudflare-named-tunnel-token>
+```
+
+The Amethyst Caddy image serves the web app and proxies `/xrpc/*` to Aqua, so the same public origin can be used for both `EXPO_PUBLIC_BASE_URL` and `EXPO_PUBLIC_AQUA_URL`.
+
+## Build And Run
+
+```bash
+docker compose -f compose.dev.yml --profile named-tunnel build amethyst
+docker compose -f compose.dev.yml --profile named-tunnel up amethyst aqua-api cadet postgres garnet cloudflared-named
+```
+
+Confirm the OAuth client metadata is served from the stable host:
+
+```bash
+curl https://$TUNNEL_HOST/client-metadata.json
+```
+
+The metadata must include:
+
+```json
+{
+  "redirect_uris": ["https://teal-dev.example.com/auth/callback"],
+  "client_id": "https://teal-dev.example.com/client-metadata.json",
+  "client_uri": "https://teal-dev.example.com"
+}
+```
+
+## OAuth QA Checklist
+
+- Open `https://$TUNNEL_HOST`.
+- Start sign-in with a test ATProto account.
+- Confirm the authorization server accepts `https://$TUNNEL_HOST/client-metadata.json`.
+- Confirm the callback returns to `https://$TUNNEL_HOST/auth/callback`.
+- Confirm the app restores the signed-in session after refresh.
+

--- a/lexicons/fm.teal.alpha/feed/getActorFeed.json
+++ b/lexicons/fm.teal.alpha/feed/getActorFeed.json
@@ -36,6 +36,10 @@
                 "type": "ref",
                 "ref": "fm.teal.alpha.feed.defs#playView"
               }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Opaque cursor for the next page of plays"
             }
           }
         }

--- a/services/cadet/src/ingestors/teal/feed_play.rs
+++ b/services/cadet/src/ingestors/teal/feed_play.rs
@@ -1504,18 +1504,25 @@ impl PlayIngestor {
         .execute(&self.sql)
         .await?;
 
+        sqlx::query("DELETE FROM play_to_artists_extended WHERE play_uri = $1")
+            .bind(uri)
+            .execute(&self.sql)
+            .await?;
+        sqlx::query!("DELETE FROM play_to_artists WHERE play_uri = $1", uri)
+            .execute(&self.sql)
+            .await?;
+
         // Insert plays into the extended join table (supports all artists)
         for (artist_id, artist_name) in &parsed_artists {
-            sqlx::query!(
+            sqlx::query(
                 r#"
                     INSERT INTO play_to_artists_extended (play_uri, artist_id, artist_name) VALUES
-                    ($1, $2, $3)
-                    ON CONFLICT (play_uri, artist_id) DO NOTHING;
+                    ($1, $2, $3);
                 "#,
-                uri,
-                artist_id,
-                artist_name
             )
+            .bind(uri)
+            .bind(artist_id)
+            .bind(artist_name)
             .execute(&self.sql)
             .await?;
         }
@@ -1607,6 +1614,164 @@ impl LexiconIngestor for PlayIngestor {
         } else {
             return Err(anyhow!("Message has no commit"));
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jacquard_common::types::value;
+    use rocketman::{
+        ingestion::LexiconIngestor,
+        types::event::{Commit, Event, Kind, Operation},
+    };
+    use serde_json::json;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    use super::PlayIngestor;
+
+    async fn test_pool() -> anyhow::Result<PgPool> {
+        let database_url = std::env::var("DATABASE_URL")?;
+        Ok(PgPool::connect(&database_url).await?)
+    }
+
+    fn play_record(
+        track_name: &str,
+        artist_name: &str,
+        release_mbid: Uuid,
+        recording_mbid: Uuid,
+    ) -> anyhow::Result<types::fm_teal::alpha::feed::play::Play> {
+        Ok(value::from_json_value::<
+            types::fm_teal::alpha::feed::play::Play,
+        >(json!({
+            "$type": "fm.teal.alpha.feed.play",
+            "trackName": track_name,
+            "recordingMbId": format!("mbid:{recording_mbid}"),
+            "releaseName": "Cadet Test Release",
+            "releaseMbId": format!("mbid:{release_mbid}"),
+            "duration": 181,
+            "artists": [{
+                "artistName": artist_name
+            }],
+            "musicServiceBaseDomain": "tests.teal.fm",
+            "submissionClientAgent": "cadet-test/1.0",
+            "playedTime": "2026-06-01T00:00:00Z"
+        }))?)
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL pointing at a migrated Postgres database"]
+    async fn creates_updates_and_deletes_play() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let ingestor = PlayIngestor::new(pool.clone());
+        let did = format!("did:plc:cadet-play-test-{}", Uuid::new_v4());
+        let rkey = "3k2akjdlkjsf";
+        let uri = format!("at://{did}/fm.teal.alpha.feed.play/{rkey}");
+        let release_mbid = Uuid::new_v4();
+        let recording_mbid = Uuid::new_v4();
+
+        ingestor
+            .insert_play(
+                &play_record(
+                    "First Cadet Test Track",
+                    "First Cadet Test Artist",
+                    release_mbid,
+                    recording_mbid,
+                )?,
+                &uri,
+                "bafyreicadetcreate",
+                &did,
+                rkey,
+            )
+            .await?;
+
+        let inserted = sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
+            "SELECT track_name, release_name, music_service_base_domain FROM plays WHERE uri = $1",
+        )
+        .bind(&uri)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(inserted.0, "First Cadet Test Track");
+        assert_eq!(inserted.1.as_deref(), Some("Cadet Test Release"));
+        assert_eq!(inserted.2.as_deref(), Some("tests.teal.fm"));
+
+        ingestor
+            .insert_play(
+                &play_record(
+                    "Updated Cadet Test Track",
+                    "Updated Cadet Test Artist",
+                    release_mbid,
+                    recording_mbid,
+                )?,
+                &uri,
+                "bafyreicadetupdate",
+                &did,
+                rkey,
+            )
+            .await?;
+
+        let updated = sqlx::query_as::<_, (String, Option<serde_json::Value>)>(
+            "SELECT track_name, artist_names_raw FROM plays WHERE uri = $1",
+        )
+        .bind(&uri)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(updated.0, "Updated Cadet Test Track");
+        assert_eq!(
+            updated.1,
+            Some(json!(["Updated Cadet Test Artist"]))
+        );
+
+        let extended_artist_links = sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT COUNT(*), MAX(artist_name) FROM play_to_artists_extended WHERE play_uri = $1",
+        )
+        .bind(&uri)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(extended_artist_links.0, 1);
+        assert_eq!(
+            extended_artist_links.1.as_deref(),
+            Some("Updated Cadet Test Artist")
+        );
+
+        ingestor
+            .ingest(Event {
+                did: did.clone(),
+                time_us: Some(1),
+                kind: Kind::Commit,
+                commit: Some(Commit {
+                    rev: "test-rev".to_string(),
+                    operation: Operation::Delete,
+                    collection: "fm.teal.alpha.feed.play".to_string(),
+                    rkey: rkey.to_string(),
+                    record: None,
+                    cid: None,
+                }),
+                identity: None,
+            })
+            .await?;
+
+        let remaining_plays =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM plays WHERE uri = $1")
+                .bind(&uri)
+                .fetch_one(&pool)
+                .await?;
+        let remaining_legacy_links =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM play_to_artists WHERE play_uri = $1")
+                .bind(&uri)
+                .fetch_one(&pool)
+                .await?;
+        let remaining_extended_links =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM play_to_artists_extended WHERE play_uri = $1")
+                .bind(&uri)
+                .fetch_one(&pool)
+                .await?;
+
+        assert_eq!(remaining_plays, 0);
+        assert_eq!(remaining_legacy_links, 0);
+        assert_eq!(remaining_extended_links, 0);
+
         Ok(())
     }
 }

--- a/services/satellite/src/counts.rs
+++ b/services/satellite/src/counts.rs
@@ -80,8 +80,7 @@ pub async fn get_latest_plays(
     if params.limit < 1 || params.limit > 50 {
         return Err((StatusCode::BAD_REQUEST, "Invalid limit".to_string()));
     }
-    let result = sqlx::query_as!(
-        Play,
+    let result = sqlx::query_as::<_, Play>(
         r#"
             SELECT
                 p.did,
@@ -100,8 +99,8 @@ pub async fn get_latest_plays(
             ORDER BY p.played_time DESC
             LIMIT $1
         "#,
-        params.limit
     )
+    .bind(params.limit)
     .fetch_all(&state.db_pool)
     .await;
 

--- a/todo.md
+++ b/todo.md
@@ -40,7 +40,7 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 
 ## Next: Aqua And Lexicons
 
-- [ ] Add pagination support for `fm.teal.alpha.feed.getActorFeed` cursor and limit parameters.
+- [x] Add pagination support for `fm.teal.alpha.feed.getActorFeed` cursor and limit parameters.
 - [x] Add keyset pagination and infinite scrolling for the global latest-play feed.
 - [x] Run SQLx prepare against the development Postgres instance and commit refreshed query cache data.
 - [ ] Resolve the existing Satellite SQLx offline-cache gap so `pnpm turbo run test:rust` passes without a live Docker hostname.

--- a/todo.md
+++ b/todo.md
@@ -26,39 +26,39 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 - [ ] Build Amethyst with `EXPO_PUBLIC_BASE_URL=https://<tunnel-host>` and `EXPO_PUBLIC_AQUA_URL=https://<public-aqua-host>`.
 - [ ] Serve `/client-metadata.json` with `redirect_uris=["https://<tunnel-host>/auth/callback"]`.
 - [ ] Complete ATProto OAuth sign-in and callback QA through the stable public hostname.
-- [ ] Document the stable tunnel token or named-tunnel setup without committing secrets.
+- [x] Document the stable tunnel token or named-tunnel setup without committing secrets.
 
 ## Next: Firehose Ingestion
 
-- [ ] Add Cadet create, update, and delete integration tests for `fm.teal.alpha.feed.play`.
+- [x] Add Cadet create, update, and delete integration tests for `fm.teal.alpha.feed.play`.
 - [x] Add profile create, update, and delete ingestion integration tests for `fm.teal.alpha.actor.profile`.
 - [ ] Verify Jetstream filtering against `wantedCollections=fm.teal.alpha.feed.play` in a live environment.
-- [ ] Verify Cadet cursor recovery after restart with Garnet enabled.
-- [ ] Verify delete handling removes the play URI from `plays`, `play_to_artists`, and `play_to_artists_extended`.
+- [x] Verify Cadet cursor recovery after restart with Garnet enabled.
+- [x] Verify delete handling removes the play URI from `plays`, `play_to_artists`, and `play_to_artists_extended`.
 - [ ] Add a `subscribeRepos` CBOR adapter only if relay-level firehose sync becomes necessary.
-- [ ] Keep CAR import as a backfill path and add regression tests for it.
+- [x] Keep CAR import as a backfill path and add regression tests for it.
 
 ## Next: Aqua And Lexicons
 
 - [x] Add pagination support for `fm.teal.alpha.feed.getActorFeed` cursor and limit parameters.
 - [x] Add keyset pagination and infinite scrolling for the global latest-play feed.
 - [x] Run SQLx prepare against the development Postgres instance and commit refreshed query cache data.
-- [ ] Resolve the existing Satellite SQLx offline-cache gap so `pnpm turbo run test:rust` passes without a live Docker hostname.
+- [x] Resolve the existing Satellite SQLx offline-cache gap so `pnpm turbo run test:rust` passes without a live Docker hostname.
 - [ ] Decide whether the legacy `play_to_artists` join table can be removed after Aqua reads move fully to `play_to_artists_extended`.
-- [ ] Validate the Teal lexicons and regenerate Rust and TypeScript bindings before each PR.
+- [x] Validate the Teal lexicons and regenerate Rust and TypeScript bindings before each PR.
 
 ## Next: Amethyst UI
 
 - [x] Add Explore search for users, songs, artists, and albums.
 - [ ] Add album-cover preview controls only after Teal has a real audio preview source and playback behavior.
-- [ ] Finish profile avatar and banner blob URL rendering.
+- [x] Finish profile avatar and banner blob URL rendering.
 - [x] Add artist and release detail routes in addition to track detail.
 - [x] Refresh the shared UI system and apply it across feed, search, profiles, music pages, sign-in, onboarding, settings, and manual stamping.
 - [ ] Select a dedicated artist-image source. Artist pages currently use representative Cover Art Archive release artwork.
 - [ ] Enrich album track ordering from MusicBrainz release media. Teal currently lists the tracks observed in indexed plays alphabetically.
-- [ ] Render real Cover Art Archive images for recordings with MusicBrainz IDs and polished fallbacks for missing art.
+- [x] Render real Cover Art Archive images for recordings with MusicBrainz IDs and polished fallbacks for missing art.
 - [ ] Exercise empty, loading, error, signed-out, and populated feed states at desktop and mobile widths.
-- [ ] Fix populated desktop feed-card text collisions for long DIDs, track titles, and artist names.
+- [x] Fix populated desktop feed-card text collisions for long DIDs, track titles, and artist names.
 - [ ] Verify SPA fallback routing in the production Caddy image for Home, Explore, Notifications, Profile, music detail, and OAuth callback routes.
 - [ ] Capture final Chrome screenshots after Aqua and Cadet are running with live ingested data.
 


### PR DESCRIPTION
Paginate actor plays and repair profile and cover rendering. This groups the existing commits by chronology and the area they change.

Part 6 of 33 replacing #113. Review this PR against `feature/obbpr-05-interface-refresh`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 13bd676 feat(feed): paginate actor plays
- ab07741 fix(satellite): avoid sqlx offline cache gap
- 885491c test(cadet): cover play ingestion lifecycle
- eb265ca fix(amethyst): render teal profile blobs
- 380b015 fix(amethyst): resolve recording cover art
- a7d14ed fix(amethyst): clamp feed card text
- b887a5c docs(amethyst): add stable oauth tunnel setup
- b24b59a docs: update teal todo progress

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/199
- Next: https://github.com/teal-fm/teal/pull/201
- Full stack index: https://github.com/teal-fm/teal/pull/113
