### PR TITLE
[10/33] feat(amethyst): add composer modal and profile editing

### DIFF
--- a/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
+++ b/apps/amethyst/app/(tabs)/:o/music/[artist]/[release]/[track].tsx
@@ -14,8 +14,9 @@ import {
   getLatestPlays,
   getPlayByUri,
   getRecordingCoverArtUrl,
+  getSearchResults,
 } from "@/lib/teal/api";
-import { musicAlbumHref, musicArtistHref } from "@/lib/teal/routes";
+import { musicAlbumHref, musicArtistHref, routePart } from "@/lib/teal/routes";
 import { Disc3 } from "lucide-react-native";
 
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
@@ -23,6 +24,13 @@ import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs"
 export default function MusicDetail() {
   const params = useLocalSearchParams();
   const uri = Array.isArray(params.uri) ? params.uri[0] : params.uri;
+  const artistSlug = Array.isArray(params.artist)
+    ? params.artist[0]
+    : params.artist;
+  const releaseSlug = Array.isArray(params.release)
+    ? params.release[0]
+    : params.release;
+  const trackSlug = Array.isArray(params.track) ? params.track[0] : params.track;
   const [play, setPlay] = useState<PlayView | null>(null);
   const [related, setRelated] = useState<PlayView[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -31,11 +39,33 @@ export default function MusicDetail() {
 
   useEffect(() => {
     let mounted = true;
+    async function resolvePlayFromSlugs() {
+      if (!trackSlug) {
+        throw new Error("Missing track slug");
+      }
+      const query = trackSlug.replace(/-/g, " ");
+      const results = await getSearchResults(query, 25);
+      const match = results.songs.find((song) => {
+        const trackMatches = routePart(song.trackName) === trackSlug;
+        const releaseMatches =
+          !releaseSlug || routePart(song.releaseName) === releaseSlug;
+        const artistMatches =
+          !artistSlug || routePart(song.artistName) === artistSlug;
+        return trackMatches && releaseMatches && artistMatches;
+      });
+
+      if (!match) {
+        throw new Error("No indexed play matches this music URL");
+      }
+
+      return (await getPlayByUri(match.uri)).play;
+    }
+
     async function load() {
       try {
         const selected = uri
           ? (await getPlayByUri(uri)).play
-          : (await getLatestPlays(1)).plays[0];
+          : await resolvePlayFromSlugs();
         const latest = await getLatestPlays(20);
         if (!mounted) return;
         setPlay(selected);
@@ -55,7 +85,7 @@ export default function MusicDetail() {
     return () => {
       mounted = false;
     };
-  }, [uri]);
+  }, [artistSlug, releaseSlug, trackSlug, uri]);
 
   const releaseArt = coverArtUrl(play?.releaseMbId, 500);
   const art = artFailed ? undefined : releaseArt || recordingArt;

--- a/apps/amethyst/app/(tabs)/index.tsx
+++ b/apps/amethyst/app/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import {
   type NativeSyntheticEvent,
 } from "react-native";
 import { Stack } from "expo-router";
+import CreateSocialPostModal from "@/components/teal/CreateSocialPostModal";
 import PlayFeedCard from "@/components/teal/PlayFeedCard";
 import RightRail from "@/components/teal/RightRail";
 import SocialComposer from "@/components/teal/SocialComposer";
@@ -13,7 +14,9 @@ import SocialPostCard from "@/components/teal/SocialPostCard";
 import TealShell, {
   SectionHeading,
 } from "@/components/teal/TealShell";
+import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
+import { Icon } from "@/lib/icons/iconWithClassName";
 import {
   displayArtists,
   getLatestPlays,
@@ -22,6 +25,7 @@ import {
   type SocialPostView,
 } from "@/lib/teal/api";
 import { useStore } from "@/stores/mainStore";
+import { Plus } from "lucide-react-native";
 
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
 
@@ -32,6 +36,7 @@ export default function HomeScreen() {
   const [cursor, setCursor] = useState<string>();
   const [error, setError] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [createPostOpen, setCreatePostOpen] = useState(false);
   const loadingMoreRef = useRef(false);
   const pdsAgent = useStore((state) => state.pdsAgent);
 
@@ -130,6 +135,31 @@ export default function HomeScreen() {
         eyebrow="Global feed"
         title="Recently listened"
         detail="LIVE INDEX"
+      />
+      <View className="mb-6 rounded-lg border border-border bg-card p-4">
+        <View className="flex-row items-center justify-between gap-4">
+          <View className="min-w-0 flex-1">
+            <Text className="font-mono text-[10px] uppercase text-primary">
+              Teal social
+            </Text>
+            <Text className="mt-1 text-lg font-black">Post about any song</Text>
+            <Text className="text-sm text-muted-foreground">
+              Attach a MusicBrainz result or one of your indexed recent plays.
+            </Text>
+          </View>
+          <Button
+            className="shrink-0 flex-row gap-2"
+            onPress={() => setCreatePostOpen(true)}
+          >
+            <Icon icon={Plus} size={17} className="text-primary-foreground" />
+            <Text>Create post</Text>
+          </Button>
+        </View>
+      </View>
+      <CreateSocialPostModal
+        visible={createPostOpen}
+        onClose={() => setCreatePostOpen(false)}
+        onPublished={(post) => setSocialPosts((current) => [post, ...current])}
       />
       {currentStatus && (
         <View className="mb-6 gap-3">

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -9,6 +9,7 @@ import {
 import { Link, Stack, useLocalSearchParams } from "expo-router";
 import PlayFeedCard from "@/components/teal/PlayFeedCard";
 import BadgeManager from "@/components/teal/BadgeManager";
+import EditProfileModal from "@/components/teal/EditProfileModal";
 import { PlaylistCreator } from "@/components/teal/PlaylistControls";
 import RichText from "@/components/teal/RichText";
 import RightRail from "@/components/teal/RightRail";
@@ -17,9 +18,9 @@ import TealShell, {
 } from "@/components/teal/TealShell";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
-import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { resolveHandle } from "@/lib/atp/pid";
 import { Icon } from "@/lib/icons/iconWithClassName";
+import { getProfileImageUrl } from "@/lib/teal/actors";
 import {
   getActorFeed,
   getActorBadges,
@@ -34,7 +35,7 @@ import {
 import { useStore } from "@/stores/mainStore";
 import { playlistHref } from "@/lib/teal/routes";
 import type { AppBskyActorDefs } from "@atproto/api";
-import { Info, UserRoundPlus } from "lucide-react-native";
+import { Info, Pencil, UserRoundPlus } from "lucide-react-native";
 
 import type { ProfileView } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
@@ -52,16 +53,6 @@ type DisplayProfile = Pick<
   handle?: string;
 };
 
-function isHttpUrl(value?: string) {
-  return value?.startsWith("http://") || value?.startsWith("https://");
-}
-
-function profileImageUrl(did: string, value?: string) {
-  if (!value) return undefined;
-  if (isHttpUrl(value) || value.startsWith("data:")) return value;
-  return getImageCdnLink({ did, hash: value });
-}
-
 export default function ProfileScreen() {
   const { handle } = useLocalSearchParams();
   const actor = Array.isArray(handle) ? handle[0] : handle;
@@ -72,6 +63,7 @@ export default function ProfileScreen() {
   const [plays, setPlays] = useState<PlayView[]>([]);
   const [cursor, setCursor] = useState<string>();
   const [loadingMore, setLoadingMore] = useState(false);
+  const [editProfileOpen, setEditProfileOpen] = useState(false);
   const [isBlueskyFallback, setIsBlueskyFallback] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const loadingMoreRef = useRef(false);
@@ -116,7 +108,13 @@ export default function ProfileScreen() {
 
           const bskyProfile: AppBskyActorDefs.ProfileViewDetailed =
             await getBlueskyProfile(resolved);
-          nextProfile = bskyProfile;
+          nextProfile = {
+            displayName: bskyProfile.displayName,
+            description: bskyProfile.description,
+            avatar: bskyProfile.avatar,
+            banner: bskyProfile.banner,
+            handle: bskyProfile.handle,
+          };
           nextIsBlueskyFallback = true;
         }
 
@@ -175,8 +173,12 @@ export default function ProfileScreen() {
   );
 
   const isSelf = did === pdsAgent?.did;
-  const avatarUrl = did ? profileImageUrl(did, profile?.avatar) : undefined;
-  const bannerUrl = did ? profileImageUrl(did, profile?.banner) : undefined;
+  const avatarUrl = did
+    ? getProfileImageUrl(did, profile?.avatar, "avatar")
+    : undefined;
+  const bannerUrl = did
+    ? getProfileImageUrl(did, profile?.banner, "banner")
+    : undefined;
   const currentStatus = profile?.status?.item;
   const onboarding = profile?.profileStatus?.completedOnboarding;
 
@@ -232,6 +234,16 @@ export default function ProfileScreen() {
               <Text className="font-mono text-sm text-muted-foreground">
                 {did}
               </Text>
+              {isSelf && (
+                <Button
+                  className="mt-5 flex-row gap-2 self-start"
+                  variant="outline"
+                  onPress={() => setEditProfileOpen(true)}
+                >
+                  <Icon icon={Pencil} size={16} />
+                  <Text>Edit profile</Text>
+                </Button>
+              )}
               {isBlueskyFallback && (
                 <View className="mt-4 flex-row gap-3 rounded-lg border border-bsky/30 bg-bsky/10 p-3">
                   <Icon icon={Info} size={18} className="mt-0.5 text-bsky" />
@@ -312,6 +324,21 @@ export default function ProfileScreen() {
               )}
             </View>
           </View>
+          {isSelf && (
+            <EditProfileModal
+              did={did}
+              profile={profile}
+              visible={editProfileOpen}
+              onClose={() => setEditProfileOpen(false)}
+              onSaved={(updatedProfile) => {
+                setProfile((current) => ({
+                  ...(current || {}),
+                  ...updatedProfile,
+                }));
+                setIsBlueskyFallback(false);
+              }}
+            />
+          )}
           <View className="mb-8">
             <SectionHeading eyebrow="Collections" title="Playlists" />
             {isSelf && (

--- a/apps/amethyst/app/(tabs)/search/index.tsx
+++ b/apps/amethyst/app/(tabs)/search/index.tsx
@@ -7,8 +7,8 @@ import TealShell, {
 } from "@/components/teal/TealShell";
 import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
-import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { Icon } from "@/lib/icons/iconWithClassName";
+import { getProfileImageUrl } from "@/lib/teal/actors";
 import {
   coverArtUrl,
   getSearchResults,
@@ -78,7 +78,7 @@ function mergeUsers(
       handle: user.handle?.replace(/^at:\/\//, ""),
       avatarUrl:
         user.avatar && user.did
-          ? getImageCdnLink({ did: user.did, hash: user.avatar })
+          ? getProfileImageUrl(user.did, user.avatar, "avatar")
           : merged.get(user.did)?.avatarUrl,
     });
   });

--- a/apps/amethyst/components/teal/CreateSocialPostModal.tsx
+++ b/apps/amethyst/components/teal/CreateSocialPostModal.tsx
@@ -1,0 +1,457 @@
+import { useEffect, useMemo, useState } from "react";
+import { Image, Modal, Pressable, ScrollView, View } from "react-native";
+import { RichText as AtprotoRichText } from "@atproto/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { Textarea } from "@/components/ui/textarea";
+import { Icon } from "@/lib/icons/iconWithClassName";
+import {
+  coverArtUrl,
+  displayArtists,
+  getActorFeed,
+  type SocialPostView,
+} from "@/lib/teal/api";
+import { playViewToTrackView } from "@/lib/teal/social";
+import {
+  type MusicBrainzRecording,
+  type MusicBrainzRelease,
+  searchMusicbrainz,
+} from "@/lib/oldStamp";
+import { timeAgo } from "@/lib/utils";
+import { useStore } from "@/stores/mainStore";
+import { Check, Disc3, Music2, Search, X } from "lucide-react-native";
+
+import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+
+type CreateSocialPostModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  onPublished: (post: SocialPostView) => void;
+};
+
+type SearchMode = "musicbrainz" | "recent";
+
+type MusicBrainzFields = {
+  track: string;
+  artist: string;
+  release: string;
+};
+
+function extractTags(text: string) {
+  return Array.from(text.matchAll(/(^|\s)#([\p{L}\p{N}_-]{1,64})/gu))
+    .map((match) => match[2])
+    .slice(0, 8);
+}
+
+function currentLangs() {
+  if (typeof navigator === "undefined") return undefined;
+  const language = navigator.language?.split("-")[0];
+  return language ? [language].slice(0, 3) : undefined;
+}
+
+function bestRelease(recording: MusicBrainzRecording) {
+  const releases = [...(recording.releases || [])];
+  if (releases.length === 0) return undefined;
+  releases.sort(
+    (a, b) =>
+      (a.date || "9999").localeCompare(b.date || "9999") ||
+      a.title.localeCompare(b.title) ||
+      a.id.localeCompare(b.id),
+  );
+  return (
+    releases.find(
+      (release) =>
+        (release.country === "XW" || release.country === "US") &&
+        release.title !== recording.title,
+    ) ||
+    releases.find((release) => release.title !== recording.title) ||
+    releases[0]
+  );
+}
+
+function musicBrainzToPlayView(
+  recording: MusicBrainzRecording,
+  release?: MusicBrainzRelease,
+): PlayView {
+  const selectedRelease = release || recording.selectedRelease || bestRelease(recording);
+  return {
+    trackName: recording.title || "Unknown track",
+    trackMbId: recording.id ? `mbid:${recording.id}` : undefined,
+    recordingMbId: recording.id ? `mbid:${recording.id}` : undefined,
+    duration: recording.length ? Math.floor(recording.length / 1000) : undefined,
+    artists:
+      recording["artist-credit"]?.map((credit) => ({
+        artistName: credit.name || credit.artist.name,
+        artistMbId: credit.artist.id ? `mbid:${credit.artist.id}` : undefined,
+      })) || [],
+    releaseName: selectedRelease?.title,
+    releaseMbId: selectedRelease?.id ? `mbid:${selectedRelease.id}` : undefined,
+    isrc: recording.isrcs?.[0],
+    originUrl: recording.id
+      ? `https://musicbrainz.org/recording/${recording.id}`
+      : undefined,
+  };
+}
+
+function artForPlay(play: PlayView) {
+  return coverArtUrl(play.releaseMbId);
+}
+
+function TrackOption({
+  play,
+  selected,
+  detail,
+  onPress,
+}: {
+  play: PlayView;
+  selected: boolean;
+  detail?: string;
+  onPress: () => void;
+}) {
+  const art = artForPlay(play);
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-row items-center gap-3 rounded-lg border p-3 web:transition-colors ${
+        selected
+          ? "border-primary bg-primary/10"
+          : "border-border bg-card web:hover:border-primary/45"
+      }`}
+    >
+      <View className="h-14 w-14 shrink-0 overflow-hidden rounded-lg bg-muted">
+        {art ? (
+          <Image source={{ uri: art }} className="h-full w-full" />
+        ) : (
+          <View className="h-full w-full items-center justify-center">
+            <Icon icon={Disc3} size={24} className="text-muted-foreground" />
+          </View>
+        )}
+      </View>
+      <View className="min-w-0 flex-1">
+        <Text className="font-black" numberOfLines={2}>
+          {play.trackName}
+        </Text>
+        <Text className="text-sm font-bold text-muted-foreground" numberOfLines={1}>
+          {displayArtists(play) || "Unknown artist"}
+        </Text>
+        {(play.releaseName || detail) && (
+          <Text className="mt-1 font-mono text-[10px] uppercase text-muted-foreground" numberOfLines={1}>
+            {detail || play.releaseName}
+          </Text>
+        )}
+      </View>
+      <View
+        className={`h-8 w-8 items-center justify-center rounded-full border ${
+          selected ? "border-primary bg-primary" : "border-border"
+        }`}
+      >
+        {selected && <Icon icon={Check} size={16} className="text-primary-foreground" />}
+      </View>
+    </Pressable>
+  );
+}
+
+export default function CreateSocialPostModal({
+  visible,
+  onClose,
+  onPublished,
+}: CreateSocialPostModalProps) {
+  const pdsAgent = useStore((state) => state.pdsAgent);
+  const status = useStore((state) => state.status);
+  const [mode, setMode] = useState<SearchMode>("musicbrainz");
+  const [fields, setFields] = useState<MusicBrainzFields>({
+    track: "",
+    artist: "",
+    release: "",
+  });
+  const [musicBrainzResults, setMusicBrainzResults] = useState<PlayView[]>([]);
+  const [recentPlays, setRecentPlays] = useState<PlayView[]>([]);
+  const [recentQuery, setRecentQuery] = useState("");
+  const [selectedTrack, setSelectedTrack] = useState<PlayView | null>(null);
+  const [postText, setPostText] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [loadingRecent, setLoadingRecent] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const tags = useMemo(() => extractTags(postText), [postText]);
+
+  useEffect(() => {
+    if (!visible || mode !== "recent" || !pdsAgent?.did || recentPlays.length > 0) {
+      return;
+    }
+    let mounted = true;
+    setLoadingRecent(true);
+    getActorFeed(pdsAgent.did, 30)
+      .then((res) => {
+        if (mounted) setRecentPlays(res.plays);
+      })
+      .catch((e) => {
+        if (mounted) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (mounted) setLoadingRecent(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [mode, pdsAgent?.did, recentPlays.length, visible]);
+
+  const filteredRecent = useMemo(() => {
+    const query = recentQuery.trim().toLowerCase();
+    if (!query) return recentPlays;
+    return recentPlays.filter((play) =>
+      `${play.trackName} ${displayArtists(play)} ${play.releaseName || ""}`
+        .toLowerCase()
+        .includes(query),
+    );
+  }, [recentPlays, recentQuery]);
+
+  async function searchMusicBrainz() {
+    if (!fields.track.trim() && !fields.artist.trim() && !fields.release.trim()) return;
+    setSearching(true);
+    setError(null);
+    setSelectedTrack(null);
+    try {
+      const results = await searchMusicbrainz({
+        track: fields.track.trim(),
+        artist: fields.artist.trim(),
+        release: fields.release.trim(),
+      });
+      setMusicBrainzResults(results.slice(0, 12).map((result) => musicBrainzToPlayView(result)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function submit() {
+    if (!pdsAgent?.did || !selectedTrack || submitting) return;
+    const text = postText.trim();
+    if (!text) {
+      setError("Write something before posting.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const rt = new AtprotoRichText({ text });
+      await rt.detectFacets(pdsAgent);
+      const record = {
+        $type: "fm.teal.alpha.feed.social.post",
+        text,
+        track: playViewToTrackView(selectedTrack),
+        facets: rt.facets,
+        tags,
+        langs: currentLangs(),
+        createdAt: new Date().toISOString(),
+      };
+      const res = await pdsAgent.call(
+        "com.atproto.repo.createRecord",
+        {},
+        {
+          repo: pdsAgent.did,
+          collection: "fm.teal.alpha.feed.social.post",
+          record,
+        },
+      );
+      onPublished({
+        uri: (res.data as { uri?: string }).uri || "",
+        cid: (res.data as { cid?: string }).cid || "",
+        authorDid: pdsAgent.did,
+        text,
+        track: record.track,
+        facets: rt.facets,
+        tags,
+        langs: record.langs,
+        createdAt: record.createdAt,
+        likeCount: 0,
+        repostCount: 0,
+        replyCount: 0,
+      });
+      setPostText("");
+      setSelectedTrack(null);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal animationType="fade" transparent visible={visible} onRequestClose={onClose}>
+      <View className="flex-1 bg-foreground/70 p-3 md:items-center md:justify-center md:p-6">
+        <View className="max-h-[94vh] w-full overflow-hidden rounded-lg border border-border bg-background md:max-w-[46rem]">
+          <View className="flex-row items-center justify-between border-b border-border px-4 py-3">
+            <View className="min-w-0 flex-1">
+              <Text className="font-mono text-[10px] uppercase text-primary">
+                Create post
+              </Text>
+              <Text className="text-xl font-black">Find a song, say the thing</Text>
+            </View>
+            <Button variant="ghost" size="icon" onPress={onClose}>
+              <Icon icon={X} size={20} />
+            </Button>
+          </View>
+
+          <ScrollView className="max-h-[82vh]" contentContainerClassName="gap-4 p-4">
+            {status !== "loggedIn" ? (
+              <View className="rounded-lg border border-border bg-card p-4">
+                <Text className="font-bold">Sign in to create Teal posts.</Text>
+                <Text className="mt-1 text-sm text-muted-foreground">
+                  Posts are written to your ATProto repo and indexed by Teal.
+                </Text>
+              </View>
+            ) : (
+              <>
+                <View className="flex-row rounded-lg border border-border bg-card p-1">
+                  <Pressable
+                    onPress={() => setMode("musicbrainz")}
+                    className={`flex-1 flex-row items-center justify-center gap-2 rounded-md px-3 py-2 ${
+                      mode === "musicbrainz" ? "bg-accent" : ""
+                    }`}
+                  >
+                    <Icon icon={Search} size={16} className={mode === "musicbrainz" ? "text-primary" : "text-muted-foreground"} />
+                    <Text className="text-sm font-black">MusicBrainz</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => setMode("recent")}
+                    className={`flex-1 flex-row items-center justify-center gap-2 rounded-md px-3 py-2 ${
+                      mode === "recent" ? "bg-accent" : ""
+                    }`}
+                  >
+                    <Icon icon={Music2} size={16} className={mode === "recent" ? "text-primary" : "text-muted-foreground"} />
+                    <Text className="text-sm font-black">My recent plays</Text>
+                  </Pressable>
+                </View>
+
+                {mode === "musicbrainz" ? (
+                  <View className="gap-3">
+                    <View className="gap-2 md:flex-row">
+                      <Input
+                        className="md:flex-1"
+                        placeholder="Track"
+                        value={fields.track}
+                        onChangeText={(track) => setFields((current) => ({ ...current, track }))}
+                        onSubmitEditing={searchMusicBrainz}
+                      />
+                      <Input
+                        className="md:flex-1"
+                        placeholder="Artist"
+                        value={fields.artist}
+                        onChangeText={(artist) => setFields((current) => ({ ...current, artist }))}
+                        onSubmitEditing={searchMusicBrainz}
+                      />
+                    </View>
+                    <View className="gap-2 md:flex-row">
+                      <Input
+                        className="md:flex-1"
+                        placeholder="Album (optional)"
+                        value={fields.release}
+                        onChangeText={(release) => setFields((current) => ({ ...current, release }))}
+                        onSubmitEditing={searchMusicBrainz}
+                      />
+                      <Button
+                        className="md:w-36"
+                        disabled={searching || (!fields.track.trim() && !fields.artist.trim() && !fields.release.trim())}
+                        onPress={searchMusicBrainz}
+                      >
+                        <Text>{searching ? "Searching..." : "Search"}</Text>
+                      </Button>
+                    </View>
+                    <View className="gap-2">
+                      {musicBrainzResults.map((play) => (
+                        <TrackOption
+                          key={`${play.recordingMbId}-${play.releaseMbId}`}
+                          play={play}
+                          selected={selectedTrack?.recordingMbId === play.recordingMbId}
+                          onPress={() => setSelectedTrack(play)}
+                        />
+                      ))}
+                      {!searching && musicBrainzResults.length === 0 && (
+                        <Text className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                          Search MusicBrainz by track, artist, or album to attach a song.
+                        </Text>
+                      )}
+                    </View>
+                  </View>
+                ) : (
+                  <View className="gap-3">
+                    <Input
+                      placeholder="Filter recent plays"
+                      value={recentQuery}
+                      onChangeText={setRecentQuery}
+                    />
+                    <View className="gap-2">
+                      {loadingRecent && (
+                        <Text className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+                          Loading your recent plays...
+                        </Text>
+                      )}
+                      {filteredRecent.map((play) => (
+                        <TrackOption
+                          key={play.uri || `${play.trackName}-${play.playedTime}`}
+                          play={play}
+                          detail={
+                            play.playedTime
+                              ? `listened ${timeAgo(new Date(play.playedTime))}`
+                              : undefined
+                          }
+                          selected={selectedTrack?.uri === play.uri}
+                          onPress={() => setSelectedTrack(play)}
+                        />
+                      ))}
+                      {!loadingRecent && filteredRecent.length === 0 && (
+                        <Text className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                          No indexed recent plays matched.
+                        </Text>
+                      )}
+                    </View>
+                  </View>
+                )}
+
+                <View className="gap-2">
+                  <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                    Post text
+                  </Text>
+                  {selectedTrack && (
+                    <Text className="text-sm font-bold" numberOfLines={1}>
+                      Attached: {selectedTrack.trackName} · {displayArtists(selectedTrack)}
+                    </Text>
+                  )}
+                  <Textarea
+                    className="min-h-28"
+                    placeholder="What do you want to say about this song?"
+                    value={postText}
+                    onChangeText={setPostText}
+                  />
+                  {tags.length > 0 && (
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Tags: {tags.join(", ")}
+                    </Text>
+                  )}
+                </View>
+
+                {error && <Text className="text-sm text-destructive">{error}</Text>}
+
+                <View className="flex-row justify-end gap-2 border-t border-border pt-4">
+                  <Button variant="outline" onPress={onClose}>
+                    <Text>Cancel</Text>
+                  </Button>
+                  <Button
+                    disabled={submitting || !selectedTrack || !postText.trim() || postText.length > 3000}
+                    onPress={submit}
+                  >
+                    <Text>{submitting ? "Posting..." : "Post"}</Text>
+                  </Button>
+                </View>
+              </>
+            )}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/amethyst/components/teal/EditProfileModal.tsx
+++ b/apps/amethyst/components/teal/EditProfileModal.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  View,
+} from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { RichText as AtprotoRichText } from "@atproto/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { Textarea } from "@/components/ui/textarea";
+import { getProfileImageUrl } from "@/lib/teal/actors";
+import { Icon } from "@/lib/icons/iconWithClassName";
+import { useStore } from "@/stores/mainStore";
+import { ImagePlus, Save, UserRoundPen, X } from "lucide-react-native";
+
+import type { ProfileView } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
+import type { Record as ProfileRecord } from "@teal/lexicons/src/types/fm/teal/alpha/actor/profile";
+
+type EditableProfile = Pick<
+  ProfileView,
+  "displayName" | "description" | "descriptionFacets" | "avatar" | "banner"
+>;
+
+type EditProfileModalProps = {
+  did: string;
+  profile: EditableProfile | null;
+  visible: boolean;
+  onClose: () => void;
+  onSaved: (profile: EditableProfile) => void;
+};
+
+type BlobRef = NonNullable<ProfileRecord["avatar"]>;
+
+function blobCid(blob?: BlobRef) {
+  if (!blob) return undefined;
+  const value = blob as unknown as {
+    ref?: { $link?: string };
+    ["r#ref"]?: string;
+    cid?: string;
+  };
+  return value.ref?.$link || value["r#ref"] || value.cid;
+}
+
+function mimeFromUri(uri: string, fallback = "image/jpeg") {
+  if (uri.startsWith("data:")) return uri.slice(5, uri.indexOf(";")) || fallback;
+  if (uri.endsWith(".png")) return "image/png";
+  if (uri.endsWith(".webp")) return "image/webp";
+  return fallback;
+}
+
+async function selectedImageBlob(uri: string) {
+  const response = await fetch(uri);
+  const data = await response.blob();
+  return new Blob([data], { type: data.type || mimeFromUri(uri) });
+}
+
+async function maybeUploadImage(
+  agent: NonNullable<ReturnType<typeof useStore.getState>["pdsAgent"]>,
+  uri: string,
+  currentBlob: BlobRef | undefined,
+  currentUrl: string | undefined,
+) {
+  if (!uri) return undefined;
+  if (currentBlob && uri === currentUrl) return currentBlob;
+  const blob = await selectedImageBlob(uri);
+  return (
+    await agent.uploadBlob(blob, { encoding: blob.type || mimeFromUri(uri) })
+  ).data.blob as unknown as BlobRef;
+}
+
+export default function EditProfileModal({
+  did,
+  profile,
+  visible,
+  onClose,
+  onSaved,
+}: EditProfileModalProps) {
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [avatarUri, setAvatarUri] = useState("");
+  const [bannerUri, setBannerUri] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [picking, setPicking] = useState<"avatar" | "banner" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const agent = useStore((state) => state.pdsAgent);
+
+  const currentAvatarUrl = useMemo(
+    () => getProfileImageUrl(did, profile?.avatar, "avatar"),
+    [did, profile?.avatar],
+  );
+  const currentBannerUrl = useMemo(
+    () => getProfileImageUrl(did, profile?.banner, "banner"),
+    [did, profile?.banner],
+  );
+
+  useEffect(() => {
+    if (!visible) return;
+    setDisplayName(profile?.displayName || "");
+    setDescription(profile?.description || "");
+    setAvatarUri(currentAvatarUrl || "");
+    setBannerUri(currentBannerUrl || "");
+    setError(null);
+  }, [currentAvatarUrl, currentBannerUrl, profile, visible]);
+
+  async function pickImage(kind: "avatar" | "banner") {
+    setPicking(kind);
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        allowsEditing: true,
+        aspect: kind === "avatar" ? [1, 1] : [3, 1],
+        quality: 0.92,
+      });
+      if (!result.canceled) {
+        if (kind === "avatar") setAvatarUri(result.assets[0].uri);
+        else setBannerUri(result.assets[0].uri);
+      }
+    } finally {
+      setPicking(null);
+    }
+  }
+
+  async function save() {
+    if (!agent?.did || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      let currentRecord: ProfileRecord | undefined;
+      let swapRecord: string | undefined;
+      try {
+        const existing = await agent.call("com.atproto.repo.getRecord", {
+          repo: agent.did,
+          collection: "fm.teal.alpha.actor.profile",
+          rkey: "self",
+        });
+        currentRecord = existing.data.value as ProfileRecord;
+        swapRecord = existing.data.cid;
+      } catch {
+        currentRecord = undefined;
+      }
+
+      const richText = new AtprotoRichText({ text: description.trim() });
+      await richText.detectFacets(agent);
+      const avatar = await maybeUploadImage(
+        agent,
+        avatarUri,
+        currentRecord?.avatar,
+        currentAvatarUrl,
+      );
+      const banner = await maybeUploadImage(
+        agent,
+        bannerUri,
+        currentRecord?.banner,
+        currentBannerUrl,
+      );
+      const record: ProfileRecord = {
+        displayName: displayName.trim(),
+        description: description.trim(),
+        descriptionFacets: richText.facets,
+        avatar,
+        banner,
+      };
+
+      if (swapRecord) {
+        await agent.call(
+          "com.atproto.repo.putRecord",
+          {},
+          {
+            repo: agent.did,
+            collection: "fm.teal.alpha.actor.profile",
+            rkey: "self",
+            record,
+            swapRecord,
+          },
+        );
+      } else {
+        await agent.call(
+          "com.atproto.repo.createRecord",
+          {},
+          {
+            repo: agent.did,
+            collection: "fm.teal.alpha.actor.profile",
+            rkey: "self",
+            record,
+          },
+        );
+      }
+
+      onSaved({
+        displayName: record.displayName,
+        description: record.description,
+        descriptionFacets: record.descriptionFacets,
+        avatar: blobCid(avatar) || profile?.avatar,
+        banner: blobCid(banner) || profile?.banner,
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 items-center justify-center bg-black/55 px-4 py-8">
+        <View className="max-h-full w-full max-w-2xl overflow-hidden rounded-lg border border-border bg-background">
+          <View className="flex-row items-start justify-between border-b border-border p-4">
+            <View>
+              <Text className="font-mono text-[10px] uppercase text-primary">
+                Teal profile
+              </Text>
+              <Text className="font-sans text-2xl font-black">Edit profile</Text>
+            </View>
+            <Button variant="ghost" size="icon" onPress={onClose}>
+              <Icon icon={X} size={20} />
+            </Button>
+          </View>
+          <ScrollView className="max-h-[80vh]">
+            <View className="gap-5 p-4">
+              <Pressable onPress={() => pickImage("banner")}>
+                <View className="aspect-[3/1] w-full overflow-hidden rounded-lg border border-border bg-muted">
+                  {bannerUri ? (
+                    <Image
+                      source={{ uri: bannerUri }}
+                      className="h-full w-full"
+                    />
+                  ) : (
+                    <View className="h-full w-full items-center justify-center gap-2">
+                      <Icon
+                        icon={ImagePlus}
+                        size={24}
+                        className="text-muted-foreground"
+                      />
+                      <Text className="text-sm text-muted-foreground">
+                        Add banner image
+                      </Text>
+                    </View>
+                  )}
+                  {picking === "banner" && (
+                    <View className="absolute inset-0 items-center justify-center bg-background/70">
+                      <ActivityIndicator />
+                    </View>
+                  )}
+                </View>
+              </Pressable>
+              <Pressable
+                onPress={() => pickImage("avatar")}
+                className="-mt-12 self-start pl-4"
+              >
+                <View className="h-24 w-24 overflow-hidden rounded-lg border-4 border-background bg-primary">
+                  {avatarUri ? (
+                    <Image
+                      source={{ uri: avatarUri }}
+                      className="h-full w-full"
+                    />
+                  ) : (
+                    <View className="h-full w-full items-center justify-center">
+                      <Icon
+                        icon={UserRoundPen}
+                        size={28}
+                        className="text-primary-foreground"
+                      />
+                    </View>
+                  )}
+                  {picking === "avatar" && (
+                    <View className="absolute inset-0 items-center justify-center bg-background/70">
+                      <ActivityIndicator />
+                    </View>
+                  )}
+                </View>
+              </Pressable>
+              <View className="gap-2">
+                <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                  Display name
+                </Text>
+                <Input
+                  value={displayName}
+                  onChangeText={setDisplayName}
+                  placeholder="How should Teal show your name?"
+                  maxLength={64}
+                />
+              </View>
+              <View className="gap-2">
+                <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                  Bio
+                </Text>
+                <Textarea
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="A few words, links, or mentions."
+                  numberOfLines={5}
+                  maxLength={512}
+                />
+              </View>
+              {error && (
+                <View className="rounded-lg border border-destructive/30 bg-destructive/10 p-3">
+                  <Text className="font-bold text-destructive">{error}</Text>
+                </View>
+              )}
+              <View className="flex-row justify-end gap-2">
+                <Button variant="outline" onPress={onClose} disabled={saving}>
+                  <Text>Cancel</Text>
+                </Button>
+                <Button
+                  className="flex-row gap-2"
+                  onPress={save}
+                  disabled={saving || !agent}
+                >
+                  {saving ? (
+                    <ActivityIndicator />
+                  ) : (
+                    <Icon icon={Save} size={17} />
+                  )}
+                  <Text>{saving ? "Saving" : "Save profile"}</Text>
+                </Button>
+              </View>
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/amethyst/components/teal/PlayFeedCard.tsx
+++ b/apps/amethyst/components/teal/PlayFeedCard.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from "react";
 import { Image, Pressable, View } from "react-native";
 import { Link } from "expo-router";
-import getImageCdnLink from "@/lib/atp/getImageCdnLink";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import {
   coverArtUrl,
   displayArtists,
-  getBlueskyProfile,
   getRecordingCoverArtUrl,
 } from "@/lib/teal/api";
+import {
+  actorAvatarUrl,
+  actorProfileHref,
+  displayActorName,
+  getCachedBlueskyProfile,
+  normalizeHandle,
+  type DisplayActor,
+} from "@/lib/teal/actors";
 import { musicTrackHref } from "@/lib/teal/routes";
 import { cn, timeAgo } from "@/lib/utils";
 import { Disc3 } from "lucide-react-native";
@@ -22,31 +28,6 @@ type PlayFeedCardProps = {
   compact?: boolean;
 };
 
-type FeedAuthor = {
-  avatar?: string;
-  did?: string;
-  displayName?: string;
-  handle?: string;
-};
-
-const blueskyProfileCache = new Map<string, Promise<FeedAuthor | undefined>>();
-
-function getCachedBlueskyProfile(did: string) {
-  let profile = blueskyProfileCache.get(did);
-  if (!profile) {
-    profile = getBlueskyProfile(did)
-      .then(({ avatar, displayName, handle }) => ({
-        avatar,
-        did,
-        displayName,
-        handle,
-      }))
-      .catch(() => undefined);
-    blueskyProfileCache.set(did, profile);
-  }
-  return profile;
-}
-
 export function musicHref(play: PlayView) {
   return musicTrackHref(
     displayArtists(play),
@@ -57,18 +38,28 @@ export function musicHref(play: PlayView) {
 }
 
 export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
-  const [blueskyAuthor, setBlueskyAuthor] = useState<FeedAuthor>();
+  const [blueskyAuthor, setBlueskyAuthor] = useState<DisplayActor>();
   const [artFailed, setArtFailed] = useState(false);
   const [recordingArt, setRecordingArt] = useState<string>();
-  const indexedAuthor = play.author as FeedAuthor | undefined;
-  const authorProfile = indexedAuthor || blueskyAuthor;
+  const indexedAuthor = play.author as DisplayActor | undefined;
+  const authorProfile = indexedAuthor
+    ? {
+        ...blueskyAuthor,
+        ...indexedAuthor,
+        avatar: indexedAuthor.avatar || blueskyAuthor?.avatar,
+        displayName: indexedAuthor.displayName || blueskyAuthor?.displayName,
+        handle: indexedAuthor.handle || blueskyAuthor?.handle,
+      }
+    : blueskyAuthor;
   const authorDid = authorProfile?.did || play.authorDid;
   const releaseArt = coverArtUrl(play.releaseMbId);
   const art = artFailed ? undefined : releaseArt || recordingArt;
 
   useEffect(() => {
     let mounted = true;
-    if (!authorDid || indexedAuthor) {
+    const needsBlueskyFallback =
+      !indexedAuthor?.displayName || !indexedAuthor?.handle;
+    if (!authorDid || !needsBlueskyFallback) {
       setBlueskyAuthor(undefined);
       return;
     }
@@ -95,19 +86,10 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
     };
   }, [play.recordingMbId, releaseArt]);
 
-  const authorHandle = authorProfile?.handle?.replace(/^at:\/\//, "");
-  const authorName =
-    authorProfile?.displayName ||
-    authorHandle ||
-    authorDid ||
-    "Unknown listener";
-  const authorHref = authorHandle || authorDid || "unknown";
-  const authorAvatar =
-    authorDid && indexedAuthor?.avatar
-      ? getImageCdnLink({ did: authorDid, hash: indexedAuthor.avatar })
-      : authorProfile?.avatar
-        ? authorProfile.avatar
-        : undefined;
+  const authorHandle = normalizeHandle(authorProfile?.handle);
+  const authorName = displayActorName(authorProfile, authorDid);
+  const authorHref = actorProfileHref(authorProfile, authorDid);
+  const authorAvatar = actorAvatarUrl(authorProfile, authorDid);
   const when = play.playedTime
     ? timeAgo(new Date(play.playedTime))
     : "recently";

--- a/apps/amethyst/components/teal/SocialPostCard.tsx
+++ b/apps/amethyst/components/teal/SocialPostCard.tsx
@@ -1,10 +1,18 @@
-import { useMemo, useState } from "react";
-import { Pressable, View } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Image, Pressable, View } from "react-native";
 import { Link } from "expo-router";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import { displayArtists, type SocialPostView } from "@/lib/teal/api";
+import {
+  actorAvatarUrl,
+  actorProfileHref,
+  displayActorName,
+  getCachedBlueskyProfile,
+  normalizeHandle,
+  type DisplayActor,
+} from "@/lib/teal/actors";
 import { musicHref } from "@/components/teal/PlayFeedCard";
 import RichText from "@/components/teal/RichText";
 import SocialComposer from "@/components/teal/SocialComposer";
@@ -32,14 +40,43 @@ export default function SocialPostCard({ post }: { post: SocialPostView }) {
   const [repostCount, setRepostCount] = useState(post.repostCount);
   const [replyCount, setReplyCount] = useState(post.replyCount);
   const [replyOpen, setReplyOpen] = useState(false);
+  const [blueskyAuthor, setBlueskyAuthor] = useState<DisplayActor>();
   const [like, setLike] = useState<ActionState>({ active: false, busy: false });
   const [repost, setRepost] = useState<ActionState>({
     active: false,
     busy: false,
   });
-  const authorLabel =
-    post.author?.displayName || post.author?.handle || post.authorDid;
-  const authorHref = post.author?.handle || post.authorDid;
+  const indexedAuthor = post.author as DisplayActor | undefined;
+  const authorProfile = indexedAuthor
+    ? {
+        ...blueskyAuthor,
+        ...indexedAuthor,
+        avatar: indexedAuthor.avatar || blueskyAuthor?.avatar,
+        displayName: indexedAuthor.displayName || blueskyAuthor?.displayName,
+        handle: indexedAuthor.handle || blueskyAuthor?.handle,
+      }
+    : blueskyAuthor;
+  const authorDid = authorProfile?.did || post.authorDid;
+  const authorHandle = normalizeHandle(authorProfile?.handle);
+  const authorLabel = displayActorName(authorProfile, authorDid);
+  const authorHref = actorProfileHref(authorProfile, authorDid);
+  const authorAvatar = actorAvatarUrl(authorProfile, authorDid);
+
+  useEffect(() => {
+    let mounted = true;
+    const needsBlueskyFallback =
+      !indexedAuthor?.displayName || !indexedAuthor?.handle;
+    if (!authorDid || !needsBlueskyFallback) {
+      setBlueskyAuthor(undefined);
+      return;
+    }
+    getCachedBlueskyProfile(authorDid).then((profile) => {
+      if (mounted) setBlueskyAuthor(profile);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [authorDid, indexedAuthor]);
 
   async function toggleAction(kind: "like" | "repost") {
     if (!pdsAgent?.did || status !== "loggedIn") return;
@@ -95,17 +132,41 @@ export default function SocialPostCard({ post }: { post: SocialPostView }) {
   return (
     <View className="rounded-lg border border-border bg-card p-4">
       <View className="flex-row items-start justify-between gap-3">
-        <View className="min-w-0 flex-1">
+        <View className="min-w-0 flex-1 flex-row gap-3">
           <Link href={`/profile/${authorHref}` as any} asChild>
-            <Pressable>
-              <Text className="font-black" numberOfLines={1}>
-                {authorLabel}
-              </Text>
+            <Pressable className="h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary">
+              {authorAvatar ? (
+                <Image
+                  source={{ uri: authorAvatar }}
+                  className="h-full w-full"
+                />
+              ) : (
+                <Text className="text-lg font-black text-primary-foreground">
+                  {authorLabel.slice(0, 1).toUpperCase()}
+                </Text>
+              )}
             </Pressable>
           </Link>
-          <Text className="font-mono text-[10px] uppercase text-muted-foreground">
-            posted {timeAgo(new Date(post.createdAt))}
-          </Text>
+          <View className="min-w-0 flex-1">
+            <Link href={`/profile/${authorHref}` as any} asChild>
+              <Pressable>
+                <Text className="font-black" numberOfLines={1}>
+                  {authorLabel}
+                </Text>
+              </Pressable>
+            </Link>
+            {authorHandle && (
+              <Text
+                className="max-w-full font-mono text-xs text-muted-foreground"
+                numberOfLines={1}
+              >
+                @{authorHandle}
+              </Text>
+            )}
+            <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+              posted {timeAgo(new Date(post.createdAt))}
+            </Text>
+          </View>
         </View>
         <View className="rounded-full bg-accent px-2 py-1">
           <Text className="font-mono text-[10px] uppercase text-primary">

--- a/apps/amethyst/lib/teal/actors.ts
+++ b/apps/amethyst/lib/teal/actors.ts
@@ -1,0 +1,77 @@
+import { getBlueskyProfile } from "@/lib/teal/api";
+
+import type { MiniProfileView } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
+
+export type DisplayActor = {
+  avatar?: string;
+  did?: string;
+  displayName?: string;
+  handle?: string;
+};
+
+const blueskyProfileCache = new Map<string, Promise<DisplayActor | undefined>>();
+
+export function isHttpUrl(value?: string) {
+  return value?.startsWith("http://") || value?.startsWith("https://");
+}
+
+export function normalizeHandle(value?: string) {
+  return value?.replace(/^at:\/\//, "").replace(/^@/, "");
+}
+
+export function getProfileImageUrl(
+  did: string,
+  value?: string,
+  kind: "avatar" | "banner" = "avatar",
+) {
+  if (!value) return undefined;
+  if (
+    isHttpUrl(value) ||
+    value.startsWith("data:") ||
+    value.startsWith("blob:")
+  ) {
+    return value;
+  }
+  if (value.startsWith("at://")) return value;
+  return `https://cdn.bsky.app/img/${kind}/plain/${did}/${value}@jpeg`;
+}
+
+export function getCachedBlueskyProfile(did: string) {
+  let profile = blueskyProfileCache.get(did);
+  if (!profile) {
+    profile = getBlueskyProfile(did)
+      .then(({ avatar, displayName, handle }) => ({
+        avatar,
+        did,
+        displayName,
+        handle,
+      }))
+      .catch(() => undefined);
+    blueskyProfileCache.set(did, profile);
+  }
+  return profile;
+}
+
+export function displayActorName(
+  actor: DisplayActor | MiniProfileView | undefined,
+  did?: string,
+) {
+  const handle = normalizeHandle(actor?.handle);
+  return actor?.displayName || handle || did || "Unknown listener";
+}
+
+export function actorProfileHref(
+  actor: DisplayActor | MiniProfileView | undefined,
+  did?: string,
+) {
+  return normalizeHandle(actor?.handle) || actor?.did || did || "unknown";
+}
+
+export function actorAvatarUrl(
+  actor: DisplayActor | MiniProfileView | undefined,
+  did?: string,
+) {
+  const authorDid = actor?.did || did;
+  if (!authorDid || !actor?.avatar) return undefined;
+  return getProfileImageUrl(authorDid, actor.avatar, "avatar");
+}

--- a/todo.md
+++ b/todo.md
@@ -10,6 +10,8 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 - Cadet consumes Teal records from Jetstream, stores a durable cursor in Redis with file fallback, and ingests create, update, and delete events for profiles and plays.
 - The public Amethyst feed uses only live Aqua XRPC data. There is no seeded, mocked, demo, or backup play feed.
 - Amethyst Home includes a Teal social composer entry point. Signed-in users can open a modal, attach a song from MusicBrainz search or their indexed recent plays, write rich text, and publish `fm.teal.alpha.feed.social.post` records.
+- Amethyst social posts and recent listens merge indexed Teal actor data with Bluesky fallback handle/display-name/avatar data when the appview only has partial profile rows.
+- Amethyst profile images use the Bluesky CDN avatar/banner transforms for indexed Teal blob CIDs, and signed-in users can edit their Teal display name, bio, avatar, and banner from their own profile page.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
 - Missing Teal profiles fall back to public Bluesky profile data with an in-app disclaimer, and signed-in listeners can publish a Teal profile through the onboarding wizard.
 - Development and production Compose files include Amethyst, Aqua, Cadet, Satellite, Postgres, and Garnet.

--- a/todo.md
+++ b/todo.md
@@ -12,6 +12,7 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 - Amethyst Home includes a Teal social composer entry point. Signed-in users can open a modal, attach a song from MusicBrainz search or their indexed recent plays, write rich text, and publish `fm.teal.alpha.feed.social.post` records.
 - Amethyst social posts and recent listens merge indexed Teal actor data with Bluesky fallback handle/display-name/avatar data when the appview only has partial profile rows.
 - Amethyst profile images use the Bluesky CDN avatar/banner transforms for indexed Teal blob CIDs, and signed-in users can edit their Teal display name, bio, avatar, and banner from their own profile page.
+- Amethyst music track pretty URLs resolve from artist/release/track slugs when no play URI query string is present, instead of falling back to the latest global play.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
 - Missing Teal profiles fall back to public Bluesky profile data with an in-app disclaimer, and signed-in listeners can publish a Teal profile through the onboarding wizard.
 - Development and production Compose files include Amethyst, Aqua, Cadet, Satellite, Postgres, and Garnet.

--- a/todo.md
+++ b/todo.md
@@ -13,10 +13,10 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 - Missing Teal profiles fall back to public Bluesky profile data with an in-app disclaimer, and signed-in listeners can publish a Teal profile through the onboarding wizard.
 - Development and production Compose files include Amethyst, Aqua, Cadet, Satellite, Postgres, and Garnet.
 - Development Compose includes an optional Cloudflare Tunnel profile.
-- Current temporary UI preview: `https://directory-extensive-viewer-agreement.trycloudflare.com`
+- Current temporary UI preview: `https://architects-trips-sql-wildlife.trycloudflare.com`
   - This is an account-less Cloudflare quick tunnel. It remains available while the local tunnel process is running and its hostname will change after restart.
   - The preview serves the current Amethyst export and proxies `/xrpc/*` to the locally running Aqua API through the same public hostname.
-  - The current preview build embeds `EXPO_PUBLIC_BASE_URL=https://directory-extensive-viewer-agreement.trycloudflare.com` and serves a matching `/client-metadata.json` OAuth redirect.
+  - The current preview build embeds `EXPO_PUBLIC_BASE_URL=https://architects-trips-sql-wildlife.trycloudflare.com` and serves a matching `/client-metadata.json` OAuth redirect.
   - OAuth callback testing still requires the stable-host work below.
 
 ## Next: Public Demo And OAuth

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,7 @@ This file is the working handoff for the Teal-native Teal clone. Keep it updated
 - Aqua exposes Teal XRPC routes for cursor-paginated latest plays, individual plays, actor feeds, profiles, stats, indexed search, artist discographies, and albums with track lists plus cursor-paginated listens.
 - Cadet consumes Teal records from Jetstream, stores a durable cursor in Redis with file fallback, and ingests create, update, and delete events for profiles and plays.
 - The public Amethyst feed uses only live Aqua XRPC data. There is no seeded, mocked, demo, or backup play feed.
+- Amethyst Home includes a Teal social composer entry point. Signed-in users can open a modal, attach a song from MusicBrainz search or their indexed recent plays, write rich text, and publish `fm.teal.alpha.feed.social.post` records.
 - Live Jetstream ingestion has been verified end-to-end through Cadet, Postgres, Aqua, and the public preview URL.
 - Missing Teal profiles fall back to public Bluesky profile data with an in-app disclaimer, and signed-in listeners can publish a Teal profile through the onboarding wizard.
 - Development and production Compose files include Amethyst, Aqua, Cadet, Satellite, Postgres, and Garnet.


### PR DESCRIPTION
Add composer modal and profile editing. This groups the existing commits by chronology and the area they change.

Part 10 of 33 replacing #113. Review this PR against `feature/obbpr-09-social-interface`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 6ab03c9 docs(deploy): record cloudflare preview
- 23fa464 feat(amethyst): add social post creation modal
- 0d12a56 docs(todo): note social composer flow
- 948232f feat(amethyst): add profile editing and actor resolution
- 782e360 fix(amethyst): resolve music track slugs deterministically

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/203
- Next: https://github.com/teal-fm/teal/pull/205
- Full stack index: https://github.com/teal-fm/teal/pull/113
