### PR TITLE
[21/33] feat(amethyst): add individual and bulk scrobble editing

### DIFF
--- a/apps/amethyst/app/(tabs)/listen/[did]/[rkey].tsx
+++ b/apps/amethyst/app/(tabs)/listen/[did]/[rkey].tsx
@@ -5,6 +5,7 @@ import PlayFeedCard, { musicHref } from "@/components/teal/PlayFeedCard";
 import RightRail from "@/components/teal/RightRail";
 import TealShell, { SectionHeading } from "@/components/teal/TealShell";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import {
@@ -19,8 +20,25 @@ import {
   getCachedBlueskyProfile,
   type DisplayActor,
 } from "@/lib/teal/actors";
+import {
+  applyEditableFields,
+  artistTextFromRecord,
+  deletePlayRecord,
+  loadPlayRecord,
+  putPlayRecord,
+  type EditablePlayRecord,
+} from "@/lib/teal/playRecords";
 import { timeAgo } from "@/lib/utils";
-import { Disc3, ExternalLink, UserRound } from "lucide-react-native";
+import { useStore } from "@/stores/mainStore";
+import {
+  Disc3,
+  ExternalLink,
+  Pencil,
+  Save,
+  Trash2,
+  UserRound,
+  X,
+} from "lucide-react-native";
 
 import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
 
@@ -33,6 +51,19 @@ export default function ListenDetail() {
   const [recordingArt, setRecordingArt] = useState<string>();
   const [artFailed, setArtFailed] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deleted, setDeleted] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [sourceRecord, setSourceRecord] = useState<EditablePlayRecord | null>(
+    null,
+  );
+  const [swapRecord, setSwapRecord] = useState<string>();
+  const [trackName, setTrackName] = useState("");
+  const [artistsText, setArtistsText] = useState("");
+  const [releaseName, setReleaseName] = useState("");
+  const [playedTime, setPlayedTime] = useState("");
+  const [editBusy, setEditBusy] = useState(false);
+  const [deleteArmed, setDeleteArmed] = useState(false);
+  const agent = useStore((state) => state.pdsAgent);
 
   useEffect(() => {
     let mounted = true;
@@ -40,6 +71,7 @@ export default function ListenDetail() {
       if (!did || !rkey) return;
       try {
         setError(null);
+        setDeleted(false);
         const response = await getPlayByAuthorRkey(did, rkey);
         if (mounted) setPlay(response.play);
       } catch (e) {
@@ -72,6 +104,85 @@ export default function ListenDetail() {
     : play
       ? "recently"
       : "";
+  const canManage = !!agent?.did && !!did && agent.did === did && !!rkey;
+
+  async function openEditor() {
+    if (!agent || !did || !rkey || !play) return;
+    setEditBusy(true);
+    setError(null);
+    try {
+      const loaded = await loadPlayRecord(agent, did, rkey, play);
+      setSourceRecord(loaded.record);
+      setSwapRecord(loaded.swapRecord);
+      setTrackName(loaded.record.trackName);
+      setArtistsText(artistTextFromRecord(loaded.record));
+      setReleaseName(loaded.record.releaseName || "");
+      setPlayedTime(
+        loaded.record.playedTime
+          ? loaded.record.playedTime.slice(0, 16)
+          : "",
+      );
+      setDeleteArmed(false);
+      setEditOpen(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setEditBusy(false);
+    }
+  }
+
+  async function saveEdit() {
+    if (!agent || !did || !rkey || !sourceRecord) return;
+    setEditBusy(true);
+    setError(null);
+    try {
+      const record = applyEditableFields(sourceRecord, {
+        trackName,
+        artistsText,
+        releaseName,
+        playedTime,
+      });
+      await putPlayRecord(agent, did, rkey, record, swapRecord);
+      setSourceRecord(record);
+      setSwapRecord(undefined);
+      setPlay((current) =>
+        current
+          ? {
+              ...current,
+              trackName: record.trackName,
+              artists: record.artists || [],
+              releaseName: record.releaseName,
+              playedTime: record.playedTime,
+            }
+          : current,
+      );
+      setEditOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setEditBusy(false);
+    }
+  }
+
+  async function deleteListen() {
+    if (!agent || !did || !rkey) return;
+    if (!deleteArmed) {
+      setDeleteArmed(true);
+      return;
+    }
+    setEditBusy(true);
+    setError(null);
+    try {
+      await deletePlayRecord(agent, did, rkey);
+      setPlay(null);
+      setDeleted(true);
+      setEditOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setEditBusy(false);
+    }
+  }
 
   useEffect(() => {
     let mounted = true;
@@ -109,9 +220,20 @@ export default function ListenDetail() {
       <Stack.Screen
         options={{ title: play?.trackName || "Listen", headerShown: false }}
       />
-      {!play && !error && (
+      {!play && !error && !deleted && (
         <View className="min-h-[24rem] items-center justify-center">
           <ActivityIndicator size="large" />
+        </View>
+      )}
+      {deleted && (
+        <View className="rounded-lg border border-border bg-card p-6">
+          <Text className="font-sans text-2xl font-black">
+            Listen deleted.
+          </Text>
+          <Text className="mt-2 text-muted-foreground">
+            Cadet will remove it from public feeds after the PDS update is
+            indexed.
+          </Text>
         </View>
       )}
       {error && (
@@ -182,12 +304,107 @@ export default function ListenDetail() {
                     <Text>Song page</Text>
                   </Button>
                 </Link>
+                {canManage && (
+                  <Button
+                    variant="outline"
+                    className="flex-row gap-2"
+                    disabled={editBusy}
+                    onPress={openEditor}
+                  >
+                    <Icon icon={Pencil} size={16} />
+                    <Text>Edit listen</Text>
+                  </Button>
+                )}
               </View>
 
               <Text className="mt-4 text-sm text-muted-foreground">
                 {authorName} listened {when}
                 {play.releaseName ? ` from ${play.releaseName}` : ""}.
               </Text>
+
+              {editOpen && canManage && (
+                <View className="mt-5 gap-3 rounded-lg border border-border bg-background p-4">
+                  <View className="flex-row items-start justify-between gap-3">
+                    <View className="min-w-0 flex-1">
+                      <Text className="font-mono text-xs uppercase text-muted-foreground">
+                        Edit record
+                      </Text>
+                      <Text className="font-bold">
+                        Changes are written to your PDS and reindexed by Cadet.
+                      </Text>
+                    </View>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      disabled={editBusy}
+                      onPress={() => setEditOpen(false)}
+                    >
+                      <Icon icon={X} size={18} />
+                    </Button>
+                  </View>
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Track
+                    </Text>
+                    <Input
+                      value={trackName}
+                      onChangeText={setTrackName}
+                      editable={!editBusy}
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Artists
+                    </Text>
+                    <Input
+                      value={artistsText}
+                      onChangeText={setArtistsText}
+                      editable={!editBusy}
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Release
+                    </Text>
+                    <Input
+                      value={releaseName}
+                      onChangeText={setReleaseName}
+                      editable={!editBusy}
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Played time
+                    </Text>
+                    <Input
+                      value={playedTime}
+                      onChangeText={setPlayedTime}
+                      editable={!editBusy}
+                      inputMode="text"
+                      placeholder="2026-06-15T12:30"
+                    />
+                  </View>
+                  <View className="flex-row flex-wrap gap-2">
+                    <Button
+                      className="flex-row gap-2"
+                      disabled={editBusy}
+                      onPress={saveEdit}
+                    >
+                      <Icon icon={Save} size={16} />
+                      <Text>Save listen</Text>
+                    </Button>
+                    <Button
+                      variant={deleteArmed ? "destructive" : "outline"}
+                      className="flex-row gap-2"
+                      disabled={editBusy}
+                      onPress={deleteListen}
+                    >
+                      <Icon icon={Trash2} size={16} />
+                      <Text>{deleteArmed ? "Confirm delete" : "Delete"}</Text>
+                    </Button>
+                  </View>
+                </View>
+              )}
             </View>
           </View>
 

--- a/apps/amethyst/app/(tabs)/playlist/[name].tsx
+++ b/apps/amethyst/app/(tabs)/playlist/[name].tsx
@@ -109,7 +109,7 @@ export default function PlaylistDetailScreen() {
         ),
       );
       if (!authors.includes(playlist.authorDid)) authors.unshift(playlist.authorDid);
-      const current = await pdsAgent
+      const current: { cover?: unknown } = await pdsAgent
         .call("com.atproto.repo.getRecord", {
           repo: playlist.authorDid,
           collection: "fm.teal.alpha.feed.social.playlist",

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -18,6 +18,7 @@ import TealShell, {
   SectionHeading,
 } from "@/components/teal/TealShell";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import { resolveHandle } from "@/lib/atp/pid";
 import { Icon } from "@/lib/icons/iconWithClassName";
@@ -51,13 +52,23 @@ import {
   type StatsPeriod,
   XrpcError,
 } from "@/lib/teal/api";
+import {
+  artistsFromText,
+  deletePlayRecord,
+  loadPlayRecord,
+  putPlayRecord,
+} from "@/lib/teal/playRecords";
 import { useStore } from "@/stores/mainStore";
 import { musicAlbumHref, playlistHref } from "@/lib/teal/routes";
 import type { AppBskyActorDefs } from "@atproto/api";
 import {
+  CheckSquare,
   Disc3,
   Info,
   Pencil,
+  Save,
+  Square,
+  Trash2,
   UserMinus,
   UserPlus,
   UserRoundPlus,
@@ -287,6 +298,14 @@ export default function ProfileScreen() {
   const [plays, setPlays] = useState<PlayView[]>([]);
   const [followBusy, setFollowBusy] = useState(false);
   const [editProfileOpen, setEditProfileOpen] = useState(false);
+  const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [selectedPlayRkeys, setSelectedPlayRkeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [bulkArtistsText, setBulkArtistsText] = useState("");
+  const [bulkReleaseName, setBulkReleaseName] = useState("");
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkDeleteArmed, setBulkDeleteArmed] = useState(false);
   const [isBlueskyFallback, setIsBlueskyFallback] = useState(false);
   const [statusRecordingArt, setStatusRecordingArt] = useState<string>();
   const [statusArtFailed, setStatusArtFailed] = useState(false);
@@ -310,6 +329,11 @@ export default function ProfileScreen() {
         setFollows([]);
         setPosts([]);
         setPlays([]);
+        setSelectedPlayRkeys(new Set());
+        setBulkEditOpen(false);
+        setBulkDeleteArmed(false);
+        setBulkArtistsText("");
+        setBulkReleaseName("");
         const resolved = actor.startsWith("did:")
           ? actor
           : await resolveHandle(actor);
@@ -413,6 +437,7 @@ export default function ProfileScreen() {
   }, [actor, pdsAgent?.did]);
 
   const isSelf = did === pdsAgent?.did;
+  const selectedPlayCount = selectedPlayRkeys.size;
   const viewerFollowing = graphSummary.viewerFollowing;
   const canFollow = authStatus === "loggedIn" && !!pdsAgent?.did && !!did;
   async function toggleFollow() {
@@ -461,6 +486,110 @@ export default function ProfileScreen() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setFollowBusy(false);
+    }
+  }
+
+  function toggleBulkEdit() {
+    setBulkEditOpen((current) => !current);
+    setSelectedPlayRkeys(new Set());
+    setBulkDeleteArmed(false);
+    setBulkArtistsText("");
+    setBulkReleaseName("");
+  }
+
+  function togglePlaySelection(rkey?: string) {
+    if (!rkey || bulkBusy) return;
+    setBulkDeleteArmed(false);
+    setSelectedPlayRkeys((current) => {
+      const next = new Set(current);
+      if (next.has(rkey)) {
+        next.delete(rkey);
+      } else {
+        next.add(rkey);
+      }
+      return next;
+    });
+  }
+
+  function selectVisiblePlays() {
+    setBulkDeleteArmed(false);
+    const visibleRkeys = plays
+      .slice(0, 10)
+      .map((play) => play.rkey)
+      .filter((rkey): rkey is string => !!rkey);
+    setSelectedPlayRkeys(new Set(visibleRkeys));
+  }
+
+  async function deleteSelectedPlays() {
+    if (!pdsAgent?.did || !did || selectedPlayCount === 0 || bulkBusy) return;
+    if (!bulkDeleteArmed) {
+      setBulkDeleteArmed(true);
+      return;
+    }
+    setBulkBusy(true);
+    setError(null);
+    try {
+      const rkeys = Array.from(selectedPlayRkeys);
+      for (const selectedRkey of rkeys) {
+        await deletePlayRecord(pdsAgent, did, selectedRkey);
+      }
+      setPlays((current) =>
+        current.filter((play) => !play.rkey || !selectedPlayRkeys.has(play.rkey)),
+      );
+      setSelectedPlayRkeys(new Set());
+      setBulkDeleteArmed(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function updateSelectedPlays() {
+    if (!pdsAgent?.did || !did || selectedPlayCount === 0 || bulkBusy) return;
+    const nextArtists = bulkArtistsText.trim();
+    const nextRelease = bulkReleaseName.trim();
+    if (!nextArtists && !nextRelease) {
+      setError("Enter artists or release text before applying a bulk edit.");
+      return;
+    }
+
+    setBulkBusy(true);
+    setError(null);
+    try {
+      const selected = new Set(selectedPlayRkeys);
+      for (const selectedRkey of selected) {
+        const loaded = await loadPlayRecord(pdsAgent, did, selectedRkey);
+        await putPlayRecord(
+          pdsAgent,
+          did,
+          selectedRkey,
+          {
+            ...loaded.record,
+            ...(nextArtists ? { artists: artistsFromText(nextArtists) } : {}),
+            ...(nextRelease ? { releaseName: nextRelease } : {}),
+          },
+          loaded.swapRecord,
+        );
+      }
+      setPlays((current) =>
+        current.map((play) => {
+          if (!play.rkey || !selected.has(play.rkey)) return play;
+          return {
+            ...play,
+            ...(nextArtists ? { artists: artistsFromText(nextArtists) } : {}),
+            ...(nextRelease ? { releaseName: nextRelease } : {}),
+          };
+        }),
+      );
+      setSelectedPlayRkeys(new Set());
+      setBulkArtistsText("");
+      setBulkReleaseName("");
+      setBulkDeleteArmed(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBulkBusy(false);
     }
   }
   const avatarUrl = did
@@ -686,17 +815,134 @@ export default function ProfileScreen() {
             )}
           </View>
           <View className="mb-8">
-            <SectionHeading eyebrow="Listening history" title="Recent plays" />
+            <View className="mb-3 flex-row flex-wrap items-center justify-between gap-3">
+              <SectionHeading
+                eyebrow="Listening history"
+                title="Recent plays"
+              />
+              {isSelf && plays.length > 0 && (
+                <Button
+                  variant={bulkEditOpen ? "default" : "outline"}
+                  className="flex-row gap-2 self-start"
+                  disabled={bulkBusy}
+                  onPress={toggleBulkEdit}
+                >
+                  <Icon
+                    icon={bulkEditOpen ? CheckSquare : Square}
+                    size={16}
+                  />
+                  <Text>{bulkEditOpen ? "Done selecting" : "Select plays"}</Text>
+                </Button>
+              )}
+            </View>
+            {bulkEditOpen && isSelf && (
+              <View className="mb-4 gap-3 rounded-lg border border-border bg-white/70 p-4">
+                <View className="flex-row flex-wrap items-center justify-between gap-3">
+                  <View>
+                    <Text className="font-bold">
+                      {selectedPlayCount} selected
+                    </Text>
+                    <Text className="text-sm text-muted-foreground">
+                      Bulk actions write directly to your PDS.
+                    </Text>
+                  </View>
+                  <View className="flex-row flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={bulkBusy}
+                      onPress={selectVisiblePlays}
+                    >
+                      <Text>Select visible</Text>
+                    </Button>
+                    <Button
+                      variant={bulkDeleteArmed ? "destructive" : "outline"}
+                      size="sm"
+                      className="flex-row gap-2"
+                      disabled={bulkBusy || selectedPlayCount === 0}
+                      onPress={deleteSelectedPlays}
+                    >
+                      <Icon icon={Trash2} size={15} />
+                      <Text>
+                        {bulkDeleteArmed ? "Confirm delete" : "Delete selected"}
+                      </Text>
+                    </Button>
+                  </View>
+                </View>
+                <View className="grid-cols-1 gap-3 md:grid md:grid-cols-2">
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Set artists
+                    </Text>
+                    <Input
+                      value={bulkArtistsText}
+                      onChangeText={setBulkArtistsText}
+                      editable={!bulkBusy}
+                      placeholder="Artist, Featured artist"
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="font-mono text-[10px] uppercase text-muted-foreground">
+                      Set release
+                    </Text>
+                    <Input
+                      value={bulkReleaseName}
+                      onChangeText={setBulkReleaseName}
+                      editable={!bulkBusy}
+                      placeholder="Album or single"
+                    />
+                  </View>
+                </View>
+                <Button
+                  className="flex-row gap-2 self-start"
+                  disabled={
+                    bulkBusy ||
+                    selectedPlayCount === 0 ||
+                    (!bulkArtistsText.trim() && !bulkReleaseName.trim())
+                  }
+                  onPress={updateSelectedPlays}
+                >
+                  <Icon icon={Save} size={15} />
+                  <Text>Apply to selected</Text>
+                </Button>
+              </View>
+            )}
             {plays.length === 0 ? (
               <Text className="text-muted-foreground">
                 No indexed plays yet.
               </Text>
             ) : (
               plays.slice(0, 10).map((play, index) => (
-                <PlayFeedCard
+                <View
                   key={play.uri || `${play.trackName}-${index}`}
-                  play={play}
-                />
+                  className={bulkEditOpen ? "flex-row gap-3" : undefined}
+                >
+                  {bulkEditOpen && (
+                    <Button
+                      variant={
+                        play.rkey && selectedPlayRkeys.has(play.rkey)
+                          ? "default"
+                          : "outline"
+                      }
+                      size="icon"
+                      className="mt-4"
+                      disabled={!play.rkey || bulkBusy}
+                      onPress={() => togglePlaySelection(play.rkey)}
+                    >
+                      <Icon
+                        icon={
+                          play.rkey && selectedPlayRkeys.has(play.rkey)
+                            ? CheckSquare
+                            : Square
+                        }
+                        size={18}
+                      />
+                    </Button>
+                  )}
+                  <View className="min-w-0 flex-1">
+                    <PlayFeedCard play={play} />
+                  </View>
+                </View>
               ))
             )}
           </View>

--- a/apps/amethyst/lib/teal/playRecords.ts
+++ b/apps/amethyst/lib/teal/playRecords.ts
@@ -1,0 +1,171 @@
+import type { Agent } from "@atproto/api";
+
+import type { PlayView } from "@teal/lexicons/src/types/fm/teal/alpha/feed/defs";
+import type { Record as PlayRecord } from "@teal/lexicons/src/types/fm/teal/alpha/feed/play";
+
+export const PLAY_COLLECTION = "fm.teal.alpha.feed.play";
+
+export type EditablePlayRecord = Pick<
+  PlayRecord,
+  | "trackName"
+  | "artists"
+  | "releaseName"
+  | "playedTime"
+  | "recordingMbId"
+  | "releaseMbId"
+  | "trackMbId"
+  | "duration"
+  | "isrc"
+  | "originUrl"
+  | "musicServiceBaseDomain"
+  | "submissionClientAgent"
+  | "trackDiscriminant"
+  | "releaseDiscriminant"
+> &
+  Record<string, unknown>;
+
+export type LoadedPlayRecord = {
+  record: EditablePlayRecord;
+  swapRecord?: string;
+};
+
+export function artistTextFromRecord(
+  record: Pick<PlayRecord, "artists" | "artistNames">,
+) {
+  return (
+    record.artists
+      ?.map((artist) => artist.artistName)
+      .filter(Boolean)
+      .join(", ") ||
+    record.artistNames?.filter(Boolean).join(", ") ||
+    ""
+  );
+}
+
+export function artistTextFromPlay(play: PlayView) {
+  return (
+    play.artists
+      ?.map((artist) => artist.artistName)
+      .filter(Boolean)
+      .join(", ") || ""
+  );
+}
+
+export function artistsFromText(value: string) {
+  return value
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((artistName) => ({ artistName }));
+}
+
+function optionalTrim(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function editableRecordFromPlay(play: PlayView): EditablePlayRecord {
+  return {
+    $type: PLAY_COLLECTION,
+    trackName: play.trackName,
+    artists: play.artists,
+    releaseName: play.releaseName,
+    playedTime: play.playedTime,
+    recordingMbId: play.recordingMbId,
+    releaseMbId: play.releaseMbId,
+    trackMbId: play.trackMbId,
+    duration: play.duration,
+    isrc: play.isrc,
+    originUrl: play.originUrl,
+    musicServiceBaseDomain: play.musicServiceBaseDomain,
+    submissionClientAgent: play.submissionClientAgent,
+  };
+}
+
+export function applyEditableFields(
+  current: EditablePlayRecord,
+  fields: {
+    trackName: string;
+    artistsText: string;
+    releaseName: string;
+    playedTime: string;
+  },
+): EditablePlayRecord {
+  const trackName = fields.trackName.trim();
+  if (!trackName) {
+    throw new Error("Track name is required.");
+  }
+
+  let playedTime: string | undefined;
+  const playedTimeText = fields.playedTime.trim();
+  if (playedTimeText) {
+    const parsed = new Date(playedTimeText);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error("Played time must be a valid date and time.");
+    }
+    playedTime = parsed.toISOString();
+  }
+
+  return {
+    ...current,
+    $type: PLAY_COLLECTION,
+    trackName,
+    artists: artistsFromText(fields.artistsText),
+    releaseName: optionalTrim(fields.releaseName),
+    playedTime,
+  };
+}
+
+export async function loadPlayRecord(
+  agent: Agent,
+  did: string,
+  rkey: string,
+  fallback?: PlayView,
+): Promise<LoadedPlayRecord> {
+  try {
+    const response = await agent.call("com.atproto.repo.getRecord", {
+      repo: did,
+      collection: PLAY_COLLECTION,
+      rkey,
+    });
+    return {
+      record: response.data.value as EditablePlayRecord,
+      swapRecord: response.data.cid,
+    };
+  } catch (error) {
+    if (!fallback) throw error;
+    return { record: editableRecordFromPlay(fallback) };
+  }
+}
+
+export async function putPlayRecord(
+  agent: Agent,
+  did: string,
+  rkey: string,
+  record: EditablePlayRecord,
+  swapRecord?: string,
+) {
+  await agent.call(
+    "com.atproto.repo.putRecord",
+    {},
+    {
+      repo: did,
+      collection: PLAY_COLLECTION,
+      rkey,
+      record,
+      swapRecord,
+    },
+  );
+}
+
+export async function deletePlayRecord(agent: Agent, did: string, rkey: string) {
+  await agent.call(
+    "com.atproto.repo.deleteRecord",
+    {},
+    {
+      repo: did,
+      collection: PLAY_COLLECTION,
+      rkey,
+    },
+  );
+}

--- a/lexicons/fm.teal.alpha/actor/defs.json
+++ b/lexicons/fm.teal.alpha/actor/defs.json
@@ -41,7 +41,7 @@
         "profileStatus": {
           "type": "ref",
           "description": "The actor's Teal onboarding state as indexed by the appview.",
-          "ref": "fm.teal.alpha.actor.profileStatus"
+          "ref": "fm.teal.alpha.actor.profileStatus#main"
         },
         "statsDefaultPeriod": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tunnel:status": "./scripts/dev-tunnel.sh status",
     "tunnel:logs": "./scripts/dev-tunnel.sh logs",
     "tunnel:verify": "./scripts/dev-tunnel.sh verify",
-    "typecheck": "pnpm -r --filter='!./vendor/*' exec tsc --noEmit",
+    "typecheck": "pnpm --filter=@teal/amethyst exec tsc --noEmit && pnpm --filter=@teal/lexicon-cli exec tsc --noEmit",
     "test": "turbo run test test:rust",
     "rust:fmt": "pnpm rust:fmt:services && pnpm rust:fmt:apps",
     "rust:clippy": "pnpm rust:clippy:services && pnpm rust:clippy:apps",

--- a/packages/lexicons/lex-gen.sh
+++ b/packages/lexicons/lex-gen.sh
@@ -27,6 +27,9 @@ done
 echo "Generating lexicons from: $lexicon_paths"
 pnpm exec lex gen-server ./src $lexicon_paths --yes
 
+perl -0pi -e 's/profileStatus\?: FmTealAlphaActorProfileStatus\.Main/profileStatus?: FmTealAlphaActorProfileStatus.Record/' \
+  ./src/types/fm/teal/alpha/actor/defs.ts
+
 mkdir -p ./src/types/app/bsky/richtext
 cat > ./src/types/app/bsky/richtext/facet.ts <<'EOF'
 import type { AppBskyRichtextFacet } from "@atproto/api";

--- a/packages/lexicons/src/lexicons.ts
+++ b/packages/lexicons/src/lexicons.ts
@@ -53,7 +53,7 @@ export const schemaDict = {
             type: 'ref',
             description:
               "The actor's Teal onboarding state as indexed by the appview.",
-            ref: 'lex:fm.teal.alpha.actor.profileStatus',
+            ref: 'lex:fm.teal.alpha.actor.profileStatus#main',
           },
           statsDefaultPeriod: {
             type: 'string',

--- a/packages/lexicons/src/types/fm/teal/alpha/actor/defs.ts
+++ b/packages/lexicons/src/types/fm/teal/alpha/actor/defs.ts
@@ -24,7 +24,7 @@ export interface ProfileView {
   /** IPLD of the banner image */
   banner?: string
   status?: StatusView
-  profileStatus?: FmTealAlphaActorProfileStatus.Main
+  profileStatus?: FmTealAlphaActorProfileStatus.Record
   /** Default time period for profile listening statistics. */
   statsDefaultPeriod?:
     | '7days'

--- a/todo.md
+++ b/todo.md
@@ -62,5 +62,5 @@ Additional Amethyst verification for scrobble editing:
 
 ```bash
 EXPO_PUBLIC_AQUA_URL=https://sigilyph.teal.fm pnpm --filter=@teal/amethyst build:web
-pnpm --filter=@teal/amethyst exec tsc --noEmit # currently blocked by existing playlist cover and generated profileStatus.Main type errors
+pnpm --filter=@teal/amethyst exec tsc --noEmit
 ```

--- a/todo.md
+++ b/todo.md
@@ -15,7 +15,7 @@ Last synced with GitHub and Linear issues: 2026-06-14.
 ## Local Open Work
 
 - [ ] Complete ATProto OAuth sign-in and callback QA through `https://sigilyph.teal.fm`.
-  - Verified on 2026-06-15 that `https://sigilyph.teal.fm/client-metadata.json` serves the stable-origin `client_id` and callback URI, and that same-origin latest plays XRPC returns live data. Remaining QA requires an interactive ATProto login/callback with a real account session.
+  - Verified again on 2026-06-15 that `https://sigilyph.teal.fm/client-metadata.json` serves the stable-origin `client_id` and callback URI, `pnpm tunnel:verify` passes, and latest plays XRPC returns live data. Remaining QA requires an interactive ATProto login/callback with a real account session.
 - [x] Drain the in-flight CAR import backfill queue for users with stale ingestion from the 2026-06-07 through 2026-06-10 Cadet outage. Redis/Garnet `LLEN car_import_jobs` returned `0` on 2026-06-14, local Cadet was running, and recent Cadet logs showed no CAR import job failures.
 - [x] Backfill the `fm.teal.alpha.feed.play` records present in `did:plc:tas6hj2xjrqben5653v5kohk`'s PDS repo but missing from the preview Postgres index. A focused CAR backfill completed on 2026-06-15 via `lightrail-backfill`; the preview index now has 10,215 plays for that DID, up from 10,172 immediately before the run and above the older 10,193-record comparison from 2026-06-11.
 - [x] Handle Jetstream account lifecycle events in Cadet, including deletes, takedowns, suspensions, activations, and tombstones. Cadet now tracks upstream account state, purges indexed public profile/social/play rows when an account becomes inactive, treats activation as the gate for future commit ingestion, and ignores legacy tombstone event kinds because modern Jetstream/account-hosting statuses replace them.
@@ -26,20 +26,20 @@ Last synced with GitHub and Linear issues: 2026-06-14.
   - Linear: `Backlog`, no priority
   - Create Popfeed records when a listener plays a track or album for the first time.
   - Consider follow-on flows for completing Popfeed reviews of songs and albums from Teal.
-  - Blocked locally: no Popfeed lexicons, service endpoint, auth flow, or record schema are present in this repo yet.
+  - Blocked locally: GitHub discussion says this should be a user-enabled sync, potentially with a later history backfill, but no Popfeed NSID, lexicon, service endpoint, auth flow, or record schema are present in this repo yet. Web search on 2026-06-15 did not find an authoritative public Popfeed record schema to implement against.
 - [x] [#57](https://github.com/teal-fm/teal/issues/57) / [TEAL-30](https://linear.app/tealfm/issue/TEAL-30/top-albums-around-profile-pic) top albums around profile pic
   - Linear: `In Progress`, low priority
   - Labels: `API`, `Frontend`, `Legacy Songish Feature`
   - Assignee: `mmattbtw`
   - Done in Amethyst profile headers: top releases for the profile's default stats period render as linked cover tiles around the avatar, with desktop and mobile visual QA against live preview data.
-- [ ] [#29](https://github.com/teal-fm/teal/issues/29) / [TEAL-21](https://linear.app/tealfm/issue/TEAL-21/mass-editing-scrobbles) mass editing scrobbles
+- [x] [#29](https://github.com/teal-fm/teal/issues/29) / [TEAL-21](https://linear.app/tealfm/issue/TEAL-21/mass-editing-scrobbles) mass editing scrobbles
   - Linear: `Backlog`, low priority
   - Labels: `Improvement`, `API`
-  - Implementation note: Cadet already reindexes updated `fm.teal.alpha.feed.play` records and deletes tombstoned plays. Remaining work is authenticated Amethyst/Aqua product flow for selecting multiple records and writing `putRecord`/`deleteRecord` changes to the user's PDS.
-- [ ] [#28](https://github.com/teal-fm/teal/issues/28) / [TEAL-20](https://linear.app/tealfm/issue/TEAL-20/editing-scrobbles) editing scrobbles
+  - Done in Amethyst self-profile recent plays: logged-in users can enter selection mode, select visible recent play records, bulk-apply shared artist/release metadata with `com.atproto.repo.putRecord`, or bulk-delete selected records with `com.atproto.repo.deleteRecord`. Browser QA verified the logged-out controls stay hidden on desktop and mobile while public profile data still renders from live XRPC.
+- [x] [#28](https://github.com/teal-fm/teal/issues/28) / [TEAL-20](https://linear.app/tealfm/issue/TEAL-20/editing-scrobbles) editing scrobbles
   - Linear: `Todo`, medium priority
   - Labels: `Feature`, `API`
-  - Implementation note: single-play edits can build on the existing Cadet upsert path; still needs authenticated UI/API design for loading the original record, editing fields, and writing it back to the PDS.
+  - Done in Amethyst listen detail pages: logged-in record owners can fetch the source `fm.teal.alpha.feed.play` record from their PDS, edit track, artists, release, and played time, save via `com.atproto.repo.putRecord`, or delete via `com.atproto.repo.deleteRecord`. Public logged-out listen pages continue to render without showing edit controls.
 - [x] [#16](https://github.com/teal-fm/teal/issues/16) / [TEAL-16](https://linear.app/tealfm/issue/TEAL-16/live-scrobble-view) Live Scrobble View
   - Linear: `Todo`, low priority
   - Labels: `Frontend`
@@ -56,4 +56,11 @@ pnpm --filter=@teal/amethyst build:web
 docker compose -f compose.dev.yml config
 docker compose -f compose.yaml config
 docker compose -f compose.dev.yml --profile tunnel up
+```
+
+Additional Amethyst verification for scrobble editing:
+
+```bash
+EXPO_PUBLIC_AQUA_URL=https://sigilyph.teal.fm pnpm --filter=@teal/amethyst build:web
+pnpm --filter=@teal/amethyst exec tsc --noEmit # currently blocked by existing playlist cover and generated profileStatus.Main type errors
 ```

--- a/todo.md
+++ b/todo.md
@@ -50,6 +50,7 @@ Last synced with GitHub and Linear issues: 2026-06-14.
 
 ```bash
 pnpm lex:gen-server
+pnpm typecheck
 SQLX_OFFLINE=true cargo check -p aqua -p cadet
 SQLX_OFFLINE=true cargo test -p cadet stores_and_loads_cursor_from_file_when_redis_is_unavailable
 pnpm --filter=@teal/amethyst build:web


### PR DESCRIPTION
Add individual and bulk scrobble editing. This groups the existing commits by chronology and the area they change.

Part 21 of 33 replacing #113. Review this PR against `feature/obbpr-20-account-lifecycle`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 4ed318b feat(amethyst): add scrobble editing flows
- 3ab526c fix(amethyst): restore typecheck verification
- ed0efa8 chore: scope typecheck to typescript workspaces

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/214
- Next: https://github.com/teal-fm/teal/pull/216
- Full stack index: https://github.com/teal-fm/teal/pull/113
