### PR TITLE
[29/33] feat(amethyst): add cohesive dark mode

### DIFF
--- a/apps/amethyst/app/(tabs)/(stamp)/stamp/index.tsx
+++ b/apps/amethyst/app/(tabs)/(stamp)/stamp/index.tsx
@@ -302,7 +302,7 @@ export function SearchResult({
     >
       <View className={`flex-row items-center justify-between gap-4`}>
         <Image
-          className="h-16 w-16 rounded-lg bg-gray-500/50"
+          className="h-16 w-16 rounded-lg bg-muted"
           source={{
             uri: `https://coverartarchive.org/release/${currentRelease?.id}/front-250`,
           }}
@@ -320,7 +320,7 @@ export function SearchResult({
               className="flex w-full items-start justify-between rounded-lg bg-secondary/10 p-1 md:flex-row md:items-center md:gap-1"
             >
               <View className="flex w-full flex-1 items-start gap-1 overflow-hidden md:flex-row">
-                <Text className="whitespace-nowrap text-sm text-gray-500">
+                <Text className="whitespace-nowrap text-sm text-muted-foreground">
                   Release:
                 </Text>
                 <Text className="line-clamp-1 text-sm">
@@ -372,7 +372,7 @@ export function SearchResult({
           {result.releases?.map((release) => (
             <TouchableOpacity
               key={release.id}
-              className={`border-b border-gray-100 p-4 ${
+              className={`border-b border-border p-4 ${
                 selectedRelease?.id === release.id ? "bg-primary/10" : ""
               }`}
               onPress={() => {
@@ -383,21 +383,21 @@ export function SearchResult({
               <Text className="font-medium">{release.title}</Text>
               <View className="flex-row gap-2">
                 {release.date && (
-                  <Text className="text-sm text-gray-500">{release.date}</Text>
+                  <Text className="text-sm text-muted-foreground">{release.date}</Text>
                 )}
                 {release.country && (
-                  <Text className="text-sm text-gray-500">
+                  <Text className="text-sm text-muted-foreground">
                     {release.country}
                   </Text>
                 )}
                 {release.status && (
-                  <Text className="text-sm text-gray-500">
+                  <Text className="text-sm text-muted-foreground">
                     {release.status}
                   </Text>
                 )}
               </View>
               {release.disambiguation && (
-                <Text className="text-sm italic text-gray-400">
+                <Text className="text-sm italic text-muted-foreground">
                   {release.disambiguation}
                 </Text>
               )}

--- a/apps/amethyst/app/(tabs)/(stamp)/stamp/submit.tsx
+++ b/apps/amethyst/app/(tabs)/(stamp)/stamp/submit.tsx
@@ -331,7 +331,7 @@ powered by @teal.fm`;
               .join(", ")}
             releaseTitle={selectedTrack?.selectedRelease?.title}
           />
-          <Text className="mt-4 text-center text-sm text-gray-500">
+          <Text className="mt-4 text-center text-sm text-muted-foreground">
             Any missing info?{" "}
             <ExternalLink
               className="text-blue-600 dark:text-blue-400"
@@ -385,7 +385,7 @@ powered by @teal.fm`;
                 className={cn(
                   "absolute bottom-1 right-2 text-center text-sm text-muted-foreground",
                   blueskyPostText.length > 150
-                    ? "text-gray-600 dark:text-gray-300"
+                  ? "text-foreground"
                     : "",
                   blueskyPostText.length > 290 ? "text-red-500" : "",
                 )}

--- a/apps/amethyst/app/(tabs)/index.tsx
+++ b/apps/amethyst/app/(tabs)/index.tsx
@@ -185,7 +185,7 @@ export default function HomeScreen() {
           }}
         />
       </View>
-      <View className="mb-5 overflow-hidden rounded-lg border border-border bg-white/75">
+      <View className="mb-5 overflow-hidden rounded-lg border border-border bg-card/80">
         <View className="flex-row overflow-hidden">
           <HomeFeedTabButton
             active={activeFeed === "posts"}

--- a/apps/amethyst/app/(tabs)/post/[did]/[rkey].tsx
+++ b/apps/amethyst/app/(tabs)/post/[did]/[rkey].tsx
@@ -79,7 +79,7 @@ export default function PostDetail() {
           </View>
           <SectionHeading eyebrow="Conversation" title="Replies" />
           {replies.length === 0 ? (
-            <View className="rounded-lg border border-border bg-white/75 p-6">
+            <View className="rounded-lg border border-border bg-card/80 p-6">
               <Text className="text-muted-foreground">
                 No indexed replies yet.
               </Text>

--- a/apps/amethyst/app/(tabs)/profile/[handle].tsx
+++ b/apps/amethyst/app/(tabs)/profile/[handle].tsx
@@ -246,7 +246,7 @@ function GraphActorRow({ actor }: { actor: MiniProfileView }) {
 
   return (
     <Link href={`/profile/${href}` as any} asChild>
-      <Pressable className="flex-row items-center gap-3 rounded-lg border border-border bg-white/65 p-3 web:transition-colors web:hover:border-primary/45">
+      <Pressable className="flex-row items-center gap-3 rounded-lg border border-border bg-card/75 p-3 web:transition-colors web:hover:border-primary/45">
         <View className="h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary">
           {avatar ? (
             <Image source={{ uri: avatar }} className="h-full w-full" />
@@ -657,7 +657,7 @@ export default function ProfileScreen() {
                 </Text>
               )}
               <View className="mt-4 flex-row flex-wrap items-center gap-3">
-                <View className="flex-row gap-4 rounded-lg border border-border bg-white/55 px-4 py-2">
+                <View className="flex-row gap-4 rounded-lg border border-border bg-card/60 px-4 py-2">
                   <Pressable onPress={() => setGraphTab("followers")}>
                     <Text className="font-sans text-lg font-black">
                       {graphSummary.followersCount}
@@ -808,7 +808,7 @@ export default function ProfileScreen() {
               )}
             </View>
             {bulkEditOpen && isSelf && (
-              <View className="mb-4 gap-3 rounded-lg border border-border bg-white/70 p-4">
+              <View className="mb-4 gap-3 rounded-lg border border-border bg-card/75 p-4">
                 <View className="flex-row flex-wrap items-center justify-between gap-3">
                   <View>
                     <Text className="font-bold">

--- a/apps/amethyst/app/+html.tsx
+++ b/apps/amethyst/app/+html.tsx
@@ -36,10 +36,10 @@ export default function Root({ children }: { children: React.ReactNode }) {
 
 const responsiveBackground = `
 body {
-  background-color: #fff;
+  background-color: hsl(226 35% 94%);
 }
 @media (prefers-color-scheme: dark) {
   body {
-    background-color: #000;
+    background-color: hsl(180 24% 7%);
   }
 }`;

--- a/apps/amethyst/app/onboarding/imageSelectionPage.tsx
+++ b/apps/amethyst/app/onboarding/imageSelectionPage.tsx
@@ -70,7 +70,7 @@ const ImageSelectionPage: React.FC<ImageSelectionPageProps> = ({
                   source={{ uri: bannerUri }}
                   className="h-full w-full rounded-lg object-cover"
                 />
-                <View className="absolute -bottom-2 -right-2 rounded-full bg-gray-500/50 p-1">
+                <View className="absolute -bottom-2 -right-2 rounded-full bg-muted/70 p-1">
                   <Icon icon={Pen} size={18} className="fill-white" />
                 </View>
               </>
@@ -89,7 +89,7 @@ const ImageSelectionPage: React.FC<ImageSelectionPageProps> = ({
               {avatarUri ? (
                 <>
                   <AvatarImage source={{ uri: avatarUri }} />
-                  <View className="absolute bottom-0 right-0 rounded-full bg-gray-500/50 p-1">
+                <View className="absolute bottom-0 right-0 rounded-full bg-muted/70 p-1">
                     <Icon icon={Pen} size={18} className="fill-white" />
                   </View>
                 </>

--- a/apps/amethyst/assets/web.css
+++ b/apps/amethyst/assets/web.css
@@ -1,6 +1,6 @@
 
 @supports not selector(::-webkit-scrollbar) {
-  scrollbar-color: rgba(0, 0, 0, 0.8) transparent;
+  scrollbar-color: hsl(var(--primary)) transparent;
   scrollbar-width: thin;
 }
 
@@ -8,13 +8,13 @@
   width: 7px;
 }
 ::-webkit-scrollbar-track {
-  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+  -webkit-box-shadow: inset 0 0 6px hsl(var(--border));
 }
 ::-webkit-scrollbar-thumb {
-  background-color: darkslategray;
-  outline: 1px solid slategrey;
+  background-color: hsl(var(--primary));
+  outline: 1px solid hsl(var(--ring));
   border-radius: 99px;
 }
 ::webkit-scrollbar-thumb:hover {
-  background-color: slategray;
+  background-color: hsl(var(--secondary));
 }

--- a/apps/amethyst/components/actor/editProfileView.tsx
+++ b/apps/amethyst/components/actor/editProfileView.tsx
@@ -145,7 +145,7 @@ export default function EditProfileModal({
                 Display Name
               </Text>
               <Input
-                className="mb-4 rounded border border-gray-300 px-3 py-2"
+                className="mb-4 rounded border border-input bg-background px-3 py-2 text-foreground"
                 placeholder="Display Name"
                 value={editedProfile.displayName}
                 onChangeText={(text) =>
@@ -156,7 +156,7 @@ export default function EditProfileModal({
                 Description
               </Text>
               <Textarea
-                className="mb-4 rounded border border-gray-300 px-3 py-2"
+                className="mb-4 rounded border border-input bg-background px-3 py-2 text-foreground"
                 placeholder="Description"
                 multiline
                 value={editedProfile.description}

--- a/apps/amethyst/components/play/playView.tsx
+++ b/apps/amethyst/components/play/playView.tsx
@@ -16,7 +16,7 @@ export default function PlayView({
   return (
     <View className="flex max-w-full flex-row gap-2">
       <Image
-        className="h-16 w-16 rounded-lg bg-gray-500/50"
+        className="h-16 w-16 rounded-lg bg-muted"
         source={{
           uri:
             releaseMbid &&

--- a/apps/amethyst/components/play/verticalPlayView.tsx
+++ b/apps/amethyst/components/play/verticalPlayView.tsx
@@ -51,7 +51,7 @@ export default function VerticalPlayView({
       <Image
         className={cn(
           imageSizes[size], // Apply image size based on variant
-          "rounded-lg bg-gray-500/50",
+          "rounded-lg bg-muted",
           marginBottoms[size], // Apply margin bottom based on variant
         )}
         source={{

--- a/apps/amethyst/components/teal/PlayFeedCard.tsx
+++ b/apps/amethyst/components/teal/PlayFeedCard.tsx
@@ -98,7 +98,7 @@ export default function PlayFeedCard({ play, compact }: PlayFeedCardProps) {
   return (
     <View
       className={cn(
-        "mb-4 w-full rounded-lg border border-border bg-white/75 p-4 web:transition-colors web:hover:border-primary/45",
+        "mb-4 w-full rounded-lg border border-border bg-card/80 p-4 web:transition-colors web:hover:border-primary/45",
         compact ? "max-w-[34rem]" : "w-full",
       )}
     >

--- a/apps/amethyst/components/teal/ProfileStats.tsx
+++ b/apps/amethyst/components/teal/ProfileStats.tsx
@@ -184,7 +184,7 @@ function StatPreviewCard({
 }) {
   const href = itemHref(item);
   const content = (
-    <Pressable className="h-full rounded-lg border border-border bg-white/65 p-3 web:transition-colors web:hover:border-primary/45">
+    <Pressable className="h-full rounded-lg border border-border bg-card/75 p-3 web:transition-colors web:hover:border-primary/45">
       <StatArtwork item={item} />
       <Text className="mt-3 font-sans text-base font-black" numberOfLines={2}>
         {item.name}
@@ -322,7 +322,7 @@ function StatsPreviewSection({
         </Link>
       </View>
       {loading ? (
-        <View className="h-36 items-center justify-center rounded-lg border border-border bg-white/55">
+        <View className="h-36 items-center justify-center rounded-lg border border-border bg-card/60">
           <ActivityIndicator />
         </View>
       ) : error ? (
@@ -330,7 +330,7 @@ function StatsPreviewSection({
           <Text className="font-bold text-destructive">{error}</Text>
         </View>
       ) : items.length === 0 ? (
-        <View className="rounded-lg border border-border bg-white/55 p-4">
+        <View className="rounded-lg border border-border bg-card/60 p-4">
           <Text className="text-muted-foreground">No plays in this period yet.</Text>
         </View>
       ) : (
@@ -361,7 +361,7 @@ export function ProfileStatsSections({
 
   return (
     <View className="mb-2">
-      <View className="mb-5 gap-3 rounded-lg border border-border bg-white/55 p-4">
+      <View className="mb-5 gap-3 rounded-lg border border-border bg-card/60 p-4">
         <View className="flex-row items-center gap-2">
           <Icon icon={ListMusic} size={18} className="text-primary" />
           <Text className="font-mono text-[10px] uppercase text-muted-foreground">
@@ -450,7 +450,7 @@ export function ProfileStatsMorePage({
           <Text className="font-bold text-destructive">{error}</Text>
         </View>
       ) : items.length === 0 ? (
-        <View className="rounded-lg border border-border bg-white/55 p-4">
+        <View className="rounded-lg border border-border bg-card/60 p-4">
           <Text className="text-muted-foreground">No plays in this period yet.</Text>
         </View>
       ) : (

--- a/apps/amethyst/components/teal/SocialComposer.tsx
+++ b/apps/amethyst/components/teal/SocialComposer.tsx
@@ -350,7 +350,7 @@ export default function SocialComposer({
 
   if (status !== "loggedIn") {
     return (
-      <View className="rounded-lg border border-border bg-white/75 p-4">
+      <View className="rounded-lg border border-border bg-card/80 p-4">
         <Text className="font-semibold">
           Sign in to {replyTo ? "reply" : "post"} about what you hear.
         </Text>
@@ -362,7 +362,7 @@ export default function SocialComposer({
   }
 
   return (
-    <View className="rounded-lg border border-border bg-white/75 p-4">
+    <View className="rounded-lg border border-border bg-card/80 p-4">
       <Text className="text-xs font-light text-primary">
         {replyTo ? "Reply to post" : "Create post"}
       </Text>
@@ -370,7 +370,7 @@ export default function SocialComposer({
         <Pressable
           disabled={!canChangeTrack}
           onPress={() => setPickerOpen((open) => !open)}
-          className={`mt-2 flex-row items-center gap-3 rounded-lg border border-border bg-white/55 p-2 ${
+          className={`mt-2 flex-row items-center gap-3 rounded-lg border border-border bg-accent/45 p-2 ${
             canChangeTrack ? "web:hover:border-primary/50" : ""
           }`}
         >
@@ -393,7 +393,7 @@ export default function SocialComposer({
         <Pressable
           disabled={!canChangeTrack}
           onPress={() => setPickerOpen(true)}
-          className="mt-2 rounded-lg border border-dashed border-border bg-white/55 p-3"
+          className="mt-2 rounded-lg border border-dashed border-border bg-accent/45 p-3"
         >
           <Text className="font-semibold">
             {loadingRecent ? "Finding your latest listen..." : "Choose a song"}
@@ -404,7 +404,7 @@ export default function SocialComposer({
         </Pressable>
       )}
       {pickerOpen && canChangeTrack && (
-        <View className="mt-3 gap-3 rounded-lg border border-border bg-white/55 p-3">
+        <View className="mt-3 gap-3 rounded-lg border border-border bg-accent/45 p-3">
           <View className="gap-2 md:flex-row">
             <Input
               className="md:flex-1"

--- a/apps/amethyst/components/teal/SocialPostCard.tsx
+++ b/apps/amethyst/components/teal/SocialPostCard.tsx
@@ -193,7 +193,7 @@ export default function SocialPostCard({ post }: { post: SocialPostView }) {
   }
 
   return (
-    <View className="rounded-lg border border-border bg-white/75 p-4">
+    <View className="rounded-lg border border-border bg-card/80 p-4">
       <View className="flex-row items-start justify-between gap-3">
         <View className="min-w-0 flex-1 flex-row gap-3">
           <Link href={`/profile/${authorHref}` as any} asChild>
@@ -252,7 +252,7 @@ export default function SocialPostCard({ post }: { post: SocialPostView }) {
       ) : null}
 
       <Link href={trackHref as any} asChild>
-        <Pressable className="mt-4 rounded-lg border border-border bg-white/55 p-3">
+        <Pressable className="mt-4 rounded-lg border border-border bg-accent/45 p-3">
           <View className="flex-row items-center gap-3">
             <View className="h-12 w-12 items-center justify-center overflow-hidden rounded-lg bg-accent">
               {art ? (

--- a/apps/amethyst/components/teal/TealShell.tsx
+++ b/apps/amethyst/components/teal/TealShell.tsx
@@ -31,7 +31,7 @@ type TealShellProps = {
 
 const landingBackgroundStyle = {
   backgroundImage:
-    "radial-gradient(circle at 48% 24%, rgba(255,255,255,0.7) 0, rgba(255,255,255,0) 30rem), linear-gradient(135deg, #e9eef7 0%, #f4e8ff 48%, #dfe7f0 100%)",
+    "radial-gradient(circle at 48% 24%, hsl(var(--popover) / 0.78) 0, hsl(var(--popover) / 0) 30rem), linear-gradient(135deg, hsl(var(--background)) 0%, hsl(var(--accent) / 0.48) 48%, hsl(var(--background)) 100%)",
 } as any;
 
 function RecordLogo() {
@@ -70,7 +70,7 @@ function NavItem({
     <Link href={href as any} asChild>
       <Pressable
         className={`flex-row items-center gap-3 rounded-lg px-3 py-3 web:transition-colors ${
-          active ? "bg-white/70" : "web:hover:bg-white/45"
+          active ? "bg-accent/70" : "web:hover:bg-accent/45"
         }`}
       >
         <Icon
@@ -118,7 +118,7 @@ function LeftRail() {
     : undefined;
 
   return (
-    <View className="hidden w-[16rem] shrink-0 border-r border-border bg-white/35 px-5 py-7 lg:flex">
+    <View className="hidden w-[16rem] shrink-0 border-r border-border bg-background/55 px-5 py-7 lg:flex">
       <RecordLogo />
       <View className="mt-12 gap-1">
         <NavItem href="/" icon={Home} label="Home" active={pathname === "/"} />
@@ -144,7 +144,7 @@ function LeftRail() {
           }
           asChild
         >
-          <Pressable className="flex-row items-center gap-3 rounded-lg border border-border bg-white/70 p-3 web:hover:border-primary/50">
+          <Pressable className="flex-row items-center gap-3 rounded-lg border border-border bg-card/75 p-3 web:hover:border-primary/50">
             <View className="h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-primary">
               {status === "loggedIn" && avatar ? (
                 <Image source={{ uri: avatar }} className="h-full w-full" />
@@ -191,7 +191,7 @@ function MobileNav() {
     { href: "/auth/login", icon: CircleUserRound, active: false },
   ];
   return (
-    <View className="absolute bottom-4 left-4 right-4 z-30 flex-row items-center justify-around rounded-lg border border-border bg-white/90 p-2 shadow-lg lg:hidden">
+    <View className="absolute bottom-4 left-4 right-4 z-30 flex-row items-center justify-around rounded-lg border border-border bg-popover/95 p-2 shadow-lg lg:hidden">
       {items.map((item) => (
         <Link key={item.href} href={item.href as any} asChild>
           <Pressable
@@ -252,7 +252,7 @@ export default function TealShell({
       className="min-h-screen flex-1 bg-background"
       style={landingBackgroundStyle}
     >
-      <View className="z-20 flex-row items-center justify-center border-b border-border bg-white/35 px-3 py-2">
+      <View className="z-20 flex-row items-center justify-center border-b border-border bg-background/55 px-3 py-2">
         <Text className="text-[11px] font-light text-primary">
           {
             "this is an early early work in progress!! 🚧 expect bugs, missing features, and regular database wipes"
@@ -277,7 +277,7 @@ export default function TealShell({
           </View>
         </ScrollView>
         {!isMobile && rightRail && (
-          <View className="hidden w-[19rem] shrink-0 border-l border-border bg-white/35 px-5 py-7 xl:flex">
+          <View className="hidden w-[19rem] shrink-0 border-l border-border bg-background/55 px-5 py-7 xl:flex">
             {rightRail}
           </View>
         )}

--- a/apps/amethyst/components/ui/ago.tsx
+++ b/apps/amethyst/components/ui/ago.tsx
@@ -2,7 +2,7 @@ import { Text } from "./text";
 
 const Ago = ({ time }: { time: Date }) => {
   return (
-    <Text className="text-sm text-gray-500">{timeAgoSinceDate(time)}</Text>
+    <Text className="text-sm text-muted-foreground">{timeAgoSinceDate(time)}</Text>
   );
 };
 

--- a/apps/amethyst/constants/Colors.ts
+++ b/apps/amethyst/constants/Colors.ts
@@ -1,17 +1,17 @@
-const tintColorLight = "#2f95dc";
-const tintColorDark = "#fff";
+const tintColorLight = "#1daea0";
+const tintColorDark = "#42d3c0";
 
 export default {
   light: {
-    text: "#000",
-    background: "#fff",
+    text: "#262626",
+    background: "#eff2f8",
     tint: tintColorLight,
     tabIconDefault: "#ccc",
     tabIconSelected: tintColorLight,
   },
   dark: {
-    text: "#fff",
-    background: "#000",
+    text: "#f4f3e9",
+    background: "#0d1616",
     tint: tintColorDark,
     tabIconDefault: "#ccc",
     tabIconSelected: tintColorDark,

--- a/apps/amethyst/global.css
+++ b/apps/amethyst/global.css
@@ -29,22 +29,22 @@
   }
 
   .dark:root {
-    --background: 180 24% 8%;
-    --foreground: 226 35% 94%;
-    --muted: 176 16% 16%;
-    --muted-foreground: 174 20% 70%;
-    --popover: 180 24% 10%;
+    --background: 180 24% 7%;
+    --foreground: 52 30% 94%;
+    --muted: 176 16% 14%;
+    --muted-foreground: 174 20% 72%;
+    --popover: 180 24% 11%;
     --popover-foreground: 226 35% 94%;
     --card: 180 24% 10%;
-    --card-foreground: 226 35% 94%;
-    --border: 176 17% 20%;
-    --input: 176 17% 20%;
+    --card-foreground: 52 30% 94%;
+    --border: 176 17% 22%;
+    --input: 176 17% 24%;
     --primary: 176 70% 49%;
     --primary-foreground: 180 24% 8%;
     --secondary: 174 72% 41%;
     --secondary-foreground: 226 35% 94%;
     --accent: 176 20% 17%;
-    --accent-foreground: 226 35% 94%;
+    --accent-foreground: 52 30% 94%;
     --destructive: 5 91% 60%;
     --destructive-foreground: 0 0% 100%;
     --bsky: 211.08 99.11% 60.08%;


### PR DESCRIPTION
Add cohesive dark mode. This groups the existing commits by chronology and the area they change.

Part 29 of 33 replacing #113. Review this PR against `feature/obbpr-28-discography-routes`. Merge the stack from oldest to newest. The original `obbpr` branch remains unchanged at `d3cf209d6ab5ae6d3b2b7ac353b3dbb7d54fe133` for rollback.

Commits in this group:

- dfce527 feat(amethyst): add cohesive dark mode

Validation: checked the branch ancestry and confirmed that the final stack tree exactly matches `obbpr`. This split preserves existing commits and merge history; no source edits or new build/test runs. Intermediate snapshots have not been independently validated, so these PRs start as drafts. Historical main merges are preserved.

Stack navigation:

- Previous: https://github.com/teal-fm/teal/pull/222
- Next: https://github.com/teal-fm/teal/pull/224
- Full stack index: https://github.com/teal-fm/teal/pull/113
