### PR TITLE
[27/33] feat(amethyst): group notifications and show post context

### DIFF
--- a/apps/amethyst/app/(tabs)/notifications.tsx
+++ b/apps/amethyst/app/(tabs)/notifications.tsx
@@ -1,25 +1,42 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Image,
   Pressable,
   View,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from "react-native";
-import { Link, Stack, useRouter } from "expo-router";
+import { Link, Stack } from "expo-router";
 import RightRail from "@/components/teal/RightRail";
 import TealShell, { SectionHeading } from "@/components/teal/TealShell";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { Icon } from "@/lib/icons/iconWithClassName";
 import {
+  coverArtUrl,
+  displayArtists,
   getNotifications,
+  getSocialPost,
   type SocialNotificationView,
+  type SocialPostView,
 } from "@/lib/teal/api";
+import {
+  actorAvatarUrl,
+  actorProfileHref,
+  displayActorName,
+} from "@/lib/teal/actors";
 import { postHrefFromUri } from "@/lib/teal/routes";
-import { timeAgo } from "@/lib/utils";
+import { trackViewToPlayView } from "@/lib/teal/social";
 import { useStore } from "@/stores/mainStore";
-import { Bell, Heart, MessageCircle, Repeat2 } from "lucide-react-native";
+import {
+  Bell,
+  ChevronRight,
+  Disc3,
+  Heart,
+  MessageCircle,
+  Repeat2,
+} from "lucide-react-native";
 
 function reasonLabel(reason: string) {
   switch (reason) {
@@ -29,6 +46,10 @@ function reasonLabel(reason: string) {
       return "reposted your post";
     case "reply":
       return "replied to your post";
+    case "follow":
+      return "followed you";
+    case "badgeAssignment":
+      return "gave you a badge";
     default:
       return reason;
   }
@@ -47,55 +68,249 @@ function reasonIcon(reason: string) {
   }
 }
 
-function NotificationRow({ notification }: { notification: SocialNotificationView }) {
-  const router = useRouter();
+type NotificationGroup = {
+  key: string;
+  reason: string;
+  notifications: SocialNotificationView[];
+  contextUri?: string;
+};
+
+const contextualReasons = new Set(["like", "repost", "reply"]);
+
+function groupNotifications(items: SocialNotificationView[]) {
+  const groups: NotificationGroup[] = [];
+  const grouped = new Map<string, NotificationGroup>();
+
+  for (const notification of items) {
+    const contextUri =
+      notification.reason === "reply"
+        ? notification.recordUri
+        : notification.subjectUri;
+    const canGroup = contextualReasons.has(notification.reason) && contextUri;
+    const key = canGroup
+      ? `${notification.reason}:${contextUri}`
+      : `notification:${notification.id}`;
+    const existing = grouped.get(key);
+
+    if (existing) {
+      existing.notifications.push(notification);
+      continue;
+    }
+
+    const group = {
+      key,
+      reason: notification.reason,
+      notifications: [notification],
+      contextUri,
+    };
+    grouped.set(key, group);
+    groups.push(group);
+  }
+
+  return groups;
+}
+
+function compactTimeAgo(value: string) {
+  const seconds = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(value).getTime()) / 1000),
+  );
+  if (seconds < 60) return "now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d`;
+  return `${Math.floor(seconds / 604800)}w`;
+}
+
+function reasonIconClass(reason: string) {
+  switch (reason) {
+    case "like":
+      return "text-rose-500";
+    case "repost":
+      return "text-primary";
+    case "reply":
+      return "text-bsky";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function ActorAvatar({ notification }: { notification: SocialNotificationView }) {
   const actor = notification.actor;
-  const actorLabel =
-    actor?.displayName || actor?.handle || notification.actorDid || "Someone";
-  const actorHref = actor?.handle || notification.actorDid;
-  const IconForReason = reasonIcon(notification.reason);
-  const subjectHref =
-    notification.reason === "like" || notification.reason === "repost"
-      ? postHrefFromUri(notification.subjectUri)
-      : undefined;
+  const actorDid = actor?.did || notification.actorDid;
+  const label = displayActorName(actor, actorDid);
+  const avatar = actorAvatarUrl(actor, actorDid);
+  const href = actorProfileHref(actor, actorDid);
 
   return (
-    <Pressable
-      className="rounded-lg border border-border bg-card p-4"
-      disabled={!subjectHref}
-      onPress={() => {
-        if (subjectHref) router.push(subjectHref as any);
-      }}
-      accessibilityRole={subjectHref ? "link" : undefined}
-      accessibilityLabel={subjectHref ? "View the post" : undefined}
-    >
-      <View className="flex-row gap-3">
-        <View className="h-10 w-10 items-center justify-center rounded-full bg-accent">
-          <Icon icon={IconForReason} size={18} className="text-primary" />
+    <Link href={`/profile/${href}` as any} asChild>
+      <Pressable
+        className="h-11 w-11 items-center justify-center overflow-hidden rounded-full border-2 border-background bg-primary"
+        accessibilityLabel={`View ${label}'s profile`}
+      >
+        {avatar ? (
+          <Image source={{ uri: avatar }} className="h-full w-full" />
+        ) : (
+          <Text className="text-sm font-black text-primary-foreground">
+            {label.slice(0, 1).toUpperCase()}
+          </Text>
+        )}
+      </Pressable>
+    </Link>
+  );
+}
+
+function PostPreview({ post }: { post: SocialPostView }) {
+  const play = trackViewToPlayView(post.track);
+  const art = coverArtUrl(play.releaseMbId);
+
+  return (
+    <View className="rounded-lg border border-border bg-card/70 p-3">
+      {post.text ? (
+        <Text className="text-[15px] leading-6" numberOfLines={4}>
+          {post.text}
+        </Text>
+      ) : (
+        <Text className="text-sm italic text-muted-foreground">
+          Shared a track
+        </Text>
+      )}
+      <View className="mt-3 flex-row items-center gap-3 rounded-md bg-muted/55 p-2">
+        <View className="h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-accent">
+          {art ? (
+            <Image source={{ uri: art }} className="h-full w-full" />
+          ) : (
+            <Icon icon={Disc3} size={18} className="text-primary" />
+          )}
         </View>
         <View className="min-w-0 flex-1">
-          <Link href={`/profile/${actorHref}` as any} asChild>
-            <Pressable>
-              <Text className="font-black" numberOfLines={1}>
-                {actorLabel}
-              </Text>
-            </Pressable>
-          </Link>
-          <Text className="text-sm text-muted-foreground">
-            {reasonLabel(notification.reason)}
+          <Text className="font-semibold" numberOfLines={1}>
+            {play.trackName}
           </Text>
-          <Text className="mt-2 font-mono text-[10px] uppercase text-muted-foreground">
-            {timeAgo(new Date(notification.createdAt))}
+          <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+            {displayArtists(play) || "Unknown artist"}
           </Text>
         </View>
       </View>
-    </Pressable>
+    </View>
+  );
+}
+
+function NotificationRow({ group }: { group: NotificationGroup }) {
+  const notifications = group.notifications;
+  const first = notifications[0];
+  const IconForReason = reasonIcon(group.reason);
+  const postHref = group.contextUri
+    ? postHrefFromUri(group.contextUri)
+    : undefined;
+  const [postState, setPostState] = useState<{
+    uri: string;
+    post: SocialPostView | null;
+  }>();
+  const post =
+    group.contextUri && contextualReasons.has(group.reason)
+      ? postState?.uri === group.contextUri
+        ? postState.post
+        : undefined
+      : null;
+
+  useEffect(() => {
+    if (!group.contextUri || !contextualReasons.has(group.reason)) return;
+
+    let mounted = true;
+    getSocialPost(group.contextUri)
+      .then((response) => {
+        if (mounted) {
+          setPostState({ uri: group.contextUri!, post: response.post });
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setPostState({ uri: group.contextUri!, post: null });
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [group.contextUri, group.reason]);
+
+  const actorLabel = displayActorName(first.actor, first.actorDid);
+  const otherCount = notifications.length - 1;
+
+  return (
+    <View className="border-b border-border py-5 first:pt-2">
+      <View className="flex-row gap-3">
+        <View className="h-10 w-10 items-center justify-center rounded-full bg-accent">
+          <Icon
+            icon={IconForReason}
+            size={20}
+            className={reasonIconClass(group.reason)}
+          />
+        </View>
+        <View className="min-w-0 flex-1">
+          <View className="flex-row items-center justify-between gap-3">
+            <View className="flex-row items-center pl-1">
+              {notifications.slice(0, 3).map((notification, index) => (
+                <View
+                  key={notification.id}
+                  className={index > 0 ? "-ml-2" : undefined}
+                  style={{ zIndex: 3 - index }}
+                >
+                  <ActorAvatar notification={notification} />
+                </View>
+              ))}
+            </View>
+            {postHref && (
+              <Icon
+                icon={ChevronRight}
+                size={18}
+                className="text-muted-foreground"
+              />
+            )}
+          </View>
+          <Text className="mt-3 text-[15px] leading-6">
+            <Text className="font-black">{actorLabel}</Text>
+            {otherCount > 0
+              ? ` and ${otherCount} ${otherCount === 1 ? "other" : "others"}`
+              : ""}{" "}
+            {reasonLabel(group.reason)}
+            <Text className="text-muted-foreground">
+              {` · ${compactTimeAgo(first.createdAt)}`}
+            </Text>
+          </Text>
+
+          {postHref && post === undefined && (
+            <View className="mt-3 gap-2 rounded-lg border border-border bg-card/45 p-3">
+              <View className="h-3 w-4/5 rounded-full bg-muted" />
+              <View className="h-3 w-2/5 rounded-full bg-muted" />
+            </View>
+          )}
+          {postHref && post && (
+            <Link href={postHref as any} asChild>
+              <Pressable
+                className="mt-3 web:hover:opacity-80"
+                accessibilityRole="link"
+                accessibilityLabel="View the original post"
+              >
+                <PostPreview post={post} />
+              </Pressable>
+            </Link>
+          )}
+          {postHref && post === null && (
+            <Text className="mt-3 text-sm italic text-muted-foreground">
+              The original post is no longer available.
+            </Text>
+          )}
+        </View>
+      </View>
+    </View>
   );
 }
 
 export default function Notifications() {
   const status = useStore((state) => state.status);
   const pdsAgent = useStore((state) => state.pdsAgent);
+  const actorDid = pdsAgent?.did;
   const [items, setItems] = useState<SocialNotificationView[] | null>(null);
   const [cursor, setCursor] = useState<string>();
   const [error, setError] = useState<string | null>(null);
@@ -104,14 +319,12 @@ export default function Notifications() {
 
   useEffect(() => {
     let mounted = true;
-    if (status !== "loggedIn" || !pdsAgent?.did) {
-      setItems([]);
-      setCursor(undefined);
+    if (status !== "loggedIn" || !actorDid) {
       return;
     }
     setItems(null);
     setError(null);
-    getNotifications(pdsAgent.did, 30)
+    getNotifications(actorDid, 30)
       .then((res) => {
         if (!mounted) return;
         setItems(res.items);
@@ -125,13 +338,13 @@ export default function Notifications() {
     return () => {
       mounted = false;
     };
-  }, [pdsAgent?.did, status]);
+  }, [actorDid, status]);
 
   const loadMore = useCallback(() => {
-    if (!pdsAgent?.did || !cursor || loadingMoreRef.current) return;
+    if (!actorDid || !cursor || loadingMoreRef.current) return;
     loadingMoreRef.current = true;
     setLoadingMore(true);
-    getNotifications(pdsAgent.did, 30, cursor)
+    getNotifications(actorDid, 30, cursor)
       .then((res) => {
         setItems((current) => {
           const knownIds = new Set(current?.map((item) => item.id) || []);
@@ -147,7 +360,7 @@ export default function Notifications() {
         loadingMoreRef.current = false;
         setLoadingMore(false);
       });
-  }, [cursor, pdsAgent?.did]);
+  }, [actorDid, cursor]);
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -159,6 +372,7 @@ export default function Notifications() {
     },
     [loadMore],
   );
+  const groups = items ? groupNotifications(items) : [];
 
   if (status !== "loggedIn") {
     return (
@@ -214,9 +428,9 @@ export default function Notifications() {
           </Text>
         </View>
       )}
-      <View className="gap-3">
-        {items?.map((notification) => (
-          <NotificationRow key={notification.id} notification={notification} />
+      <View className="mt-2">
+        {groups.map((group) => (
+          <NotificationRow key={group.key} group={group} />
         ))}
       </View>
       {loadingMore && (

--- a/todo.md
+++ b/todo.md
@@ -20,7 +20,10 @@ Last synced with GitHub and Linear issues: 2026-06-14.
 - Music detail social-link fix (2026-07-11): social-post track links now carry the source post URI instead of an empty play URI, track pages match listens by recording identity with a metadata fallback, and the originating post renders on the track page.
 - Music album metadata/dedup fix (2026-07-16): album pages use MusicBrainz release artist metadata, collapse case/recording-ID variants into one track row, preserve canonical release recording IDs, and sum merged listen counts; artist pages now merge duplicate release titles and avoid cross-title MBID collisions.
 - Automatic catalog cleanup/discography split (2026-07-16): Cadet now runs catalog consolidation on a six-hour interval, artist responses expose MusicBrainz release-group types, and Amethyst separates Albums from Singles. Audited the top 12 artists in the preview; none had duplicate album titles after normalization.
+- Discography count fix (2026-07-16): Aqua now paginates the complete MusicBrainz release classification instead of stopping at 100 releases, and Amethyst counts only true album release types while separating EPs, singles, and other releases.
 - Notification post navigation (2026-07-16): like and repost notifications now navigate to their original post through the indexed subject URI while preserving actor profile links.
+- Notification context refinement (2026-07-16): Amethyst notifications now group same-post likes/reposts, stack linked actor avatars, use compact relative timestamps, and load the referenced post text plus track preview; follow and badge activity remain lightweight rows.
+- Playlist track lookup (2026-07-16): playlist editors can search their own indexed listening history or MusicBrainz and add matching tracks directly to a playlist.
 
 ## Local Open Work
 


### PR DESCRIPTION
Group notifications and show post context. This groups the existing commits by chronology and the area they change.

Part 27 of 33 replacing #113. Review this PR against `feature/obbpr-26-lexicon-validation`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- 1670ed7 feat(amethyst): add notification context

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/220
- Next: https://github.com/teal-fm/teal/pull/222
- Full stack index: https://github.com/teal-fm/teal/pull/113
