### PR TITLE
[20/33] feat(teal): handle account lifecycle and profile top albums

### DIFF
--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -39,6 +39,7 @@ import {
   getGraphFollows,
   getGraphSummary,
   getProfile,
+  getUserTopReleases,
   getSocialFeed,
   coverArtUrl,
   displayArtists,
@@ -47,12 +48,14 @@ import {
   type SocialBadgeAssignmentView,
   type SocialPostView,
   type SocialPlaylistView,
+  type StatsPeriod,
   XrpcError,
 } from "@/lib/teal/api";
 import { useStore } from "@/stores/mainStore";
-import { playlistHref } from "@/lib/teal/routes";
+import { musicAlbumHref, playlistHref } from "@/lib/teal/routes";
 import type { AppBskyActorDefs } from "@atproto/api";
 import {
+  Disc3,
   Info,
   Pencil,
   UserMinus,
@@ -66,6 +69,7 @@ import type {
   ProfileView,
 } from "@teal/lexicons/src/types/fm/teal/alpha/actor/defs";
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+import type { ReleaseView } from "@teal/lexicons/src/types/fm/teal/alpha/stats/defs";
 
 type DisplayProfile = Pick<
   ProfileView,
@@ -106,6 +110,100 @@ function needsBlueskyFallback(profile: DisplayProfile) {
 
 function rkeyFromUri(uri?: string) {
   return uri?.split("/").pop();
+}
+
+function normalizeStatsPeriod(value?: string): StatsPeriod {
+  return ["7days", "30days", "90days", "180days", "365days", "all"].includes(
+    value || "",
+  )
+    ? (value as StatsPeriod)
+    : "90days";
+}
+
+function ProfileAlbumTile({
+  release,
+  index,
+}: {
+  release: ReleaseView;
+  index: number;
+}) {
+  const [failed, setFailed] = useState(false);
+  const art = failed ? undefined : coverArtUrl(release.mbid, 100);
+  const href = release.mbid
+    ? musicAlbumHref("music", release.name || "Unknown album", release.mbid)
+    : undefined;
+  const positions = [
+    { left: 4, top: 2, transform: [{ rotate: "-8deg" }] },
+    { left: 0, top: 76, transform: [{ rotate: "7deg" }] },
+    { right: 14, top: 0, transform: [{ rotate: "9deg" }] },
+    { right: 0, top: 82, transform: [{ rotate: "-6deg" }] },
+  ];
+  const content = (
+    <Pressable
+      accessibilityLabel={`${release.name || "Album"}: ${release.playCount || 0} plays`}
+      className="absolute h-14 w-14 items-center justify-center overflow-hidden rounded-md border-2 border-background bg-muted shadow-sm web:transition-transform web:hover:scale-105"
+      style={positions[index]}
+    >
+      {art ? (
+        <Image
+          source={{ uri: art }}
+          className="h-full w-full"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <Icon icon={Disc3} size={22} className="text-muted-foreground" />
+      )}
+    </Pressable>
+  );
+
+  return href ? (
+    <Link href={href as any} asChild>
+      {content}
+    </Link>
+  ) : (
+    content
+  );
+}
+
+function ProfileAvatarCluster({
+  avatarUrl,
+  fallback,
+  topReleases,
+}: {
+  avatarUrl?: string;
+  fallback: string;
+  topReleases: ReleaseView[];
+}) {
+  const albumTiles = topReleases.slice(0, 4);
+  const avatar = avatarUrl ? (
+    <Image
+      source={{ uri: avatarUrl }}
+      className="h-24 w-24 rounded-lg border-4 border-background bg-primary"
+    />
+  ) : (
+    <View className="h-24 w-24 items-center justify-center rounded-lg border-4 border-background bg-primary">
+      <Text className="text-4xl font-black text-primary-foreground">
+        {fallback.slice(0, 1)}
+      </Text>
+    </View>
+  );
+
+  if (albumTiles.length === 0) {
+    return avatar;
+  }
+
+  return (
+    <View className="relative h-36 w-56">
+      {albumTiles.map((release, index) => (
+        <ProfileAlbumTile
+          key={`${release.mbid || release.name}-${index}`}
+          release={release}
+          index={index}
+        />
+      ))}
+      <View className="absolute left-[4.25rem] top-5">{avatar}</View>
+    </View>
+  );
 }
 
 function GraphActorRow({ actor }: { actor: MiniProfileView }) {
@@ -175,6 +273,7 @@ export default function ProfileScreen() {
   const [profile, setProfile] = useState<DisplayProfile | null>(null);
   const [badges, setBadges] = useState<SocialBadgeAssignmentView[]>([]);
   const [playlists, setPlaylists] = useState<SocialPlaylistView[]>([]);
+  const [topReleases, setTopReleases] = useState<ReleaseView[]>([]);
   const [graphSummary, setGraphSummary] = useState<GraphSummaryView>({
     followersCount: 0,
     followsCount: 0,
@@ -205,6 +304,7 @@ export default function ProfileScreen() {
         setProfile(null);
         setBadges([]);
         setPlaylists([]);
+        setTopReleases([]);
         setGraphSummary({ followersCount: 0, followsCount: 0 });
         setFollowers([]);
         setFollows([]);
@@ -284,9 +384,18 @@ export default function ProfileScreen() {
         }
 
         if (!mounted) return;
+        const topReleaseRes = await getUserTopReleases(
+          resolved,
+          normalizeStatsPeriod(nextProfile?.statsDefaultPeriod),
+          4,
+        ).catch(() => ({
+          releases: [],
+        }));
+        if (!mounted) return;
         setProfile(nextProfile);
         setBadges(badgeRes.items);
         setPlaylists(playlistRes.items);
+        setTopReleases(topReleaseRes.releases);
         setGraphSummary(graphSummaryRes);
         setFollowers(followersRes.actors);
         setFollows(followsRes.actors);
@@ -414,19 +523,12 @@ export default function ProfileScreen() {
               )}
             </View>
             <View className="-mt-12 px-6 pb-6">
-              {avatarUrl ? (
-                <Image
-                  source={{ uri: avatarUrl }}
-                  className="h-24 w-24 rounded-lg border-4 border-background bg-primary"
-                />
-              ) : (
-                <View className="h-24 w-24 items-center justify-center rounded-lg border-4 border-background bg-primary">
-                  <Text className="text-4xl font-black text-primary-foreground">
-                    {(profile?.displayName || actor || "T").slice(0, 1)}
-                  </Text>
-                </View>
-              )}
-              <Text className="mt-3 font-sans text-3xl font-black">
+              <ProfileAvatarCluster
+                avatarUrl={avatarUrl}
+                fallback={profile?.displayName || actor || "T"}
+                topReleases={topReleases}
+              />
+              <Text className="mt-1 font-sans text-3xl font-black">
                 {profile?.displayName || actor}
               </Text>
               {profile?.handle && (

--- a/migrations/20241220000016_account_lifecycle.sql
+++ b/migrations/20241220000016_account_lifecycle.sql
@@ -1,0 +1,13 @@
+-- Track upstream ATProto account hosting state observed by Cadet.
+
+CREATE TABLE account_states (
+    did TEXT PRIMARY KEY,
+    active BOOLEAN NOT NULL,
+    status TEXT,
+    event_time TIMESTAMP WITH TIME ZONE,
+    seq BIGINT,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_account_states_active ON account_states (active);
+CREATE INDEX idx_account_states_status ON account_states (status);

--- a/services/cadet/src/account.rs
+++ b/services/cadet/src/account.rs
@@ -1,0 +1,401 @@
+use serde::Deserialize;
+use sqlx::{PgPool, Postgres, Transaction};
+use tracing::info;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum EventKind {
+    Account,
+    Commit,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountEnvelope {
+    did: String,
+    kind: EventKind,
+    account: Option<AccountDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountDetails {
+    active: bool,
+    status: Option<String>,
+    seq: Option<i64>,
+    time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitEnvelope {
+    did: String,
+    kind: EventKind,
+}
+
+pub async fn ingest_account_event(pool: &PgPool, text: &str) -> anyhow::Result<bool> {
+    if text.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let envelope: AccountEnvelope = serde_json::from_str(text)?;
+    if envelope.kind != EventKind::Account {
+        return Ok(false);
+    }
+
+    let Some(account) = envelope.account else {
+        return Ok(false);
+    };
+
+    upsert_account_state(pool, &envelope.did, &account).await?;
+    if !account.active {
+        purge_indexed_account_data(pool, &envelope.did).await?;
+    }
+
+    info!(
+        "Indexed account lifecycle event for {}: active={}, status={:?}",
+        envelope.did, account.active, account.status
+    );
+    Ok(true)
+}
+
+pub async fn should_ingest_commit(pool: &PgPool, text: &str) -> anyhow::Result<bool> {
+    if text.trim().is_empty() {
+        return Ok(true);
+    }
+
+    let envelope: CommitEnvelope = serde_json::from_str(text)?;
+    if envelope.kind != EventKind::Commit {
+        return Ok(true);
+    }
+
+    let active = sqlx::query_scalar::<_, bool>(
+        r#"
+            SELECT COALESCE(
+                (SELECT active FROM account_states WHERE did = $1),
+                TRUE
+            )
+        "#,
+    )
+    .bind(&envelope.did)
+    .fetch_one(pool)
+    .await?;
+
+    if !active {
+        info!("Skipping commit from inactive account {}", envelope.did);
+    }
+    Ok(active)
+}
+
+async fn upsert_account_state(
+    pool: &PgPool,
+    did: &str,
+    account: &AccountDetails,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+            INSERT INTO account_states (did, active, status, event_time, seq)
+            VALUES ($1, $2, $3, $4::timestamptz, $5)
+            ON CONFLICT (did) DO UPDATE SET
+                active = EXCLUDED.active,
+                status = EXCLUDED.status,
+                event_time = EXCLUDED.event_time,
+                seq = EXCLUDED.seq,
+                updated_at = NOW()
+        "#,
+    )
+    .bind(did)
+    .bind(account.active)
+    .bind(account.status.as_deref())
+    .bind(account.time.as_deref())
+    .bind(account.seq)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn purge_indexed_account_data(pool: &PgPool, did: &str) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+
+    delete_plays(&mut tx, did).await?;
+    delete_profile_records(&mut tx, did).await?;
+    delete_social_records(&mut tx, did).await?;
+
+    tx.commit().await?;
+    info!("Purged indexed records for inactive account {}", did);
+    Ok(())
+}
+
+async fn delete_plays(tx: &mut Transaction<'_, Postgres>, did: &str) -> anyhow::Result<()> {
+    let play_uris = sqlx::query_scalar::<_, String>("SELECT uri FROM plays WHERE did = $1")
+        .bind(did)
+        .fetch_all(&mut **tx)
+        .await?;
+
+    if play_uris.is_empty() {
+        return Ok(());
+    }
+
+    sqlx::query("DELETE FROM play_to_artists_extended WHERE play_uri = ANY($1)")
+        .bind(&play_uris)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM play_to_artists WHERE play_uri = ANY($1)")
+        .bind(&play_uris)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM plays WHERE uri = ANY($1)")
+        .bind(&play_uris)
+        .execute(&mut **tx)
+        .await?;
+
+    Ok(())
+}
+
+async fn delete_profile_records(
+    tx: &mut Transaction<'_, Postgres>,
+    did: &str,
+) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM featured_items WHERE did = $1")
+        .bind(did)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM profile_statuses WHERE did = $1")
+        .bind(did)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM statii WHERE did = $1")
+        .bind(did)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM profiles WHERE did = $1")
+        .bind(did)
+        .execute(&mut **tx)
+        .await?;
+
+    Ok(())
+}
+
+async fn delete_social_records(
+    tx: &mut Transaction<'_, Postgres>,
+    did: &str,
+) -> anyhow::Result<()> {
+    let mut record_uris = Vec::new();
+    record_uris.extend(fetch_uris(tx, "social_posts", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_likes", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_reposts", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_follows", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_playlists", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_playlist_items", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_badges", did).await?);
+    record_uris.extend(fetch_uris(tx, "social_badge_assignments", did).await?);
+
+    let reply_subjects =
+        fetch_optional_subject_uris(tx, "social_posts", "reply_parent_uri", did).await?;
+    let like_subjects = fetch_subject_uris(tx, "social_likes", "subject_uri", did).await?;
+    let repost_subjects = fetch_subject_uris(tx, "social_reposts", "subject_uri", did).await?;
+    let playlist_subjects =
+        fetch_subject_uris(tx, "social_playlist_items", "playlist_uri", did).await?;
+
+    delete_by_did(tx, "social_badge_assignments", did).await?;
+    delete_by_did(tx, "social_badges", did).await?;
+    delete_by_did(tx, "social_playlist_items", did).await?;
+    delete_by_did(tx, "social_playlists", did).await?;
+    delete_by_did(tx, "social_reposts", did).await?;
+    delete_by_did(tx, "social_likes", did).await?;
+    delete_by_did(tx, "social_posts", did).await?;
+    delete_by_did(tx, "social_follows", did).await?;
+
+    decrement_subject_counts(tx, &reply_subjects, "reply_count").await?;
+    decrement_subject_counts(tx, &like_subjects, "like_count").await?;
+    decrement_subject_counts(tx, &repost_subjects, "repost_count").await?;
+    decrement_subject_counts(tx, &playlist_subjects, "playlist_item_count").await?;
+
+    if !record_uris.is_empty() {
+        sqlx::query("DELETE FROM indexed_record_facets WHERE record_uri = ANY($1)")
+            .bind(&record_uris)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query("DELETE FROM indexed_record_blobs WHERE record_uri = ANY($1)")
+            .bind(&record_uris)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query(
+            r#"
+                DELETE FROM social_notifications
+                WHERE record_uri = ANY($1)
+                   OR actor_did = $2
+                   OR recipient_did = $2
+            "#,
+        )
+        .bind(&record_uris)
+        .bind(did)
+        .execute(&mut **tx)
+        .await?;
+    } else {
+        sqlx::query("DELETE FROM social_notifications WHERE actor_did = $1 OR recipient_did = $1")
+            .bind(did)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_uris(
+    tx: &mut Transaction<'_, Postgres>,
+    table: &str,
+    did: &str,
+) -> anyhow::Result<Vec<String>> {
+    let sql = format!("SELECT uri FROM {table} WHERE did = $1");
+    Ok(sqlx::query_scalar::<_, String>(&sql)
+        .bind(did)
+        .fetch_all(&mut **tx)
+        .await?)
+}
+
+async fn fetch_subject_uris(
+    tx: &mut Transaction<'_, Postgres>,
+    table: &str,
+    column: &str,
+    did: &str,
+) -> anyhow::Result<Vec<String>> {
+    let sql = format!("SELECT {column} FROM {table} WHERE did = $1");
+    Ok(sqlx::query_scalar::<_, String>(&sql)
+        .bind(did)
+        .fetch_all(&mut **tx)
+        .await?)
+}
+
+async fn fetch_optional_subject_uris(
+    tx: &mut Transaction<'_, Postgres>,
+    table: &str,
+    column: &str,
+    did: &str,
+) -> anyhow::Result<Vec<String>> {
+    let sql = format!("SELECT {column} FROM {table} WHERE did = $1 AND {column} IS NOT NULL");
+    Ok(sqlx::query_scalar::<_, String>(&sql)
+        .bind(did)
+        .fetch_all(&mut **tx)
+        .await?)
+}
+
+async fn delete_by_did(
+    tx: &mut Transaction<'_, Postgres>,
+    table: &str,
+    did: &str,
+) -> anyhow::Result<()> {
+    let sql = format!("DELETE FROM {table} WHERE did = $1");
+    sqlx::query(&sql).bind(did).execute(&mut **tx).await?;
+    Ok(())
+}
+
+async fn decrement_subject_counts(
+    tx: &mut Transaction<'_, Postgres>,
+    subject_uris: &[String],
+    column: &str,
+) -> anyhow::Result<()> {
+    for subject_uri in subject_uris {
+        let sql = format!(
+            r#"
+                INSERT INTO social_subject_counts (subject_uri, {column})
+                VALUES ($1, 0)
+                ON CONFLICT (subject_uri) DO UPDATE SET
+                    {column} = GREATEST(social_subject_counts.{column} - 1, 0),
+                    updated_at = NOW()
+            "#
+        );
+        sqlx::query(&sql)
+            .bind(subject_uri)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_active_account_event() {
+        let envelope: AccountEnvelope = serde_json::from_str(
+            r#"{
+                "did": "did:plc:listener",
+                "time_us": 1,
+                "kind": "account",
+                "account": {
+                    "active": true,
+                    "did": "did:plc:listener",
+                    "seq": 10,
+                    "time": "2026-06-05T00:00:00Z"
+                }
+            }"#,
+        )
+        .expect("account event parses");
+
+        let account = envelope.account.expect("account details");
+        assert_eq!(envelope.kind, EventKind::Account);
+        assert!(account.active);
+        assert_eq!(account.status, None);
+    }
+
+    #[test]
+    fn parses_inactive_account_event_status() {
+        let envelope: AccountEnvelope = serde_json::from_str(
+            r#"{
+                "did": "did:plc:listener",
+                "time_us": 1,
+                "kind": "account",
+                "account": {
+                    "active": false,
+                    "did": "did:plc:listener",
+                    "seq": 11,
+                    "status": "takendown",
+                    "time": "2026-06-05T00:00:00Z"
+                }
+            }"#,
+        )
+        .expect("account event parses");
+
+        let account = envelope.account.expect("account details");
+        assert!(!account.active);
+        assert_eq!(account.status.as_deref(), Some("takendown"));
+    }
+
+    #[test]
+    fn parses_commit_envelope() {
+        let envelope: CommitEnvelope = serde_json::from_str(
+            r#"{
+                "did": "did:plc:listener",
+                "time_us": 1,
+                "kind": "commit",
+                "commit": {
+                    "rev": "3k",
+                    "operation": "delete",
+                    "collection": "fm.teal.alpha.feed.play",
+                    "rkey": "3k"
+                }
+            }"#,
+        )
+        .expect("commit event parses");
+
+        assert_eq!(envelope.kind, EventKind::Commit);
+    }
+
+    #[test]
+    fn treats_old_tombstone_kind_as_other() {
+        let envelope: AccountEnvelope = serde_json::from_str(
+            r#"{
+                "did": "did:plc:listener",
+                "time_us": 1,
+                "kind": "tombstone"
+            }"#,
+        )
+        .expect("legacy event parses");
+
+        assert_eq!(envelope.kind, EventKind::Other);
+        assert!(envelope.account.is_none());
+    }
+}

--- a/services/cadet/src/identity.rs
+++ b/services/cadet/src/identity.rs
@@ -16,6 +16,10 @@ struct IdentityEnvelope {
 }
 
 pub async fn ingest_identity_event(pool: &PgPool, text: &str) -> anyhow::Result<bool> {
+    if text.trim().is_empty() {
+        return Ok(false);
+    }
+
     let envelope: IdentityEnvelope = serde_json::from_str(text)?;
     if !matches!(&envelope.kind, Kind::Identity) {
         return Ok(false);

--- a/services/cadet/src/lib.rs
+++ b/services/cadet/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod cursor;
 pub mod db;
 pub mod identity;

--- a/services/cadet/src/main.rs
+++ b/services/cadet/src/main.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use cadet::{
+    account,
     cursor::{self, resolve_startup_cursor},
     db, identity, ingestors, redis_client, teal_ingestors,
 };
@@ -242,6 +243,14 @@ async fn main() {
             if let Ok(text) = message.to_text() {
                 if let Err(e) = identity::ingest_identity_event(&pool, text).await {
                     error!("Error processing identity event: {}", e);
+                }
+                if let Err(e) = account::ingest_account_event(&pool, text).await {
+                    error!("Error processing account event: {}", e);
+                }
+                match account::should_ingest_commit(&pool, text).await {
+                    Ok(false) => continue,
+                    Ok(true) => {}
+                    Err(e) => error!("Error checking account state: {}", e),
                 }
             }
             if let Err(e) =

--- a/todo.md
+++ b/todo.md
@@ -15,9 +15,10 @@ Last synced with GitHub and Linear issues: 2026-06-14.
 ## Local Open Work
 
 - [ ] Complete ATProto OAuth sign-in and callback QA through `https://sigilyph.teal.fm`.
-- [ ] Drain the in-flight CAR import backfill queue for users with stale ingestion from the 2026-06-07 through 2026-06-10 Cadet outage. Track via Redis `LLEN car_import_jobs` and Cadet logs.
-- [ ] Backfill the 381 current `fm.teal.alpha.feed.play` records present in `did:plc:tas6hj2xjrqben5653v5kohk`'s PDS repo but missing from the preview Postgres index. URI-set comparison on 2026-06-11 showed 10,193 repo records, 9,812 indexed DB rows, and no stale extra DB URIs.
-- [ ] Handle Jetstream account lifecycle events in Cadet, including deletes, takedowns, suspensions, activations, and tombstones. Decide how each state should affect indexed profiles, social records, and plays.
+  - Verified on 2026-06-15 that `https://sigilyph.teal.fm/client-metadata.json` serves the stable-origin `client_id` and callback URI, and that same-origin latest plays XRPC returns live data. Remaining QA requires an interactive ATProto login/callback with a real account session.
+- [x] Drain the in-flight CAR import backfill queue for users with stale ingestion from the 2026-06-07 through 2026-06-10 Cadet outage. Redis/Garnet `LLEN car_import_jobs` returned `0` on 2026-06-14, local Cadet was running, and recent Cadet logs showed no CAR import job failures.
+- [x] Backfill the `fm.teal.alpha.feed.play` records present in `did:plc:tas6hj2xjrqben5653v5kohk`'s PDS repo but missing from the preview Postgres index. A focused CAR backfill completed on 2026-06-15 via `lightrail-backfill`; the preview index now has 10,215 plays for that DID, up from 10,172 immediately before the run and above the older 10,193-record comparison from 2026-06-11.
+- [x] Handle Jetstream account lifecycle events in Cadet, including deletes, takedowns, suspensions, activations, and tombstones. Cadet now tracks upstream account state, purges indexed public profile/social/play rows when an account becomes inactive, treats activation as the gate for future commit ingestion, and ignores legacy tombstone event kinds because modern Jetstream/account-hosting statuses replace them.
 
 ## Tracker Issues
 
@@ -25,21 +26,25 @@ Last synced with GitHub and Linear issues: 2026-06-14.
   - Linear: `Backlog`, no priority
   - Create Popfeed records when a listener plays a track or album for the first time.
   - Consider follow-on flows for completing Popfeed reviews of songs and albums from Teal.
-- [ ] [#57](https://github.com/teal-fm/teal/issues/57) / [TEAL-30](https://linear.app/tealfm/issue/TEAL-30/top-albums-around-profile-pic) top albums around profile pic
+  - Blocked locally: no Popfeed lexicons, service endpoint, auth flow, or record schema are present in this repo yet.
+- [x] [#57](https://github.com/teal-fm/teal/issues/57) / [TEAL-30](https://linear.app/tealfm/issue/TEAL-30/top-albums-around-profile-pic) top albums around profile pic
   - Linear: `In Progress`, low priority
   - Labels: `API`, `Frontend`, `Legacy Songish Feature`
   - Assignee: `mmattbtw`
+  - Done in Amethyst profile headers: top releases for the profile's default stats period render as linked cover tiles around the avatar, with desktop and mobile visual QA against live preview data.
 - [ ] [#29](https://github.com/teal-fm/teal/issues/29) / [TEAL-21](https://linear.app/tealfm/issue/TEAL-21/mass-editing-scrobbles) mass editing scrobbles
   - Linear: `Backlog`, low priority
   - Labels: `Improvement`, `API`
+  - Implementation note: Cadet already reindexes updated `fm.teal.alpha.feed.play` records and deletes tombstoned plays. Remaining work is authenticated Amethyst/Aqua product flow for selecting multiple records and writing `putRecord`/`deleteRecord` changes to the user's PDS.
 - [ ] [#28](https://github.com/teal-fm/teal/issues/28) / [TEAL-20](https://linear.app/tealfm/issue/TEAL-20/editing-scrobbles) editing scrobbles
   - Linear: `Todo`, medium priority
   - Labels: `Feature`, `API`
-- [ ] [#16](https://github.com/teal-fm/teal/issues/16) / [TEAL-16](https://linear.app/tealfm/issue/TEAL-16/live-scrobble-view) Live Scrobble View
+  - Implementation note: single-play edits can build on the existing Cadet upsert path; still needs authenticated UI/API design for loading the original record, editing fields, and writing it back to the PDS.
+- [x] [#16](https://github.com/teal-fm/teal/issues/16) / [TEAL-16](https://linear.app/tealfm/issue/TEAL-16/live-scrobble-view) Live Scrobble View
   - Linear: `Todo`, low priority
   - Labels: `Frontend`
   - Assignee: `mmattbtw`
-  - Build a live feed of scrobbles from everyone.
+  - Done in Amethyst Home: the `Listens` feed uses Aqua `fm.teal.alpha.stats.getLatest`, supports cursor loading, and shows only live indexed records.
 
 ## Verification Commands
 


### PR DESCRIPTION
Handle account lifecycle and profile top albums. This groups the existing commits by chronology and the area they change.

Part 20 of 33 replacing #113. Review this PR against `feature/obbpr-19-profile-posts`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 0b0d73d feat(teal): complete account lifecycle and profile album todos

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/213
- Next: https://github.com/teal-fm/teal/pull/215
- Full stack index: https://github.com/teal-fm/teal/pull/113
